### PR TITLE
Add pylint rc file

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -162,7 +162,9 @@ disable=print-statement,
         super-init-not-called,
         redefined-builtin,
         attribute-defined-outside-init,
-        arguments-differ
+        arguments-differ,
+        cyclic-import,
+        bad-super-call
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -164,7 +164,8 @@ disable=print-statement,
         attribute-defined-outside-init,
         arguments-differ,
         cyclic-import,
-        bad-super-call
+        bad-super-call,
+        too-many-statements
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,618 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,configs
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        no-member,
+        invalid-name,
+        too-many-branches,
+        wrong-import-order,
+        too-many-arguments,
+        missing-function-docstring,
+        missing-module-docstring,
+        too-many-locals,
+        too-few-public-methods,
+        abstract-method,
+        broad-except,
+        too-many-nested-blocks,
+        too-many-instance-attributes,
+        missing-class-docstring,
+        duplicate-code,
+        not-callable,
+        protected-access,
+        dangerous-default-value,
+        no-name-in-module,
+        logging-fstring-interpolation,
+        super-init-not-called,
+        redefined-builtin,
+        attribute-defined-outside-init,
+        arguments-differ
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _,
+           x,
+           y,
+           w,
+           h,
+           a,
+           b
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception


### PR DESCRIPTION
Usage

```bash
pylint mmpose
```

Currently this is added for convenience.
On current master:

```bash
************* Module mmpose.core.post_processing.group
mmpose/core/post_processing/group.py:317:12: W0632: Possible unbalanced tuple unpacking with sequence defined at line 2 of : left side has 2 label(s), right side has 1 value(s) (unbalanced-tuple-unpacking)
mmpose/core/post_processing/group.py:378:12: C0200: Consider using enumerate instead of iterating with range and len (consider-using-enumerate)
************* Module mmpose.core.evaluation.eval_hooks
mmpose/core/evaluation/eval_hooks.py:99:8: C0415: Import outside toplevel (mmpose.apis.single_gpu_test) (import-outside-toplevel)
mmpose/core/evaluation/eval_hooks.py:169:8: C0415: Import outside toplevel (mmpose.apis.multi_gpu_test) (import-outside-toplevel)
************* Module mmpose.core.fp16.utils
mmpose/core/fp16/utils.py:18:4: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module mmpose.datasets.datasets.top_down.topdown_posetrack18_dataset
mmpose/datasets/datasets/top_down/topdown_posetrack18_dataset.py:140:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
************* Module mmpose.datasets.datasets.top_down.topdown_mpii_trb_dataset
mmpose/datasets/datasets/top_down/topdown_mpii_trb_dataset.py:170:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
mmpose/datasets/datasets/top_down/topdown_mpii_trb_dataset.py:173:8: W0105: String statement has no effect (pointless-string-statement)
************* Module mmpose.datasets.datasets.top_down.topdown_coco_dataset
mmpose/datasets/datasets/top_down/topdown_coco_dataset.py:321:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
************* Module mmpose.datasets.datasets.top_down.topdown_mpii_dataset
mmpose/datasets/datasets/top_down/topdown_mpii_dataset.py:168:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
************* Module mmpose.datasets.datasets.bottom_up.bottom_up_coco
mmpose/datasets/datasets/bottom_up/bottom_up_coco.py:233:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
mmpose/datasets/datasets/bottom_up/bottom_up_coco.py:205:0: W0613: Unused argument 'kwargs' (unused-argument)
************* Module mmpose.datasets.datasets.hand.panoptic_dataset
mmpose/datasets/datasets/hand/panoptic_dataset.py:150:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
************* Module mmpose.datasets.datasets.hand.onehand10k_dataset
mmpose/datasets/datasets/hand/onehand10k_dataset.py:146:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
************* Module mmpose.datasets.datasets.hand.freihand_dataset
mmpose/datasets/datasets/hand/freihand_dataset.py:146:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
************* Module mmpose.datasets.datasets.hand.interhand2d_dataset
mmpose/datasets/datasets/hand/interhand2d_dataset.py:247:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
************* Module mmpose.datasets.datasets.mesh.mesh_base_dataset
mmpose/datasets/datasets/mesh/mesh_base_dataset.py:129:8: C0200: Consider using enumerate instead of iterating with range and len (consider-using-enumerate)
************* Module mmpose.datasets.datasets.mesh.mesh_h36m_dataset
mmpose/datasets/datasets/mesh/mesh_h36m_dataset.py:34:12: R1704: Redefining argument with the local name 'metric' (redefined-argument-from-local)
mmpose/datasets/datasets/mesh/mesh_h36m_dataset.py:30:66: W0613: Unused argument 'logger' (unused-argument)
************* Module mmpose.datasets.pipelines.mesh_transform
mmpose/datasets/pipelines/mesh_transform.py:169:0: R0205: Class 'LoadIUVFromFile' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module mmpose.datasets.pipelines.top_down_transform
mmpose/datasets/pipelines/top_down_transform.py:315:4: R0201: Method could be a function (no-self-use)
************* Module mmpose.datasets.pipelines.bottom_up_transform
mmpose/datasets/pipelines/bottom_up_transform.py:164:8: C0200: Consider using enumerate instead of iterating with range and len (consider-using-enumerate)
************* Module mmpose.utils.hooks
mmpose/utils/hooks.py:16:21: W0613: Unused argument 'model' (unused-argument)
mmpose/utils/hooks.py:16:28: W0613: Unused argument 'input' (unused-argument)
************* Module mmpose.models.losses.multi_loss_factory
mmpose/models/losses/multi_loss_factory.py:90:8: R1705: Unnecessary "elif" after "return" (no-else-return)
mmpose/models/losses/multi_loss_factory.py:227:8: C0200: Consider using enumerate instead of iterating with range and len (consider-using-enumerate)
************* Module mmpose.models.keypoint_heads.top_down_multi_stage_head
mmpose/models/keypoint_heads/top_down_multi_stage_head.py:81:12: W0612: Unused variable 'i' (unused-variable)
mmpose/models/keypoint_heads/top_down_multi_stage_head.py:330:12: W0612: Unused variable 'i' (unused-variable)
mmpose/models/keypoint_heads/top_down_multi_stage_head.py:331:16: W0612: Unused variable 'j' (unused-variable)
************* Module mmpose.models.detectors.bottom_up
mmpose/models/detectors/bottom_up.py:330:24: R0916: Too many boolean expressions in if statement (10/5) (too-many-boolean-expressions)
mmpose/models/detectors/bottom_up.py:265:20: W0613: Unused argument 'thickness' (unused-argument)
mmpose/models/detectors/bottom_up.py:266:20: W0613: Unused argument 'font_scale' (unused-argument)
************* Module mmpose.models.detectors.base
mmpose/models/detectors/base.py:83:37: W0613: Unused argument 'optimizer' (unused-argument)
mmpose/models/detectors/base.py:83:0: W0613: Unused argument 'kwargs' (unused-argument)
mmpose/models/detectors/base.py:120:35: W0613: Unused argument 'optimizer' (unused-argument)
mmpose/models/detectors/base.py:120:0: W0613: Unused argument 'kwargs' (unused-argument)
************* Module mmpose.models.detectors.top_down
mmpose/models/detectors/top_down.py:129:12: C0200: Consider using enumerate instead of iterating with range and len (consider-using-enumerate)
mmpose/models/detectors/top_down.py:348:28: R0916: Too many boolean expressions in if statement (10/5) (too-many-boolean-expressions)
mmpose/models/detectors/top_down.py:262:20: W0613: Unused argument 'text_color' (unused-argument)
mmpose/models/detectors/top_down.py:264:20: W0613: Unused argument 'font_scale' (unused-argument)
************* Module mmpose.models.backbones.regnet
mmpose/models/backbones/regnet.py:279:4: R0201: Method could be a function (no-self-use)
************* Module mmpose.models.backbones.resnet
mmpose/models/backbones/resnet.py:398:16: W0612: Unused variable 'i' (unused-variable)
mmpose/models/backbones/resnet.py:563:4: R0201: Method could be a function (no-self-use)

------------------------------------------------------------------
Your code has been rated at 9.94/10 (previous run: 9.94/10, +0.00)
```