### PR TITLE
Add regex dependency

### DIFF
--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -1,6 +1,7 @@
 mmcv-full
 munkres
 poseval@git+https://github.com/svenkreiss/poseval.git
+regex
 scipy
 titlecase
 torch


### PR DESCRIPTION
In titlecase>=2.1.0, if `regex` is not successfully imported, `re` will be imported as `regex`, which may lead to unexpected behavior or errors. So we add regex into the requirements explicitly.