### PR TITLE
fix demo/top_down_img_demo.py with UDP

### DIFF
--- a/mmpose/apis/inference.py
+++ b/mmpose/apis/inference.py
@@ -289,7 +289,7 @@ def _inference_single_pose_model(model,
             'rotation':
             0,
             'ann_info': {
-                'image_size': cfg.data_cfg['image_size'],
+                'image_size': np.array(cfg.data_cfg['image_size']),
                 'num_joints': cfg.data_cfg['num_joints'],
                 'flip_pairs': flip_pairs
             }


### PR DESCRIPTION
When running demo with UDP like below, 
```
python demo/top_down_img_demo.py  \
configs/top_down/udp/coco/hrnet_w32_coco_256x192_udp.py  \https://download.openmmlab.com/mmpose/top_down/udp/hrnet_w32_coco_256x192_udp-aba0be42_20210220.pth \
 --img-root tests/data/coco/ \
--json-file tests/data/coco/test_coco.json --out-img-root vis_results
```

this error happened, and demo failed.

```
Traceback (most recent call last):
  File "demo/top_down_img_demo.py", line 104, in <module>
    main()
  File "demo/top_down_img_demo.py", line 85, in main
    outputs=output_layer_names)
  File "program/mmpose/mmpose/apis/inference.py", line 401, in inference_top_down_pose_model
    return_heatmap=return_heatmap)
  File "program/mmpose/mmpose/apis/inference.py", line 297, in _inference_single_pose_model
    data = test_pipeline(data)
  File "program/mmpose/mmpose/datasets/pipelines/shared_transform.py", line 87, in __call__
    data = t(data)
  File "program/mmpose/mmpose/datasets/pipelines/top_down_transform.py", line 198, in __call__
    trans = get_warp_matrix(r, c * 2.0, image_size - 1.0, s * 200.0)
TypeError: unsupported operand type(s) for -: 'list' and 'float'
```

This is because `image_size` is just list type. So I have changed to `np.array' .

## another option to fix 

Another option to fix is change this line 
https://github.com/open-mmlab/mmpose/blob/b0acfc423da672e61db75e00df9da106b6ead574/mmpose/apis/inference.py#L292
to `'image_size': np.array(cfg.data_cfg['image_size']),`