### PR TITLE
wipe out the extra gpu memony cost in dist_train

### DIFF
--- a/mmpose/models/backbones/utils/utils.py
+++ b/mmpose/models/backbones/utils/utils.py
@@ -5,7 +5,7 @@ from mmcv.runner.checkpoint import _load_checkpoint, load_state_dict
 
 def load_checkpoint(model,
                     filename,
-                    map_location=None,
+                    map_location='cpu',
                     strict=False,
                     logger=None):
     """Load checkpoint from a file or URI.


### PR DESCRIPTION
wipe out the extra gpu memony cost in dist_train by set the default map_location as 'cpu' , issue#201 https://github.com/open-mmlab/mmpose/issues/201