### PR TITLE
Fix multi-node distributed test

### DIFF
--- a/mmpose/apis/test.py
+++ b/mmpose/apis/test.py
@@ -108,7 +108,8 @@ def collect_results_cpu(result_part, size, tmpdir=None):
                                 dtype=torch.uint8,
                                 device='cuda')
         if rank == 0:
-            tmpdir = tempfile.mkdtemp()
+            mmcv.mkdir_or_exist('.dist_test')
+            tmpdir = tempfile.mkdtemp(dir='.dist_test')
             tmpdir = torch.tensor(
                 bytearray(tmpdir.encode()), dtype=torch.uint8, device='cuda')
             dir_tensor[:len(tmpdir)] = tmpdir
@@ -116,8 +117,11 @@ def collect_results_cpu(result_part, size, tmpdir=None):
         tmpdir = dir_tensor.cpu().numpy().tobytes().decode().rstrip()
     else:
         mmcv.mkdir_or_exist(tmpdir)
+    # synchronizes all processes to make sure tmpdir exist
+    dist.barrier()
     # dump the part result to the dir
     mmcv.dump(result_part, osp.join(tmpdir, f'part_{rank}.pkl'))
+    # synchronizes all processes for loding pickle file
     dist.barrier()
     # collect all parts
     if rank != 0:


### PR DESCRIPTION
`/tmp` dir is usually not shared in the cluster environment. Therefore it's better to use a local tmpdir to store the test result.

refs:
- https://github.com/open-mmlab/mmdetection/pull/4017
- https://github.com/open-mmlab/mmaction2/pull/292
- https://github.com/open-mmlab/mmclassification/pull/251