### PR TITLE
Fix model zoo doc generation

### DIFF
--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/README.md
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/README.md
@@ -3,7 +3,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">Associative Embedding (NIPS'2017)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1611.05424">Associative Embedding (NIPS'2017)</a></summary>
 
 ```bibtex
 @inproceedings{newell2017associative,

--- a/configs/body/2d_kpt_sview_rgb_img/deeppose/README.md
+++ b/configs/body/2d_kpt_sview_rgb_img/deeppose/README.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">DeepPose (CVPR'2014)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html">DeepPose (CVPR'2014)</a></summary>
 
 ```bibtex
 @inproceedings{toshev2014deeppose,

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_coco.md
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_coco.md
@@ -1,7 +1,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">ViPNAS (CVPR'2021)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/2105.10154">ViPNAS (CVPR'2021)</summary>
 
 ```bibtex
 @article{xu2021vipnas,
@@ -17,7 +17,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">COCO (ECCV'2014)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48">COCO (ECCV'2014)</summary>
 
 ```bibtex
 @inproceedings{lin2014microsoft,

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_coco.md
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_coco.md
@@ -1,7 +1,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right"><a href="https://arxiv.org/abs/2105.10154">ViPNAS (CVPR'2021)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/2105.10154">ViPNAS (CVPR'2021)</a></summary>
 
 ```bibtex
 @article{xu2021vipnas,
@@ -17,7 +17,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48">COCO (ECCV'2014)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48">COCO (ECCV'2014)</a></summary>
 
 ```bibtex
 @inproceedings{lin2014microsoft,

--- a/configs/body/3d_kpt_sview_rgb_img/pose_lift/README.md
+++ b/configs/body/3d_kpt_sview_rgb_img/pose_lift/README.md
@@ -3,7 +3,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">SimpleBaseline3D (ICCV'2017)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_iccv_2017/html/Martinez_A_Simple_yet_ICCV_2017_paper.html">SimpleBaseline3D (ICCV'2017)</a></summary>
 
 ```bibtex
 @inproceedings{martinez_2017_3dbaseline,

--- a/configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/README.md
+++ b/configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/README.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">VideoPose3D (CVPR'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2019/html/Pavllo_3D_Human_Pose_Estimation_in_Video_With_Temporal_Convolutions_and_CVPR_2019_paper.html">VideoPose3D (CVPR'2019)</a></summary>
 
 ```bibtex
 @inproceedings{pavllo20193d,

--- a/configs/body/3d_mesh_sview_rgb_img/hmr/README.md
+++ b/configs/body/3d_mesh_sview_rgb_img/hmr/README.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">HMR (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Kanazawa_End-to-End_Recovery_of_CVPR_2018_paper.html">HMR (CVPR'2018)</a></summary>
 
 ```bibtex
 @inProceedings{kanazawaHMR18,

--- a/configs/face/2d_kpt_sview_rgb_img/deeppose/README.md
+++ b/configs/face/2d_kpt_sview_rgb_img/deeppose/README.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">DeepPose (CVPR'2014)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html">DeepPose (CVPR'2014)</a></summary>
 
 ```bibtex
 @inproceedings{toshev2014deeppose,

--- a/configs/fashion/2d_kpt_sview_rgb_img/deeppose/README.md
+++ b/configs/fashion/2d_kpt_sview_rgb_img/deeppose/README.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">DeepPose (CVPR'2014)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html">DeepPose (CVPR'2014)</a></summary>
 
 ```bibtex
 @inproceedings{toshev2014deeppose,

--- a/configs/hand/2d_kpt_sview_rgb_img/deeppose/README.md
+++ b/configs/hand/2d_kpt_sview_rgb_img/deeppose/README.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">DeepPose (CVPR'2014)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html">DeepPose (CVPR'2014)</a></summary>
 
 ```bibtex
 @inproceedings{toshev2014deeppose,

--- a/configs/hand/3d_kpt_sview_rgb_img/internet/README.md
+++ b/configs/hand/3d_kpt_sview_rgb_img/internet/README.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">InterNet (ECCV'2020)</summary>
+<summary align="right"><a href="https://link.springer.com/content/pdf/10.1007/978-3-030-58565-5_33.pdf">InterNet (ECCV'2020)</a></summary>
 
 ```bibtex
 @InProceedings{Moon_2020_ECCV_InterHand2.6M,

--- a/configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/README.md
+++ b/configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/README.md
@@ -3,7 +3,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">Associative Embedding (NIPS'2017)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1611.05424">Associative Embedding (NIPS'2017)</a></summary>
 
 ```bibtex
 @inproceedings{newell2017associative,

--- a/docs/collect.py
+++ b/docs/collect.py
@@ -79,7 +79,6 @@ for section in sections:
         for subtopic, datasets in contents.items():
             for dataset, keywords in datasets.items():
                 keywords = {k: v for k, v in keywords.items() if keyline in v}
-                print(len(keywords))
                 if len(keywords) == 0:
                     continue
                 for keyword, info in keywords.items():

--- a/docs/collect.py
+++ b/docs/collect.py
@@ -78,10 +78,7 @@ for section in sections:
         paperlines = []
         for subtopic, datasets in contents.items():
             for dataset, keywords in datasets.items():
-                keywords = {
-                    k: v
-                    for k, v in keywords.items() if papername in v
-                }
+                keywords = {k: v for k, v in keywords.items() if keyline in v}
                 print(len(keywords))
                 if len(keywords) == 0:
                     continue

--- a/docs/collect.py
+++ b/docs/collect.py
@@ -78,7 +78,11 @@ for section in sections:
         paperlines = []
         for subtopic, datasets in contents.items():
             for dataset, keywords in datasets.items():
-                keywords = {k: v for k, v in keywords.items() if keyline in v}
+                keywords = {
+                    k: v
+                    for k, v in keywords.items() if papername in v
+                }
+                print(len(keywords))
                 if len(keywords) == 0:
                     continue
                 for keyword, info in keywords.items():

--- a/docs/papers/algorithms/associative_embedding.md
+++ b/docs/papers/algorithms/associative_embedding.md
@@ -3,7 +3,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">Associative Embedding (NIPS'2017)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1611.05424">Associative Embedding (NIPS'2017)</a></summary>
 
 ```bibtex
 @inproceedings{newell2017associative,

--- a/docs/papers/algorithms/deeppose.md
+++ b/docs/papers/algorithms/deeppose.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">DeepPose (CVPR'2014)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html">DeepPose (CVPR'2014)</a></summary>
 
 ```bibtex
 @inproceedings{toshev2014deeppose,

--- a/docs/papers/algorithms/hmr.md
+++ b/docs/papers/algorithms/hmr.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">HMR (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Kanazawa_End-to-End_Recovery_of_CVPR_2018_paper.html">HMR (CVPR'2018)</a></summary>
 
 ```bibtex
 @inProceedings{kanazawaHMR18,

--- a/docs/papers/algorithms/internet.md
+++ b/docs/papers/algorithms/internet.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">InterNet (ECCV'2020)</summary>
+<summary align="right"><a href="https://link.springer.com/content/pdf/10.1007/978-3-030-58565-5_33.pdf">InterNet (ECCV'2020)</a></summary>
 
 ```bibtex
 @InProceedings{Moon_2020_ECCV_InterHand2.6M,

--- a/docs/papers/algorithms/simplebaseline2d.md
+++ b/docs/papers/algorithms/simplebaseline2d.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">SimpleBaseline2D (ECCV'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html">SimpleBaseline2D (ECCV'2018)</a></summary>
 
 ```bibtex
 @inproceedings{xiao2018simple,

--- a/docs/papers/algorithms/simplebaseline3d.md
+++ b/docs/papers/algorithms/simplebaseline3d.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">SimpleBaseline3D (ICCV'2017)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_iccv_2017/html/Martinez_A_Simple_yet_ICCV_2017_paper.html">SimpleBaseline3D (ICCV'2017)</a></summary>
 
 ```bibtex
 @inproceedings{martinez_2017_3dbaseline,

--- a/docs/papers/algorithms/videopose3d.md
+++ b/docs/papers/algorithms/videopose3d.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">VideoPose3D (CVPR'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2019/html/Pavllo_3D_Human_Pose_Estimation_in_Video_With_Temporal_Convolutions_and_CVPR_2019_paper.html">VideoPose3D (CVPR'2019)</
 
 ```bibtex
 @inproceedings{pavllo20193d,

--- a/docs/papers/backbones/alexnet.md
+++ b/docs/papers/backbones/alexnet.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">AlexNet (NeurIPS'2012)</summary>
+<summary align="right"><a href="https://proceedings.neurips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf">AlexNet (NeurIPS'2012)</a></summary>
 
 ```bibtex
 @inproceedings{krizhevsky2012imagenet,

--- a/docs/papers/backbones/cpm.md
+++ b/docs/papers/backbones/cpm.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">CPM (CVPR'2016)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2016/html/Wei_Convolutional_Pose_Machines_CVPR_2016_paper.html">CPM (CVPR'2016)</a></summary>
 
 ```bibtex
 @inproceedings{wei2016convolutional,

--- a/docs/papers/backbones/higherhrnet.md
+++ b/docs/papers/backbones/higherhrnet.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">HigherHRNet (CVPR'2020)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2020/html/Cheng_HigherHRNet_Scale-Aware_Representation_Learning_for_Bottom-Up_Human_Pose_Estimation_CVPR_2020_paper.html">HigherHRNet (CVPR'2020)</a></summary>
 
 ```bibtex
 @inproceedings{cheng2020higherhrnet,

--- a/docs/papers/backbones/hourglass.md
+++ b/docs/papers/backbones/hourglass.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">Hourglass (ECCV'2016)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-46484-8_29">Hourglass (ECCV'2016)</a></summary>
 
 ```bibtex
 @inproceedings{newell2016stacked,

--- a/docs/papers/backbones/hrnet.md
+++ b/docs/papers/backbones/hrnet.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">HRNet (CVPR'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html">HRNet (CVPR'2019)</a></summary>
 
 ```bibtex
 @inproceedings{sun2019deep,

--- a/docs/papers/backbones/hrnetv2.md
+++ b/docs/papers/backbones/hrnetv2.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">HRNetv2 (TPAMI'2019)</summary>
+<summary align="right"><a href="https://ieeexplore.ieee.org/abstract/document/9052469/">HRNetv2 (TPAMI'2019)</a></summary>
 
 ```bibtex
 @article{WangSCJDZLMTWLX19,

--- a/docs/papers/backbones/mobilenetv2.md
+++ b/docs/papers/backbones/mobilenetv2.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">MobilenetV2 (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Sandler_MobileNetV2_Inverted_Residuals_CVPR_2018_paper.html">MobilenetV2 (CVPR'2018)</a></summary>
 
 ```bibtex
 @inproceedings{sandler2018mobilenetv2,

--- a/docs/papers/backbones/mspn.md
+++ b/docs/papers/backbones/mspn.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">MSPN (ArXiv'2019)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1901.00148">MSPN (ArXiv'2019)</a></summary>
 
 ```bibtex
 @article{li2019rethinking,

--- a/docs/papers/backbones/resnest.md
+++ b/docs/papers/backbones/resnest.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">ResNeSt (ArXiv'2020)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/2004.08955">ResNeSt (ArXiv'2020)</a></summary>
 
 ```bibtex
 @article{zhang2020resnest,

--- a/docs/papers/backbones/resnet.md
+++ b/docs/papers/backbones/resnet.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">ResNet (CVPR'2016)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html">ResNet (CVPR'2016)</a></summary>
 
 ```bibtex
 @inproceedings{he2016deep,

--- a/docs/papers/backbones/resnetv1d.md
+++ b/docs/papers/backbones/resnetv1d.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">ResNetV1D (CVPR'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2019/html/He_Bag_of_Tricks_for_Image_Classification_with_Convolutional_Neural_Networks_CVPR_2019_paper.html">ResNetV1D (CVPR'2019)</a></summary>
 
 ```bibtex
 @inproceedings{he2019bag,

--- a/docs/papers/backbones/resnext.md
+++ b/docs/papers/backbones/resnext.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">ResNext (CVPR'2017)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2017/html/Xie_Aggregated_Residual_Transformations_CVPR_2017_paper.html">ResNext (CVPR'2017)</a></summary>
 
 ```bibtex
 @inproceedings{xie2017aggregated,

--- a/docs/papers/backbones/rsn.md
+++ b/docs/papers/backbones/rsn.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">RSN (ECCV'2020)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-030-58580-8_27">RSN (ECCV'2020)</a></summary>
 
 ```bibtex
 @misc{cai2020learning,

--- a/docs/papers/backbones/scnet.md
+++ b/docs/papers/backbones/scnet.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">SCNet (CVPR'2020)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2020/html/Liu_Improving_Convolutional_Networks_With_Self-Calibrated_Convolutions_CVPR_2020_paper.html">SCNet (CVPR'2020)</a></summary>
 
 ```bibtex
 @inproceedings{liu2020improving,

--- a/docs/papers/backbones/seresnet.md
+++ b/docs/papers/backbones/seresnet.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">SEResNet (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Hu_Squeeze-and-Excitation_Networks_CVPR_2018_paper">SEResNet (CVPR'2018)</a></summary>
 
 ```bibtex
 @inproceedings{hu2018squeeze,

--- a/docs/papers/backbones/shufflenetv1.md
+++ b/docs/papers/backbones/shufflenetv1.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">ShufflenetV1 (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Zhang_ShuffleNet_An_Extremely_CVPR_2018_paper.html">ShufflenetV1 (CVPR'2018)</a></summary>
 
 ```bibtex
 @inproceedings{zhang2018shufflenet,

--- a/docs/papers/backbones/shufflenetv2.md
+++ b/docs/papers/backbones/shufflenetv2.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">ShufflenetV2 (ECCV'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_ECCV_2018/html/Ningning_Light-weight_CNN_Architecture_ECCV_2018_paper.html">ShufflenetV2 (ECCV'2018)</a></summary>
 
 ```bibtex
 @inproceedings{ma2018shufflenet,

--- a/docs/papers/backbones/vgg.md
+++ b/docs/papers/backbones/vgg.md
@@ -5,7 +5,7 @@
 <!-- [BACKBONE] -->
 
 <details>
-<summary align="right">VGG (ICLR'2015)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1409.1556">VGG (ICLR'2015)</a></summary>
 
 ```bibtex
 @article{simonyan2014very,

--- a/docs/papers/backbones/vipnas.md
+++ b/docs/papers/backbones/vipnas.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">ViPNAS (CVPR'2021)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/2105.10154">ViPNAS (CVPR'2021)</a></summary>
 
 ```bibtex
 @article{xu2021vipnas,

--- a/docs/papers/datasets/300w.md
+++ b/docs/papers/datasets/300w.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">300W (IMAVIS'2016)</summary>
+<summary align="right"><a href="https://www.sciencedirect.com/science/article/pii/S0262885616000147">300W (IMAVIS'2016)</a></summary>
 
 ```bibtex
 @article{sagonas2016300,

--- a/docs/papers/datasets/aflw.md
+++ b/docs/papers/datasets/aflw.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">AFLW (ICCVW'2011)</summary>
+<summary align="right"><a href="https://ieeexplore.ieee.org/abstract/document/6130513/">AFLW (ICCVW'2011)</a></summary>
 
 ```bibtex
 @inproceedings{koestinger2011annotated,

--- a/docs/papers/datasets/aic.md
+++ b/docs/papers/datasets/aic.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">AI Challenger (ArXiv'2017)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1711.06475">AI Challenger (ArXiv'2017)</a></summary>
 
 ```bibtex
 @article{wu2017ai,

--- a/docs/papers/datasets/animalpose.md
+++ b/docs/papers/datasets/animalpose.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Animal-Pose (ICCV'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_ICCV_2019/html/Cao_Cross-Domain_Adaptation_for_Animal_Pose_Estimation_ICCV_2019_paper.html">Animal-Pose (ICCV'2019)</a></summary>
 
 ```bibtex
 @InProceedings{Cao_2019_ICCV,

--- a/docs/papers/datasets/atrw.md
+++ b/docs/papers/datasets/atrw.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">ATRW (ACM MM'2020)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1906.05586">ATRW (ACM MM'2020)</a></summary>
 
 ```bibtex
 @inproceedings{li2020atrw,

--- a/docs/papers/datasets/coco.md
+++ b/docs/papers/datasets/coco.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">COCO (ECCV'2014)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48">COCO (ECCV'2014)</a></summary>
 
 ```bibtex
 @inproceedings{lin2014microsoft,

--- a/docs/papers/datasets/coco_wholebody.md
+++ b/docs/papers/datasets/coco_wholebody.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">COCO-WholeBody (ECCV'2020)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-030-58545-7_12">COCO-WholeBody (ECCV'2020)</a></summary>
 
 ```bibtex
 @inproceedings{jin2020whole,

--- a/docs/papers/datasets/cofw.md
+++ b/docs/papers/datasets/cofw.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">COFW (ICCV'2013)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_iccv_2013/html/Burgos-Artizzu_Robust_Face_Landmark_2013_ICCV_paper.html">COFW (ICCV'2013)</a></summary>
 
 ```bibtex
 @inproceedings{burgos2013robust,

--- a/docs/papers/datasets/crowdpose.md
+++ b/docs/papers/datasets/crowdpose.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">CrowdPose (CVPR'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2019/html/Li_CrowdPose_Efficient_Crowded_Scenes_Pose_Estimation_and_a_New_Benchmark_CVPR_2019_paper.html">CrowdPose (CVPR'2019)</a></summary>
 
 ```bibtex
 @article{li2018crowdpose,

--- a/docs/papers/datasets/deepfashion.md
+++ b/docs/papers/datasets/deepfashion.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">DeepFashion (CVPR'2016)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2016/html/Liu_DeepFashion_Powering_Robust_CVPR_2016_paper.html">DeepFashion (CVPR'2016)</a></summary>
 
 ```bibtex
 @inproceedings{liuLQWTcvpr16DeepFashion,
@@ -22,7 +22,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">DeepFashion (ECCV'2016)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-46475-6_15">DeepFashion (ECCV'2016)</a></summary>
 
 ```bibtex
 @inproceedings{liuYLWTeccv16FashionLandmark,

--- a/docs/papers/datasets/fly.md
+++ b/docs/papers/datasets/fly.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Vinegar Fly (Nature Methods'2019)</summary>
+<summary align="right"><a href="https://www.nature.com/articles/s41592-018-0234-5">Vinegar Fly (Nature Methods'2019)</a></summary>
 
 ```bibtex
 @article{pereira2019fast,

--- a/docs/papers/datasets/freihand.md
+++ b/docs/papers/datasets/freihand.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">FreiHand (ICCV'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_ICCV_2019/html/Zimmermann_FreiHAND_A_Dataset_for_Markerless_Capture_of_Hand_Pose_and_ICCV_2019_paper.html">FreiHand (ICCV'2019)</a></summary>
 
 ```bibtex
 @inproceedings{zimmermann2019freihand,

--- a/docs/papers/datasets/h36m.md
+++ b/docs/papers/datasets/h36m.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Human3.6M (TPAMI'2014)</summary>
+<summary align="right"><a href="https://ieeexplore.ieee.org/abstract/document/6682899/">Human3.6M (TPAMI'2014)</a></summary>
 
 ```bibtex
 @article{h36m_pami,

--- a/docs/papers/datasets/horse10.md
+++ b/docs/papers/datasets/horse10.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Horse-10 (WACV'2021)</summary>
+<summary align="right"><a href="https://openaccess.thecvf.com/content/WACV2021/html/Mathis_Pretraining_Boosts_Out-of-Domain_Robustness_for_Pose_Estimation_WACV_2021_paper.html">Horse-10 (WACV'2021)</a></summary>
 
 ```bibtex
 @inproceedings{mathis2021pretraining,

--- a/docs/papers/datasets/interhand.md
+++ b/docs/papers/datasets/interhand.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">InterHand2.6M (ECCV'2020)</summary>
+<summary align="right"><a href="https://link.springer.com/content/pdf/10.1007/978-3-030-58565-5_33.pdf">InterHand2.6M (ECCV'2020)</a></summary>
 
 ```bibtex
 @article{moon2020interhand2,

--- a/docs/papers/datasets/jhmdb.md
+++ b/docs/papers/datasets/jhmdb.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">JHMDB (ICCV'2013)</summary>
+<summary align="right"><a href="https://www.cv-foundation.org/openaccess/content_iccv_2013/html/Jhuang_Towards_Understanding_Action_2013_ICCV_paper.html">JHMDB (ICCV'2013)</a></summary>
 
 ```bibtex
 @inproceedings{Jhuang:ICCV:2013,

--- a/docs/papers/datasets/locust.md
+++ b/docs/papers/datasets/locust.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Desert Locust (Elife'2019)</summary>
+<summary align="right"><a href="https://elifesciences.org/articles/47994">Desert Locust (Elife'2019)</a></summary>
 
 ```bibtex
 @article{graving2019deepposekit,

--- a/docs/papers/datasets/macaque.md
+++ b/docs/papers/datasets/macaque.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">MacaquePose (bioRxiv'2020)</summary>
+<summary align="right"><a href="https://www.ncbi.nlm.nih.gov/pmc/articles/pmc7874091/">MacaquePose (bioRxiv'2020)</a></summary>
 
 ```bibtex
 @article{labuguen2020macaquepose,

--- a/docs/papers/datasets/mhp.md
+++ b/docs/papers/datasets/mhp.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">MHP (ACM MM'2018)</summary>
+<summary align="right"><a href="https://dl.acm.org/doi/abs/10.1145/3240508.3240509">MHP (ACM MM'2018)</a></summary>
 
 ```bibtex
 @inproceedings{zhao2018understanding,

--- a/docs/papers/datasets/mpi_inf_3dhp.md
+++ b/docs/papers/datasets/mpi_inf_3dhp.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">MPI-INF-3DHP (3DV'2017)</summary>
+<summary align="right"><a href="https://ieeexplore.ieee.org/abstract/document/8374605/">MPI-INF-3DHP (3DV'2017)</a></summary>
 
 ```bibtex
 @inproceedings{mono-3dhp2017,

--- a/docs/papers/datasets/mpii.md
+++ b/docs/papers/datasets/mpii.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">MPII (CVPR'2014)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html">MPII (CVPR'2014)</a></summary>
 
 ```bibtex
 @inproceedings{andriluka14cvpr,

--- a/docs/papers/datasets/mpii_trb.md
+++ b/docs/papers/datasets/mpii_trb.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">MPII-TRB (ICCV'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_ICCV_2019/html/Duan_TRB_A_Novel_Triplet_Representation_for_Understanding_2D_Human_Body_ICCV_2019_paper.html">MPII-TRB (ICCV'2019)</a></summary>
 
 ```bibtex
 @inproceedings{duan2019trb,

--- a/docs/papers/datasets/ochuman.md
+++ b/docs/papers/datasets/ochuman.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">OCHuman (CVPR'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2019/html/Zhang_Pose2Seg_Detection_Free_Human_Instance_Segmentation_CVPR_2019_paper.html">OCHuman (CVPR'2019)</a></summary>
 
 ```bibtex
 @inproceedings{zhang2019pose2seg,

--- a/docs/papers/datasets/onehand10k.md
+++ b/docs/papers/datasets/onehand10k.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">OneHand10K (TCSVT'2019)</summary>
+<summary align="right"><a href="https://ieeexplore.ieee.org/abstract/document/8529221/">OneHand10K (TCSVT'2019)</a></summary>
 
 ```bibtex
 @article{wang2018mask,

--- a/docs/papers/datasets/panoptic.md
+++ b/docs/papers/datasets/panoptic.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">CMU Panoptic HandDB (CVPR'2017)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2017/html/Simon_Hand_Keypoint_Detection_CVPR_2017_paper.html">CMU Panoptic HandDB (CVPR'2017)</a></summary>
 
 ```bibtex
 @inproceedings{simon2017hand,

--- a/docs/papers/datasets/posetrack18.md
+++ b/docs/papers/datasets/posetrack18.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">PoseTrack18 (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Andriluka_PoseTrack_A_Benchmark_CVPR_2018_paper.html">PoseTrack18 (CVPR'2018)</a></summary>
 
 ```bibtex
 @inproceedings{andriluka2018posetrack,

--- a/docs/papers/datasets/rhd.md
+++ b/docs/papers/datasets/rhd.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">RHD (ICCV'2017)</summary>
+<summary align="right"><a href="https://lmb.informatik.uni-freiburg.de/projects/hand3d/">RHD (ICCV'2017)</a></summary>
 
 ```bibtex
 @TechReport{zb2017hand,

--- a/docs/papers/datasets/wflw.md
+++ b/docs/papers/datasets/wflw.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">WFLW (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Wu_Look_at_Boundary_CVPR_2018_paper.html">WFLW (CVPR'2018)</a></summary>
 
 ```bibtex
 @inproceedings{wu2018look,

--- a/docs/papers/datasets/zebra.md
+++ b/docs/papers/datasets/zebra.md
@@ -5,7 +5,7 @@
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Grévy’s Zebra (Elife'2019)</summary>
+<summary align="right"><a href="https://elifesciences.org/articles/47994">Grévy’s Zebra (Elife'2019)</a></summary>
 
 ```bibtex
 @article{graving2019deepposekit,

--- a/docs/papers/techniques/albumentations.md
+++ b/docs/papers/techniques/albumentations.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">Albumentations (Information'2020)</summary>
+<summary align="right"><a href="https://www.mdpi.com/649002">Albumentations (Information'2020)</a></summary>
 
 ```bibtex
 @article{buslaev2020albumentations,

--- a/docs/papers/techniques/dark.md
+++ b/docs/papers/techniques/dark.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">DarkPose (CVPR'2020)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html">DarkPose (CVPR'2020)</a></summary>
 
 ```bibtex
 @inproceedings{zhang2020distribution,

--- a/docs/papers/techniques/fp16.md
+++ b/docs/papers/techniques/fp16.md
@@ -5,7 +5,7 @@
 <!-- [OTHERS] -->
 
 <details>
-<summary align="right">FP16 (ArXiv'2017)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1710.03740">FP16 (ArXiv'2017)</a></summary>
 
 ```bibtex
 @article{micikevicius2017mixed,

--- a/docs/papers/techniques/udp.md
+++ b/docs/papers/techniques/udp.md
@@ -5,7 +5,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">UDP (CVPR'2020)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2020/html/Huang_The_Devil_Is_in_the_Details_Delving_Into_Unbiased_Data_CVPR_2020_paper.html">UDP (CVPR'2020)</a></summary>
 
 ```bibtex
 @InProceedings{Huang_2020_CVPR,

--- a/docs/papers/techniques/wingloss.md
+++ b/docs/papers/techniques/wingloss.md
@@ -1,7 +1,7 @@
 <!-- [ALGORITHM] -->
 
 <details>
-<summary align="right">Wingloss (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Feng_Wing_Loss_for_CVPR_2018_paper.html">Wingloss (CVPR'2018)</a></summary>
 
 ```bibtex
 @inproceedings{feng2018wing,

--- a/docs/tasks/2d_animal_keypoint.md
+++ b/docs/tasks/2d_animal_keypoint.md
@@ -18,7 +18,7 @@ MMPose supported datasets:
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Animal-Pose (ICCV'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_ICCV_2019/html/Cao_Cross-Domain_Adaptation_for_Animal_Pose_Estimation_ICCV_2019_paper.html">Animal-Pose (ICCV'2019)</a></summary>
 
 ```bibtex
 @InProceedings{Cao_2019_ICCV,
@@ -102,7 +102,7 @@ Those images from other sources (1000 images with 1000 annotations) are used for
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Horse-10 (WACV'2021)</summary>
+<summary align="right"><a href="https://openaccess.thecvf.com/content/WACV2021/html/Mathis_Pretraining_Boosts_Out-of-Domain_Robustness_for_Pose_Estimation_WACV_2021_paper.html">Horse-10 (WACV'2021)</a></summary>
 
 ```bibtex
 @inproceedings{mathis2021pretraining,
@@ -148,7 +148,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">MacaquePose (bioRxiv'2020)</summary>
+<summary align="right"><a href="https://www.ncbi.nlm.nih.gov/pmc/articles/pmc7874091/">MacaquePose (bioRxiv'2020)</a></summary>
 
 ```bibtex
 @article{labuguen2020macaquepose,
@@ -195,7 +195,7 @@ Since the official dataset does not provide the test set, we randomly select 125
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Vinegar Fly (Nature Methods'2019)</summary>
+<summary align="right"><a href="https://www.nature.com/articles/s41592-018-0234-5">Vinegar Fly (Nature Methods'2019)</a></summary>
 
 ```bibtex
 @article{pereira2019fast,
@@ -244,7 +244,7 @@ Since the official dataset does not provide the test set, we randomly select 90\
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Desert Locust (Elife'2019)</summary>
+<summary align="right"><a href="https://elifesciences.org/articles/47994">Desert Locust (Elife'2019)</a></summary>
 
 ```bibtex
 @article{graving2019deepposekit,
@@ -292,7 +292,7 @@ Since the official dataset does not provide the test set, we randomly select 90\
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Desert Locust (Elife'2019)</summary>
+<summary align="right"><a href="https://elifesciences.org/articles/47994">Grévy’s Zebra (Elife'2019)</a></summary>
 
 ```bibtex
 @article{graving2019deepposekit,
@@ -340,7 +340,7 @@ Since the official dataset does not provide the test set, we randomly select 90\
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">ATRW (ACM MM'2020)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1906.05586">ATRW (ACM MM'2020)</a></summary>
 
 ```bibtex
 @inproceedings{li2020atrw,

--- a/docs/tasks/2d_body_keypoint.md
+++ b/docs/tasks/2d_body_keypoint.md
@@ -22,7 +22,7 @@ MMPose supported datasets:
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">COCO (ECCV'2014)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48">COCO (ECCV'2014)</a></summary>
 
 ```bibtex
 @inproceedings{lin2014microsoft,
@@ -77,7 +77,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">MPII (CVPR'2014)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html">MPII (CVPR'2014)</a></summary>
 
 ```bibtex
 @inproceedings{andriluka14cvpr,
@@ -133,7 +133,7 @@ python tools/mat2json work_dirs/res50_mpii_256x256/pred.mat data/mpii/annotation
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">MPII-TRB (ICCV'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_ICCV_2019/html/Duan_TRB_A_Novel_Triplet_Representation_for_Understanding_2D_Human_Body_ICCV_2019_paper.html">MPII-TRB (ICCV'2019)</a></summary>
 
 ```bibtex
 @inproceedings{duan2019trb,
@@ -174,7 +174,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">AI Challenger (ArXiv'2017)</summary>
+<summary align="right"><a href="https://arxiv.org/abs/1711.06475">AI Challenger (ArXiv'2017)</a></summary>
 
 ```bibtex
 @article{wu2017ai,
@@ -220,7 +220,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">CrowdPose (CVPR'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2019/html/Li_CrowdPose_Efficient_Crowded_Scenes_Pose_Estimation_and_a_New_Benchmark_CVPR_2019_paper.html">CrowdPose (CVPR'2019)</a></summary>
 
 ```bibtex
 @article{li2018crowdpose,
@@ -266,7 +266,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">OCHuman (CVPR'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2019/html/Zhang_Pose2Seg_Detection_Free_Human_Instance_Segmentation_CVPR_2019_paper.html">OCHuman (CVPR'2019)</a></summary>
 
 ```bibtex
 @inproceedings{zhang2019pose2seg,
@@ -308,7 +308,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">MHP (ACM MM'2018)</summary>
+<summary align="right"><a href="https://dl.acm.org/doi/abs/10.1145/3240508.3240509">MHP (ACM MM'2018)</a></summary>
 
 ```bibtex
 @inproceedings{zhao2018understanding,
@@ -363,7 +363,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">PoseTrack18 (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Andriluka_PoseTrack_A_Benchmark_CVPR_2018_paper.html">PoseTrack18 (CVPR'2018)</a></summary>
 
 ```bibtex
 @inproceedings{andriluka2018posetrack,
@@ -454,7 +454,7 @@ pip install git+https://github.com/svenkreiss/poseval.git
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">RSN (ECCV'2020)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-030-58580-8_27">RSN (ECCV'2020)</a></summary>
 
 ```bibtex
 @misc{cai2020learning,

--- a/docs/tasks/2d_face_keypoint.md
+++ b/docs/tasks/2d_face_keypoint.md
@@ -88,7 +88,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">WFLW (CVPR'2018)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2018/html/Wu_Look_at_Boundary_CVPR_2018_paper.html">WFLW (CVPR'2018)</a></summary>
 
 ```bibtex
 @inproceedings{wu2018look,
@@ -144,7 +144,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">AFLW (ICCVW'2011)</summary>
+<summary align="right"><a href="https://ieeexplore.ieee.org/abstract/document/6130513/">AFLW (ICCVW'2011)</a></summary>
 
 ```bibtex
 @inproceedings{koestinger2011annotated,

--- a/docs/tasks/2d_fashion_landmark.md
+++ b/docs/tasks/2d_fashion_landmark.md
@@ -12,7 +12,7 @@ MMPose supported datasets:
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">DeepFashion (CVPR'2016)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2016/html/Liu_DeepFashion_Powering_Robust_CVPR_2016_paper.html">DeepFashion (CVPR'2016)</a></summary>
 
 ```bibtex
 @inproceedings{liuLQWTcvpr16DeepFashion,
@@ -29,7 +29,7 @@ MMPose supported datasets:
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">DeepFashion (ECCV'2016)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-46475-6_15">DeepFashion (ECCV'2016)</a></summary>
 
 ```bibtex
 @inproceedings{liuYLWTeccv16FashionLandmark,

--- a/docs/tasks/2d_hand_keypoint.md
+++ b/docs/tasks/2d_hand_keypoint.md
@@ -16,7 +16,7 @@ MMPose supported datasets:
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">OneHand10K (TCSVT'2019)</summary>
+<summary align="right"><a href="https://ieeexplore.ieee.org/abstract/document/8529221/">OneHand10K (TCSVT'2019)</a></summary>
 
 ```bibtex
 @article{wang2018mask,
@@ -66,7 +66,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">FreiHand (ICCV'2019)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_ICCV_2019/html/Zimmermann_FreiHAND_A_Dataset_for_Markerless_Capture_of_Hand_Pose_and_ICCV_2019_paper.html">FreiHand (ICCV'2019)</a></summary>
 
 ```bibtex
 @inproceedings{zimmermann2019freihand,
@@ -114,7 +114,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">CMU Panoptic HandDB (CVPR'2017)</summary>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_cvpr_2017/html/Simon_Hand_Keypoint_Detection_CVPR_2017_paper.html">CMU Panoptic HandDB (CVPR'2017)</a></summary>
 
 ```bibtex
 @inproceedings{simon2017hand,
@@ -169,7 +169,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">InterHand2.6M (ECCV'2020)</summary>
+<summary align="right"><a href="https://link.springer.com/content/pdf/10.1007/978-3-030-58565-5_33.pdf">InterHand2.6M (ECCV'2020)</a></summary>
 
 ```bibtex
 @InProceedings{Moon_2020_ECCV_InterHand2.6M,
@@ -216,7 +216,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">RHD (ICCV'2017)</summary>
+<summary align="right"><a href="https://lmb.informatik.uni-freiburg.de/projects/hand3d/">RHD (ICCV'2017)</a></summary>
 
 ```bibtex
 @TechReport{zb2017hand,

--- a/docs/tasks/2d_wholebody_keypoint.md
+++ b/docs/tasks/2d_wholebody_keypoint.md
@@ -11,6 +11,9 @@ MMPose supported datasets:
 
 <!-- [DATASET] -->
 
+<details>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-030-58545-7_12">COCO-WholeBody (ECCV'2020)</a></summary>
+
 ```bibtex
 @inproceedings{jin2020whole,
   title={Whole-Body Human Pose Estimation in the Wild},
@@ -19,6 +22,8 @@ MMPose supported datasets:
   year={2020}
 }
 ```
+
+</details>
 
 For [COCO-WholeBody](https://github.com/jin-s13/COCO-WholeBody/) datatset, images can be downloaded from [COCO download](http://cocodataset.org/#download), 2017 Train/Val is needed for COCO keypoints training and validation.
 Download COCO-WholeBody annotations for COCO-WholeBody annotations for [Train](https://drive.google.com/file/d/1thErEToRbmM9uLNi1JXXfOsaS5VK2FXf/view?usp=sharing) / [Validation](https://drive.google.com/file/d/1N6VgwKnj8DeyGXCvp1eYgNbRmw6jdfrb/view?usp=sharing) (Google Drive).

--- a/docs/tasks/3d_body_keypoint.md
+++ b/docs/tasks/3d_body_keypoint.md
@@ -12,7 +12,7 @@ MMPose supported datasets:
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Human3.6M (TPAMI'2014)</summary>
+<summary align="right"><a href="https://ieeexplore.ieee.org/abstract/document/6682899/">Human3.6M (TPAMI'2014)</a></summary>
 
 ```bibtex
 @article{h36m_pami,

--- a/docs/tasks/3d_body_mesh.md
+++ b/docs/tasks/3d_body_mesh.md
@@ -87,7 +87,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">COCO (ECCV'2014)</summary>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48">COCO (ECCV'2014)</a></summary>
 
 ```bibtex
 @inproceedings{lin2014microsoft,
@@ -127,7 +127,7 @@ mmpose
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">Human3.6M (TPAMI'2014)</summary>
+<summary align="right"><a href="https://ieeexplore.ieee.org/abstract/document/6682899/">Human3.6M (TPAMI'2014)</a></summary>
 
 ```bibtex
 @article{h36m_pami,

--- a/docs/tasks/3d_hand_keypoint.md
+++ b/docs/tasks/3d_hand_keypoint.md
@@ -12,7 +12,7 @@ MMPose supported datasets:
 <!-- [DATASET] -->
 
 <details>
-<summary align="right">InterHand2.6M (ECCV'2020)</summary>
+<summary align="right"><a href="https://link.springer.com/content/pdf/10.1007/978-3-030-58565-5_33.pdf">InterHand2.6M (ECCV'2020)</a></summary>
 
 ```bibtex
 @InProceedings{Moon_2020_ECCV_InterHand2.6M,


### PR DESCRIPTION
Motivation:

#749 modified the model performance report format in each .md file to contain the paper URL in the title line. However, the files at docs/papers/ still use old format(not contain URL). This causes keyword mismatch in doc generation.

In this PR, we update all .md files to use a unified paper title format.
