### PR TITLE
Swith to fp16 hooks in mmcv

### DIFF
--- a/mmpose/apis/train.py
+++ b/mmpose/apis/train.py
@@ -1,12 +1,24 @@
+import warnings
+
+import mmcv
 import torch
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import DistSamplerSeedHook, EpochBasedRunner, OptimizerHook
+from packaging import version
 
-from mmpose.core import (DistEvalHook, EvalHook, Fp16OptimizerHook,
-                         build_optimizers)
+from mmpose.core import DistEvalHook, EvalHook, build_optimizers
 from mmpose.core.distributed_wrapper import DistributedDataParallelWrapper
 from mmpose.datasets import build_dataloader, build_dataset
 from mmpose.utils import get_root_logger
+
+if version.parse(mmcv.__version__) >= version.parse('1.3.1'):
+    from mmcv.runner import Fp16OptimizerHook
+else:
+    warnings.warn(
+        'Fp16OptimizerHook in mmpose will be deprecateed in the next'
+        'release and replaced by Fp16Optimizer provided by mmcv (>=1.3.1)'
+        'Please upgrade your mmcv version if need.', DeprecationWarning)
+    from mmpose.core import Fp16OptimizerHook
 
 
 def train_model(model,

--- a/mmpose/apis/train.py
+++ b/mmpose/apis/train.py
@@ -15,8 +15,8 @@ if version.parse(mmcv.__version__) >= version.parse('1.3.1'):
     from mmcv.runner import Fp16OptimizerHook
 else:
     warnings.warn(
-        'Fp16OptimizerHook in mmpose will be deprecateed in the next'
-        'release and replaced by Fp16Optimizer provided by mmcv (>=1.3.1)'
+        'Fp16OptimizerHook in mmpose will be deprecated in the next'
+        'release and replaced by Fp16OptimizerHook provided by mmcv (>=1.3.1)'
         'Please upgrade your mmcv version if need.', DeprecationWarning)
     from mmpose.core import Fp16OptimizerHook
 

--- a/mmpose/apis/train.py
+++ b/mmpose/apis/train.py
@@ -17,7 +17,7 @@ else:
     warnings.warn(
         'Fp16OptimizerHook in mmpose will be deprecated in the next'
         'release and replaced by Fp16OptimizerHook provided by mmcv (>=1.3.1)'
-        'Please upgrade your mmcv version if need.', DeprecationWarning)
+        'Please upgrade your mmcv version, if needed.', DeprecationWarning)
     from mmpose.core import Fp16OptimizerHook
 
 

--- a/mmpose/core/fp16/decorators.py
+++ b/mmpose/core/fp16/decorators.py
@@ -1,4 +1,5 @@
 import functools
+import warnings
 from inspect import getfullargspec
 
 import torch
@@ -37,6 +38,11 @@ def auto_fp16(apply_to=None, out_fp32=False):
         >>>     def do_something(self, pred, others):
         >>>         pass
     """
+
+    warnings.warn(
+        'auto_fp16 in mmpose will be deprecated in the next release.'
+        'Please use mmcv.runner.auto_fp16 instead (mmcv>=1.3.1).',
+        DeprecationWarning)
 
     def auto_fp16_wrapper(old_func):
 
@@ -117,6 +123,10 @@ def force_fp32(apply_to=None, out_fp16=False):
         >>>     def post_process(self, pred, others):
         >>>         pass
     """
+    warnings.warn(
+        'force_fp32 in mmpose will be deprecated in the next release.'
+        'Please use mmcv.runner.force_fp32 instead (mmcv>=1.3.1).',
+        DeprecationWarning)
 
     def force_fp32_wrapper(old_func):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,6 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = pkg_resources,setuptools
 known_first_party = mmpose
-known_third_party = cv2,h5py,json_tricks,matplotlib,mmcv,munkres,numpy,poseval,pytest,scipy,seaborn,spacepy,titlecase,torch,torchvision,xtcocotools
+known_third_party = cv2,h5py,json_tricks,matplotlib,mmcv,munkres,numpy,packaging,poseval,pytest,scipy,seaborn,spacepy,titlecase,torch,torchvision,xtcocotools
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY


### PR DESCRIPTION
* import Fp16OptimizerHook from mmcv if its version>=1.3.1
* add deprecation warning to Fp16OptimizerHook, auto_fp16 and force_fp32