### PR TITLE
Fix GPU_IDS in distributed training

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -7,7 +7,7 @@ import time
 import mmcv
 import torch
 from mmcv import Config, DictAction
-from mmcv.runner import init_dist, set_random_seed
+from mmcv.runner import get_dist_info, init_dist, set_random_seed
 from mmcv.utils import get_git_hash
 
 from mmpose import __version__
@@ -106,6 +106,9 @@ def main():
     else:
         distributed = True
         init_dist(args.launcher, **cfg.dist_params)
+        # re-set gpu_ids with distributed training mode
+        _, world_size = get_dist_info()
+        cfg.gpu_ids = range(world_size)
 
     # create work_dir
     mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))


### PR DESCRIPTION
When resuming training, MMCV calculates the iteration from the gpu_ids, which is not available in the distributed mode. This PR provides a workaround to re-set gpu_ids according to the world_size in this case.