### PR TITLE
Fix dependency

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,5 +1,4 @@
 albumentations>=0.3.2
 onnx
 onnxruntime
-poseval@git+https://github.com/svenkreiss/poseval.git
 smplx>=0.1.28

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,6 +6,7 @@ munkres
 numpy
 opencv-python
 pillow
+poseval@git+https://github.com/svenkreiss/poseval.git
 scipy
 torchvision
 xtcocotools>=1.8


### PR DESCRIPTION
When installing mmpose with mim, the packages in optional.txt will not be installed. But when I try to import mmpose.apis, the package poseval will be imported. So it should be moved into runtime.txt.