### PR TITLE
Fix opencv 4.5.2 compatibility

### DIFF
--- a/mmpose/datasets/pipelines/bottom_up_transform.py
+++ b/mmpose/datasets/pipelines/bottom_up_transform.py
@@ -496,8 +496,8 @@ class BottomUpRandomAffine:
             mat_input = self._get_affine_matrix(center, scale,
                                                 (self.input_size,
                                                  self.input_size), aug_rot)[:2]
-            image = cv2.warpAffine(image, mat_input,
-                                   (self.input_size, self.input_size))
+            image = cv2.warpAffine(image, mat_input, (self.input_size.item(),
+                                                      self.input_size.item()))
 
         results['img'], results['mask'], results[
             'joints'] = image, mask, joints

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,5 @@
 albumentations>=0.3.2
+loguru
 onnx
 onnxruntime
 poseval@git+https://github.com/svenkreiss/poseval.git

--- a/tests/test_pipelines/test_bottom_up_pipelines.py
+++ b/tests/test_pipelines/test_bottom_up_pipelines.py
@@ -305,7 +305,6 @@ def test_BottomUpGeneratePAFTarget():
     generate_paf_target = BottomUpGeneratePAFTarget(1)
     results_generate_paf_target = generate_paf_target(results)
     sqrt = np.sqrt(2) / 2
-    print(results_generate_paf_target['target'])
     assert (results_generate_paf_target['target'] == np.array(
         [[[sqrt, sqrt, 0, sqrt, sqrt], [sqrt, sqrt, sqrt, sqrt, sqrt],
           [0, sqrt, sqrt, sqrt, 0], [sqrt, sqrt, sqrt, sqrt, sqrt],


### PR DESCRIPTION
* opencv-python 4.5.2 compatibility
BottomUpRandomAffine fails with opencv-python>=4.5.2 because a \
single valued numpy.ndarray is no longer a valid data type for \
image_size in cv2.warpAffine. This commit fix it by repacing   \
image_size with image_size.item().

* smplx 0.1.27 compatibility
smplx>=0.1.27 requires loguru, which will not be automatically installed \
 when installing smplx. So we add loguru into mmpose requirements.