### PR TITLE
Remove opencv-python-headless dependency by albumentations

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,4 @@
-albumentations>=0.3.2
+albumentations>=0.3.2 --no-binary imgaug,albumentations
 onnx
 onnxruntime
 poseval@git+https://github.com/svenkreiss/poseval.git


### PR DESCRIPTION
By default, installing `albumentations` by pip has `opencv-python-headless` dependency even if `opencv-python` has already been installed. This could cause different opencv versions installed in the environment and lead to unexpected errors.

This PR updates the installation of `albumentations` to prevent using a wheel distribution of it with `opencv-python-headless` dependency. See its [docs](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies) for details.