### PR TITLE
change --eval arg from list to str "mAP"

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -20,9 +20,7 @@ def parse_args():
     parser.add_argument('--out', help='output result file')
     parser.add_argument(
         '--eval',
-        type=str,
-        nargs='+',
-        choices=['mAP'],
+        default='mAP',
         help='evaluation metric, which depends on the dataset,'
         ' e.g., "mAP" for MSCOCO')
     parser.add_argument(


### PR DESCRIPTION
Thank you for making the code public!

I encountered the error when I evaluated your pretrained model on MS-COCO.

```
(open-mmlab) kimura@kimura-ubuntu-1:~/mot/mmpose$ python tools/test.py configs/top_down/resnet/coco/res50_coco_256x192.py checkpoints/res50_coco_256x192-ec54d7f3_20200709.pth --eval mAP
loading annotations into memory...
Done (t=0.18s)
creating index...
index created!
=> Total boxes: 104125
=> Total boxes after fliter low score@0.0: 104125
=> num_images: 5000
=> load 104125 samples
[>>>>>>>>>>>>>>>>>>>>>] 104125/104125, 59.3 task/s, elapsed: 1756s, ETA:     0sTraceback (most recent call last):
  File "tools/test.py", line 120, in <module>
    main()
  File "tools/test.py", line 116, in main
    dataset.evaluate(outputs, args.work_dir, **eval_config)
  File "/home/kimura/mot/mmpose/mmpose/datasets/datasets/top_down/topdown_coco_dataset.py", line 288, in evaluate
    assert metric == 'mAP'
AssertionError
```

Your eval methods (e.g., `TopDownCocoDataset.evaluate(.)`) expect a single string as `metric` arg like `"mAP"`, but in `test.py` a list of strings like `["mAP", ]` is passed to the eval method.

I've fixed this.