### PR TITLE
Removed torch1.4 from CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,10 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        torch: [1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0]
+        torch: [1.3.0, 1.5.0, 1.6.0, 1.7.0]
         include:
           - torch: 1.3.0
             torchvision: 0.4.2
-          - torch: 1.4.0
-            torchvision: 0.5.0
           - torch: 1.5.0
             torchvision: 0.6.1
           - torch: 1.6.0


### PR DESCRIPTION
Fix #330.

Reply from mmcv: pytorch1.4 has too many bugs, so only pre-built version is provided.