### PR TITLE
Use COCO 2D pose model in 3D demo examples

### DIFF
--- a/demo/docs/3d_human_pose_demo.md
+++ b/demo/docs/3d_human_pose_demo.md
@@ -74,8 +74,8 @@ Example:
 python demo/body3d_two_stage_video_demo.py \
     demo/mmdetection_cfg/faster_rcnn_r50_fpn_coco.py \
     https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_r50_fpn_1x_coco/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth \
-    configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/h36m/hrnet_w32_h36m_256x256.py \
-    https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_h36m_256x256-d3206675_20210621.pth \
+    configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192.py \
+    https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_256x192-b9e0b3ab_20200708.pth \
     configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_243frames_fullconv_supervised_cpn_ft.py \
     https://download.openmmlab.com/mmpose/body3d/videopose/videopose_h36m_243frames_fullconv_supervised_cpn_ft-88f5abbb_20210527.pth \
     --video-path demo/resources/body3d_demo.mp4 \


### PR DESCRIPTION
Previously an h36m 2d model was used in the 3d human pose demo example, which was reported by #777  to have poor results. We found this is because the h36m 2d model generalizes poorly to in-the-wild images. Thus we recommend using COCO 2d pose model instead and update the demo example in this PR.