### PR TITLE
fix bugs in bottom-up keypoint score

### DIFF
--- a/mmpose/core/post_processing/post_transforms.py
+++ b/mmpose/core/post_processing/post_transforms.py
@@ -186,7 +186,7 @@ def transform_preds(coords, center, scale, output_size, use_udp=False):
         scale_x = scale[0] / output_size[0]
         scale_y = scale[1] / output_size[1]
 
-    target_coords = np.zeros_like(coords)
+    target_coords = np.ones_like(coords)
     target_coords[:, 0] = coords[:, 0] * scale_x + center[0] - scale[0] * 0.5
     target_coords[:, 1] = coords[:, 1] * scale_y + center[1] - scale[1] * 0.5
 


### PR DESCRIPTION
Setting all joint scores to be 0 would cause erroneous results in testing for bottom-up approach