### PR TITLE
Fix random behavior of update_model_index in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,4 @@ repos:
         additional_dependencies: [mmcv]
         language: python
         files: ^configs/.*\.md$
+        require_serial: true

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/hrnet_animalpose.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/hrnet_animalpose.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: hrnet_animalpose
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/hrnet_animalpose.md
+  Name: hrnet_animalpose
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_ICCV_2019/html/Cao_Cross-Domain_Adaptation_for_Animal_Pose_Estimation_ICCV_2019_paper.html
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/hrnet_animalpose.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--hrnet_w32_animalpose_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/hrnet_w32_animalpose_256x256.py
   In Collection: hrnet_animalpose
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/hrnet_w32_animalpose_256x256.py
   Metadata:
     Training Data: Animal-Pose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--hrnet_w32_animalpose_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Animal-Pose
+  - Dataset: Animal-Pose
     Metrics:
       AP: 0.736
       AP@0.5: 0.959
       AP@0.75: 0.832
       AR: 0.775
       AR@0.5: 0.966
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w32_animalpose_256x256-1aa7f075_20210426.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--hrnet_w48_animalpose_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/hrnet_w48_animalpose_256x256.py
   In Collection: hrnet_animalpose
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/hrnet_w48_animalpose_256x256.py
   Metadata:
     Training Data: Animal-Pose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--hrnet_w48_animalpose_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Animal-Pose
+  - Dataset: Animal-Pose
     Metrics:
       AP: 0.737
       AP@0.5: 0.959
       AP@0.75: 0.823
       AR: 0.778
       AR@0.5: 0.962
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w48_animalpose_256x256-34644726_20210426.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/resnet_animalpose.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/resnet_animalpose.yml
@@ -1,55 +1,55 @@
 Collections:
-- Name: resnet_animalpose
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/resnet_animalpose.md
+  Name: resnet_animalpose
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_ICCV_2019/html/Cao_Cross-Domain_Adaptation_for_Animal_Pose_Estimation_ICCV_2019_paper.html
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/resnet_animalpose.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--res50_animalpose_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/res50_animalpose_256x256.py
   In Collection: resnet_animalpose
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/res50_animalpose_256x256.py
   Metadata:
     Training Data: Animal-Pose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--res50_animalpose_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Animal-Pose
+  - Dataset: Animal-Pose
     Metrics:
       AP: 0.688
       AP@0.5: 0.945
       AP@0.75: 0.772
       AR: 0.733
       AR@0.5: 0.952
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_animalpose_256x256-e1f30bff_20210426.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--res101_animalpose_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/res101_animalpose_256x256.py
   In Collection: resnet_animalpose
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/res101_animalpose_256x256.py
   Metadata:
     Training Data: Animal-Pose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--res101_animalpose_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Animal-Pose
+  - Dataset: Animal-Pose
     Metrics:
       AP: 0.696
       AP@0.5: 0.948
       AP@0.75: 0.785
       AR: 0.737
       AR@0.5: 0.954
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_animalpose_256x256-85563f4a_20210426.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--res152_animalpose_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/res152_animalpose_256x256.py
   In Collection: resnet_animalpose
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/animalpose/res152_animalpose_256x256.py
   Metadata:
     Training Data: Animal-Pose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--animalpose--res152_animalpose_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Animal-Pose
+  - Dataset: Animal-Pose
     Metrics:
       AP: 0.709
       AP@0.5: 0.948
       AP@0.75: 0.797
       AR: 0.749
       AR@0.5: 0.951
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res152_animalpose_256x256-a0a7506c_20210426.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/hrnet_atrw.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/hrnet_atrw.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: hrnet_atrw
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/hrnet_atrw.md
+  Name: hrnet_atrw
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://arxiv.org/abs/1906.05586
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/hrnet_atrw.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--hrnet_w32_atrw_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/hrnet_w32_atrw_256x256.py
   In Collection: hrnet_atrw
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/hrnet_w32_atrw_256x256.py
   Metadata:
     Training Data: ATRW
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--hrnet_w32_atrw_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: ATRW
+  - Dataset: ATRW
     Metrics:
       AP: 0.912
       AP@0.5: 0.973
       AP@0.75: 0.959
       AR: 0.938
       AR@0.5: 0.985
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w32_atrw_256x256-f027f09a_20210414.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--hrnet_w48_atrw_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/hrnet_w48_atrw_256x256.py
   In Collection: hrnet_atrw
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/hrnet_w48_atrw_256x256.py
   Metadata:
     Training Data: ATRW
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--hrnet_w48_atrw_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: ATRW
+  - Dataset: ATRW
     Metrics:
       AP: 0.911
       AP@0.5: 0.972
       AP@0.75: 0.946
       AR: 0.937
       AR@0.5: 0.985
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w48_atrw_256x256-ac088892_20210414.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/resnet_atrw.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/resnet_atrw.yml
@@ -1,55 +1,55 @@
 Collections:
-- Name: resnet_atrw
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/resnet_atrw.md
+  Name: resnet_atrw
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - https://arxiv.org/abs/1906.05586
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/resnet_atrw.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--res50_atrw_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/res50_atrw_256x256.py
   In Collection: resnet_atrw
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/res50_atrw_256x256.py
   Metadata:
     Training Data: ATRW
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--res50_atrw_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: ATRW
+  - Dataset: ATRW
     Metrics:
       AP: 0.9
       AP@0.5: 0.973
       AP@0.75: 0.932
       AR: 0.929
       AR@0.5: 0.985
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_atrw_256x256-546c4594_20210414.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--res101_atrw_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/res101_atrw_256x256.py
   In Collection: resnet_atrw
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/res101_atrw_256x256.py
   Metadata:
     Training Data: ATRW
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--res101_atrw_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: ATRW
+  - Dataset: ATRW
     Metrics:
       AP: 0.898
       AP@0.5: 0.973
       AP@0.75: 0.936
       AR: 0.927
       AR@0.5: 0.985
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_atrw_256x256-da93f371_20210414.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--res152_atrw_256x256
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/res152_atrw_256x256.py
   In Collection: resnet_atrw
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/atrw/res152_atrw_256x256.py
   Metadata:
     Training Data: ATRW
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--atrw--res152_atrw_256x256
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: ATRW
+  - Dataset: ATRW
     Metrics:
       AP: 0.896
       AP@0.5: 0.973
       AP@0.75: 0.931
       AR: 0.927
       AR@0.5: 0.985
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res152_atrw_256x256-2bb8e162_20210414.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/resnet_fly.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/resnet_fly.yml
@@ -1,49 +1,49 @@
 Collections:
-- Name: resnet_fly
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/resnet_fly.md
+  Name: resnet_fly
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - https://www.nature.com/articles/s41592-018-0234-5
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/resnet_fly.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--fly--res50_fly_192x192
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/res50_fly_192x192.py
   In Collection: resnet_fly
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/res50_fly_192x192.py
   Metadata:
     Training Data: Vinegar Fly
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--fly--res50_fly_192x192
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Vinegar Fly
+  - Dataset: Vinegar Fly
     Metrics:
-      PCK@0.2: 0.996
       AUC: 0.91
       EPE: 2.0
+      PCK@0.2: 0.996
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_fly_192x192-5d0ee2d9_20210407.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--fly--res101_fly_192x192
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/res101_fly_192x192.py
   In Collection: resnet_fly
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/res101_fly_192x192.py
   Metadata:
     Training Data: Vinegar Fly
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--fly--res101_fly_192x192
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Vinegar Fly
+  - Dataset: Vinegar Fly
     Metrics:
-      PCK@0.2: 0.996
       AUC: 0.912
       EPE: 1.95
+      PCK@0.2: 0.996
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_fly_192x192-41a7a6cc_20210407.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--fly--res152_fly_192x192
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/res152_fly_192x192.py
   In Collection: resnet_fly
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/res152_fly_192x192.py
   Metadata:
     Training Data: Vinegar Fly
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--fly--res152_fly_192x192
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Vinegar Fly
+  - Dataset: Vinegar Fly
     Metrics:
-      PCK@0.2: 0.997
       AUC: 0.917
       EPE: 1.78
+      PCK@0.2: 0.997
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res152_fly_192x192-fcafbd5a_20210407.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_horse10.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_horse10.yml
@@ -1,82 +1,82 @@
 Collections:
-- Name: hrnet_horse10
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_horse10.md
+  Name: hrnet_horse10
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://openaccess.thecvf.com/content/WACV2021/html/Mathis_Pretraining_Boosts_Out-of-Domain_Robustness_for_Pose_Estimation_WACV_2021_paper.html
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_horse10.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w32_horse10_256x256-split1
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w32_horse10_256x256-split1.py
   In Collection: hrnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w32_horse10_256x256-split1.py
   Metadata:
     Training Data: Horse-10
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w32_horse10_256x256-split1
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Horse-10
+  - Dataset: Horse-10
     Metrics:
-      PCK@0.3: 0.951
       NME: 0.122
+      PCK@0.3: 0.951
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w32_horse10_256x256_split1-401d901a_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w32_horse10_256x256-split2
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w32_horse10_256x256-split2.py
   In Collection: hrnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w32_horse10_256x256-split2.py
   Metadata:
     Training Data: Horse-10
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w32_horse10_256x256-split2
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Horse-10
+  - Dataset: Horse-10
     Metrics:
-      PCK@0.3: 0.949
       NME: 0.116
+      PCK@0.3: 0.949
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w32_horse10_256x256_split2-04840523_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w32_horse10_256x256-split3
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w32_horse10_256x256-split3.py
   In Collection: hrnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w32_horse10_256x256-split3.py
   Metadata:
     Training Data: Horse-10
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w32_horse10_256x256-split3
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Horse-10
+  - Dataset: Horse-10
     Metrics:
-      PCK@0.3: 0.939
       NME: 0.153
+      PCK@0.3: 0.939
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w32_horse10_256x256_split3-4db47400_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w48_horse10_256x256-split1
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w48_horse10_256x256-split1.py
   In Collection: hrnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w48_horse10_256x256-split1.py
   Metadata:
     Training Data: Horse-10
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w48_horse10_256x256-split1
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Horse-10
+  - Dataset: Horse-10
     Metrics:
-      PCK@0.3: 0.973
       NME: 0.095
+      PCK@0.3: 0.973
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w48_horse10_256x256_split1-3c950d3b_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w48_horse10_256x256-split2
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w48_horse10_256x256-split2.py
   In Collection: hrnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w48_horse10_256x256-split2.py
   Metadata:
     Training Data: Horse-10
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w48_horse10_256x256-split2
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Horse-10
+  - Dataset: Horse-10
     Metrics:
-      PCK@0.3: 0.969
       NME: 0.101
+      PCK@0.3: 0.969
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w48_horse10_256x256_split2-8ef72b5d_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w48_horse10_256x256-split3
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w48_horse10_256x256-split3.py
   In Collection: hrnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/hrnet_w48_horse10_256x256-split3.py
   Metadata:
     Training Data: Horse-10
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--hrnet_w48_horse10_256x256-split3
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Horse-10
+  - Dataset: Horse-10
     Metrics:
-      PCK@0.3: 0.961
       NME: 0.128
+      PCK@0.3: 0.961
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w48_horse10_256x256_split3-0232ec47_20210405.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/resnet_horse10.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/resnet_horse10.yml
@@ -1,118 +1,118 @@
 Collections:
-- Name: resnet_horse10
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/resnet_horse10.md
+  Name: resnet_horse10
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/resnet_horse10.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res50_horse10_256x256-split1
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res50_horse10_256x256-split1.py
   In Collection: resnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res50_horse10_256x256-split1.py
   Metadata:
     Training Data: HRNet
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res50_horse10_256x256-split1
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: HRNet
+  - Dataset: HRNet
     Metrics:
-      PCK@0.3: 0.956
       NME: 0.113
+      PCK@0.3: 0.956
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_horse10_256x256_split1-3a3dc37e_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res50_horse10_256x256-split2
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res50_horse10_256x256-split2.py
   In Collection: resnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res50_horse10_256x256-split2.py
   Metadata:
     Training Data: HRNet
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res50_horse10_256x256-split2
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: HRNet
+  - Dataset: HRNet
     Metrics:
-      PCK@0.3: 0.954
       NME: 0.111
+      PCK@0.3: 0.954
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_horse10_256x256_split2-65e2a508_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res50_horse10_256x256-split3
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res50_horse10_256x256-split3.py
   In Collection: resnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res50_horse10_256x256-split3.py
   Metadata:
     Training Data: HRNet
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res50_horse10_256x256-split3
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: HRNet
+  - Dataset: HRNet
     Metrics:
-      PCK@0.3: 0.946
       NME: 0.129
-  Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_horse10_256x256_split3-9637d4eb_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res101_horse10_256x256-split1
-  In Collection: resnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res101_horse10_256x256-split1.py
-  Metadata:
-    Training Data: HRNet
-  Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: HRNet
-    Metrics:
-      PCK@0.3: 0.958
-      NME: 0.115
-  Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_horse10_256x256_split1-1b7c259c_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res101_horse10_256x256-split2
-  In Collection: resnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res101_horse10_256x256-split2.py
-  Metadata:
-    Training Data: HRNet
-  Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: HRNet
-    Metrics:
-      PCK@0.3: 0.955
-      NME: 0.115
-  Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_horse10_256x256_split2-30e2fa87_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res101_horse10_256x256-split3
-  In Collection: resnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res101_horse10_256x256-split3.py
-  Metadata:
-    Training Data: HRNet
-  Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: HRNet
-    Metrics:
       PCK@0.3: 0.946
+    Task: 2D Animal Keypoint Detection
+  Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_horse10_256x256_split3-9637d4eb_20210405.pth
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res101_horse10_256x256-split1.py
+  In Collection: resnet_horse10
+  Metadata:
+    Training Data: HRNet
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res101_horse10_256x256-split1
+  Results:
+  - Dataset: HRNet
+    Metrics:
+      NME: 0.115
+      PCK@0.3: 0.958
+    Task: 2D Animal Keypoint Detection
+  Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_horse10_256x256_split1-1b7c259c_20210405.pth
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res101_horse10_256x256-split2.py
+  In Collection: resnet_horse10
+  Metadata:
+    Training Data: HRNet
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res101_horse10_256x256-split2
+  Results:
+  - Dataset: HRNet
+    Metrics:
+      NME: 0.115
+      PCK@0.3: 0.955
+    Task: 2D Animal Keypoint Detection
+  Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_horse10_256x256_split2-30e2fa87_20210405.pth
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res101_horse10_256x256-split3.py
+  In Collection: resnet_horse10
+  Metadata:
+    Training Data: HRNet
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res101_horse10_256x256-split3
+  Results:
+  - Dataset: HRNet
+    Metrics:
       NME: 0.126
+      PCK@0.3: 0.946
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_horse10_256x256_split3-2eea5bb1_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res152_horse10_256x256-split1
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res152_horse10_256x256-split1.py
   In Collection: resnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res152_horse10_256x256-split1.py
   Metadata:
     Training Data: HRNet
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res152_horse10_256x256-split1
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: HRNet
+  - Dataset: HRNet
     Metrics:
-      PCK@0.3: 0.969
       NME: 0.105
+      PCK@0.3: 0.969
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res152_horse10_256x256_split1-7e81fe2d_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res152_horse10_256x256-split2
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res152_horse10_256x256-split2.py
   In Collection: resnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res152_horse10_256x256-split2.py
   Metadata:
     Training Data: HRNet
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res152_horse10_256x256-split2
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: HRNet
+  - Dataset: HRNet
     Metrics:
-      PCK@0.3: 0.97
       NME: 0.103
+      PCK@0.3: 0.97
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res152_horse10_256x256_split2-3b3404a3_20210405.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res152_horse10_256x256-split3
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res152_horse10_256x256-split3.py
   In Collection: resnet_horse10
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/horse10/res152_horse10_256x256-split3.py
   Metadata:
     Training Data: HRNet
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--horse10--res152_horse10_256x256-split3
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: HRNet
+  - Dataset: HRNet
     Metrics:
-      PCK@0.3: 0.957
       NME: 0.131
+      PCK@0.3: 0.957
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res152_horse10_256x256_split3-c957dac5_20210405.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/resnet_locust.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/resnet_locust.yml
@@ -1,49 +1,49 @@
 Collections:
-- Name: resnet_locust
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/resnet_locust.md
+  Name: resnet_locust
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - https://elifesciences.org/articles/47994
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/resnet_locust.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--locust--res50_locust_160x160
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/res50_locust_160x160.py
   In Collection: resnet_locust
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/res50_locust_160x160.py
   Metadata:
     Training Data: Desert Locust
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--locust--res50_locust_160x160
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Desert Locust
+  - Dataset: Desert Locust
     Metrics:
-      PCK@0.2: 0.999
       AUC: 0.899
       EPE: 2.27
+      PCK@0.2: 0.999
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_locust_160x160-9efca22b_20210407.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--locust--res101_locust_160x160
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/res101_locust_160x160.py
   In Collection: resnet_locust
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/res101_locust_160x160.py
   Metadata:
     Training Data: Desert Locust
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--locust--res101_locust_160x160
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Desert Locust
+  - Dataset: Desert Locust
     Metrics:
-      PCK@0.2: 0.999
       AUC: 0.907
       EPE: 2.03
+      PCK@0.2: 0.999
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_locust_160x160-d77986b3_20210407.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--locust--res152_locust_160x160
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/res152_locust_160x160.py
   In Collection: resnet_locust
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/locust/res152_locust_160x160.py
   Metadata:
     Training Data: Desert Locust
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--locust--res152_locust_160x160
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: Desert Locust
+  - Dataset: Desert Locust
     Metrics:
-      PCK@0.2: 1.0
       AUC: 0.926
       EPE: 1.48
+      PCK@0.2: 1.0
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res152_locust_160x160-4ea9b372_20210407.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/hrnet_macaque.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/hrnet_macaque.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: hrnet_macaque
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/hrnet_macaque.md
+  Name: hrnet_macaque
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://www.ncbi.nlm.nih.gov/pmc/articles/pmc7874091/
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/hrnet_macaque.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--hrnet_w32_macaque_256x192
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/hrnet_w32_macaque_256x192.py
   In Collection: hrnet_macaque
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/hrnet_w32_macaque_256x192.py
   Metadata:
     Training Data: MacaquePose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--hrnet_w32_macaque_256x192
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: MacaquePose
+  - Dataset: MacaquePose
     Metrics:
       AP: 0.814
       AP@0.5: 0.953
       AP@0.75: 0.918
       AR: 0.851
       AR@0.5: 0.969
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w32_macaque_256x192-f7e9e04f_20210407.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--hrnet_w48_macaque_256x192
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/hrnet_w48_macaque_256x192.py
   In Collection: hrnet_macaque
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/hrnet_w48_macaque_256x192.py
   Metadata:
     Training Data: MacaquePose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--hrnet_w48_macaque_256x192
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: MacaquePose
+  - Dataset: MacaquePose
     Metrics:
       AP: 0.818
       AP@0.5: 0.963
       AP@0.75: 0.917
       AR: 0.855
       AR@0.5: 0.971
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w48_macaque_256x192-9b34b02a_20210407.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/resnet_macaque.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/resnet_macaque.yml
@@ -1,55 +1,55 @@
 Collections:
-- Name: resnet_macaque
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/resnet_macaque.md
+  Name: resnet_macaque
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - https://www.ncbi.nlm.nih.gov/pmc/articles/pmc7874091/
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/resnet_macaque.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--res50_macaque_256x192
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/res50_macaque_256x192.py
   In Collection: resnet_macaque
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/res50_macaque_256x192.py
   Metadata:
     Training Data: MacaquePose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--res50_macaque_256x192
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: MacaquePose
+  - Dataset: MacaquePose
     Metrics:
       AP: 0.799
       AP@0.5: 0.952
       AP@0.75: 0.919
       AR: 0.837
       AR@0.5: 0.964
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_macaque_256x192-98f1dd3a_20210407.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--res101_macaque_256x192
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/res101_macaque_256x192.py
   In Collection: resnet_macaque
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/res101_macaque_256x192.py
   Metadata:
     Training Data: MacaquePose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--res101_macaque_256x192
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: MacaquePose
+  - Dataset: MacaquePose
     Metrics:
       AP: 0.79
       AP@0.5: 0.953
       AP@0.75: 0.908
       AR: 0.828
       AR@0.5: 0.967
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_macaque_256x192-e3b9c6bb_20210407.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--res152_macaque_256x192
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/res152_macaque_256x192.py
   In Collection: resnet_macaque
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/macaque/res152_macaque_256x192.py
   Metadata:
     Training Data: MacaquePose
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--macaque--res152_macaque_256x192
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: MacaquePose
+  - Dataset: MacaquePose
     Metrics:
       AP: 0.794
       AP@0.5: 0.951
       AP@0.75: 0.915
       AR: 0.834
       AR@0.5: 0.968
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res152_macaque_256x192-c42abc02_20210407.pth

--- a/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/resnet_zebra.yml
+++ b/configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/resnet_zebra.yml
@@ -1,49 +1,49 @@
 Collections:
-- Name: resnet_zebra
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
-  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/resnet_zebra.md
+  Name: resnet_zebra
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - https://elifesciences.org/articles/47994
+  README: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/resnet_zebra.md
 Models:
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--zebra--res50_zebra_160x160
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/res50_zebra_160x160.py
   In Collection: resnet_zebra
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/res50_zebra_160x160.py
   Metadata:
     Training Data: "Gr\xE9vy\u2019s Zebra"
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--zebra--res50_zebra_160x160
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: "Gr\xE9vy\u2019s Zebra"
+  - Dataset: "Gr\xE9vy\u2019s Zebra"
     Metrics:
-      PCK@0.2: 1.0
       AUC: 0.914
       EPE: 1.86
+      PCK@0.2: 1.0
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res50_zebra_160x160-5a104833_20210407.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--zebra--res101_zebra_160x160
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/res101_zebra_160x160.py
   In Collection: resnet_zebra
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/res101_zebra_160x160.py
   Metadata:
     Training Data: "Gr\xE9vy\u2019s Zebra"
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--zebra--res101_zebra_160x160
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: "Gr\xE9vy\u2019s Zebra"
+  - Dataset: "Gr\xE9vy\u2019s Zebra"
     Metrics:
-      PCK@0.2: 1.0
       AUC: 0.916
       EPE: 1.82
+      PCK@0.2: 1.0
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res101_zebra_160x160-e8cb2010_20210407.pth
-- Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--zebra--res152_zebra_160x160
+- Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/res152_zebra_160x160.py
   In Collection: resnet_zebra
-  Config: configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/zebra/res152_zebra_160x160.py
   Metadata:
     Training Data: "Gr\xE9vy\u2019s Zebra"
+  Name: animal--2d_kpt_sview_rgb_img--topdown_heatmap--zebra--res152_zebra_160x160
   Results:
-  - Task: 2D Animal Keypoint Detection
-    Dataset: "Gr\xE9vy\u2019s Zebra"
+  - Dataset: "Gr\xE9vy\u2019s Zebra"
     Metrics:
-      PCK@0.2: 1.0
       AUC: 0.921
       EPE: 1.66
+      PCK@0.2: 1.0
+    Task: 2D Animal Keypoint Detection
   Weights: https://download.openmmlab.com/mmpose/animal/resnet/res152_zebra_160x160-05de71dd_20210407.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/higherhrnet_aic.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/higherhrnet_aic.yml
@@ -1,42 +1,42 @@
 Collections:
-- Name: higherhrnet_aic
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HigherHRNet
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/higherhrnet_aic.md
+  Name: higherhrnet_aic
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Cheng_HigherHRNet_Scale-Aware_Representation_Learning_for_Bottom-Up_Human_Pose_Estimation_CVPR_2020_paper.html
   - https://arxiv.org/abs/1711.06475
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/higherhrnet_aic.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--aic--higherhrnet_w32_aic_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/higherhrnet_w32_aic_512x512.py
   In Collection: higherhrnet_aic
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/higherhrnet_w32_aic_512x512.py
   Metadata:
     Training Data: AI Challenger
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--aic--higherhrnet_w32_aic_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: AI Challenger
+  - Dataset: AI Challenger
     Metrics:
       AP: 0.315
       AP@0.5: 0.71
       AP@0.75: 0.243
       AR: 0.379
       AR@0.5: 0.757
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_aic_512x512-9a674c33_20210130.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--aic--higherhrnet_w32_aic_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/higherhrnet_w32_aic_512x512.py
   In Collection: higherhrnet_aic
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/higherhrnet_w32_aic_512x512.py
   Metadata:
     Training Data: AI Challenger
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--aic--higherhrnet_w32_aic_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: AI Challenger
+  - Dataset: AI Challenger
     Metrics:
       AP: 0.323
       AP@0.5: 0.718
       AP@0.75: 0.254
       AR: 0.379
       AR@0.5: 0.758
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_aic_512x512-9a674c33_20210130.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/hrnet_aic.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/hrnet_aic.yml
@@ -1,42 +1,42 @@
 Collections:
-- Name: hrnet_aic
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/hrnet_aic.md
+  Name: hrnet_aic
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://arxiv.org/abs/1711.06475
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/hrnet_aic.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--aic--hrnet_w32_aic_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/hrnet_w32_aic_512x512.py
   In Collection: hrnet_aic
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/hrnet_w32_aic_512x512.py
   Metadata:
     Training Data: AI Challenger
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--aic--hrnet_w32_aic_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: AI Challenger
+  - Dataset: AI Challenger
     Metrics:
       AP: 0.303
       AP@0.5: 0.697
       AP@0.75: 0.225
       AR: 0.373
       AR@0.5: 0.755
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w32_aic_512x512-77e2a98a_20210131.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--aic--hrnet_w32_aic_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/hrnet_w32_aic_512x512.py
   In Collection: hrnet_aic
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/aic/hrnet_w32_aic_512x512.py
   Metadata:
     Training Data: AI Challenger
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--aic--hrnet_w32_aic_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: AI Challenger
+  - Dataset: AI Challenger
     Metrics:
       AP: 0.318
       AP@0.5: 0.717
       AP@0.75: 0.246
       AR: 0.379
       AR@0.5: 0.764
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w32_aic_512x512-77e2a98a_20210131.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_coco.yml
@@ -1,102 +1,102 @@
 Collections:
-- Name: higherhrnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HigherHRNet
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_coco.md
+  Name: higherhrnet_coco
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Cheng_HigherHRNet_Scale-Aware_Representation_Learning_for_Bottom-Up_Human_Pose_Estimation_CVPR_2020_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_512x512.py
   In Collection: higherhrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.677
       AP@0.5: 0.87
       AP@0.75: 0.738
       AR: 0.723
       AR@0.5: 0.89
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_coco_512x512-8ae85183_20200713.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_640x640
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_640x640.py
   In Collection: higherhrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_640x640.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_640x640
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.686
       AP@0.5: 0.871
       AP@0.75: 0.747
       AR: 0.733
       AR@0.5: 0.898
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_coco_640x640-a22fe938_20200712.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w48_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w48_coco_512x512.py
   In Collection: higherhrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w48_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w48_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.686
       AP@0.5: 0.873
       AP@0.75: 0.741
       AR: 0.731
       AR@0.5: 0.892
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet48_coco_512x512-60fedcbc_20200712.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_512x512.py
   In Collection: higherhrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.706
       AP@0.5: 0.881
       AP@0.75: 0.771
       AR: 0.747
       AR@0.5: 0.901
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_coco_512x512-8ae85183_20200713.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_640x640
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_640x640.py
   In Collection: higherhrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_640x640.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_640x640
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.706
       AP@0.5: 0.88
       AP@0.75: 0.77
       AR: 0.749
       AR@0.5: 0.902
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_coco_640x640-a22fe938_20200712.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w48_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w48_coco_512x512.py
   In Collection: higherhrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w48_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w48_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.716
       AP@0.5: 0.884
       AP@0.75: 0.775
       AR: 0.755
       AR@0.5: 0.901
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet48_coco_512x512-60fedcbc_20200712.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_udp_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_udp_coco.yml
@@ -1,44 +1,44 @@
 Collections:
-- Name: higherhrnet_udp_coco
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HigherHRNet
     - UDP
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_udp_coco.md
+  Name: higherhrnet_udp_coco
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Cheng_HigherHRNet_Scale-Aware_Representation_Learning_for_Bottom-Up_Human_Pose_Estimation_CVPR_2020_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Huang_The_Devil_Is_in_the_Details_Delving_Into_Unbiased_Data_CVPR_2020_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_udp_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_512x512_udp
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_512x512_udp.py
   In Collection: higherhrnet_udp_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w32_coco_512x512_udp.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w32_coco_512x512_udp
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.678
       AP@0.5: 0.862
       AP@0.75: 0.736
       AR: 0.724
       AR@0.5: 0.89
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_coco_512x512_udp-8cc64794_20210222.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w48_coco_512x512_udp
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w48_coco_512x512_udp.py
   In Collection: higherhrnet_udp_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/higherhrnet_w48_coco_512x512_udp.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--higherhrnet_w48_coco_512x512_udp
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.69
       AP@0.5: 0.872
       AP@0.75: 0.75
       AR: 0.734
       AR@0.5: 0.891
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet48_coco_512x512_udp-7cad61ef_20210222.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_coco.yml
@@ -1,72 +1,72 @@
 Collections:
-- Name: hrnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_coco.md
+  Name: hrnet_coco
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w32_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w32_coco_512x512.py
   In Collection: hrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w32_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w32_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.654
       AP@0.5: 0.863
       AP@0.75: 0.72
       AR: 0.71
       AR@0.5: 0.892
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w32_coco_512x512-bcb8c247_20200816.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_coco_512x512.py
   In Collection: hrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.665
       AP@0.5: 0.86
       AP@0.75: 0.727
       AR: 0.716
       AR@0.5: 0.889
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w48_coco_512x512-cf72fcdf_20200816.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w32_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w32_coco_512x512.py
   In Collection: hrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w32_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w32_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.698
       AP@0.5: 0.877
       AP@0.75: 0.76
       AR: 0.748
       AR@0.5: 0.907
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w32_coco_512x512-bcb8c247_20200816.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_coco_512x512.py
   In Collection: hrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.712
       AP@0.5: 0.88
       AP@0.75: 0.771
       AR: 0.757
       AR@0.5: 0.909
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w48_coco_512x512-cf72fcdf_20200816.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_udp_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_udp_coco.yml
@@ -1,44 +1,44 @@
 Collections:
-- Name: hrnet_udp_coco
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HRNet
     - UDP
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_udp_coco.md
+  Name: hrnet_udp_coco
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Huang_The_Devil_Is_in_the_Details_Delving_Into_Unbiased_Data_CVPR_2020_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_udp_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w32_coco_512x512_udp
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w32_coco_512x512_udp.py
   In Collection: hrnet_udp_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w32_coco_512x512_udp.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w32_coco_512x512_udp
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.671
       AP@0.5: 0.863
       AP@0.75: 0.729
       AR: 0.717
       AR@0.5: 0.889
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w32_coco_512x512_udp-91663bf9_20210220.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_coco_512x512_udp
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_coco_512x512_udp.py
   In Collection: hrnet_udp_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_coco_512x512_udp.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_coco_512x512_udp
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.681
       AP@0.5: 0.872
       AP@0.75: 0.741
       AR: 0.725
       AR@0.5: 0.892
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w48_coco_512x512_udp-de08fd8c_20210222.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/mobilenetv2_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/mobilenetv2_coco.yml
@@ -1,42 +1,42 @@
 Collections:
-- Name: mobilenetv2_coco
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - MobilenetV2
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/mobilenetv2_coco.md
+  Name: mobilenetv2_coco
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Sandler_MobileNetV2_Inverted_Residuals_CVPR_2018_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/mobilenetv2_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--mobilenetv2_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/mobilenetv2_coco_512x512.py
   In Collection: mobilenetv2_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/mobilenetv2_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--mobilenetv2_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.38
       AP@0.5: 0.671
       AP@0.75: 0.368
       AR: 0.473
       AR@0.5: 0.741
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/mobilenetv2_coco_512x512-4d96e309_20200816.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--mobilenetv2_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/mobilenetv2_coco_512x512.py
   In Collection: mobilenetv2_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/mobilenetv2_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--mobilenetv2_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.442
       AP@0.5: 0.696
       AP@0.75: 0.422
       AR: 0.517
       AR@0.5: 0.766
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/mobilenetv2_coco_512x512-4d96e309_20200816.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/resnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/resnet_coco.yml
@@ -1,132 +1,132 @@
 Collections:
-- Name: resnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/resnet_coco.md
+  Name: resnet_coco
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/resnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res50_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res50_coco_512x512.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res50_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res50_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.466
       AP@0.5: 0.742
       AP@0.75: 0.479
       AR: 0.552
       AR@0.5: 0.797
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/res50_coco_512x512-5521bead_20200816.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res50_coco_640x640
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res50_coco_640x640.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res50_coco_640x640.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res50_coco_640x640
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.479
       AP@0.5: 0.757
       AP@0.75: 0.487
       AR: 0.566
       AR@0.5: 0.81
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/res50_coco_640x640-2046f9cb_20200822.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res101_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res101_coco_512x512.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res101_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res101_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.554
       AP@0.5: 0.807
       AP@0.75: 0.599
       AR: 0.622
       AR@0.5: 0.841
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/res101_coco_512x512-e0c95157_20200816.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res152_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res152_coco_512x512.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res152_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res152_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.595
       AP@0.5: 0.829
       AP@0.75: 0.648
       AR: 0.651
       AR@0.5: 0.856
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/res152_coco_512x512-364eb38d_20200822.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res50_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res50_coco_512x512.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res50_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res50_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.503
       AP@0.5: 0.765
       AP@0.75: 0.521
       AR: 0.591
       AR@0.5: 0.821
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/res50_coco_512x512-5521bead_20200816.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res50_coco_640x640
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res50_coco_640x640.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res50_coco_640x640.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res50_coco_640x640
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.525
       AP@0.5: 0.784
       AP@0.75: 0.542
       AR: 0.61
       AR@0.5: 0.832
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/res50_coco_640x640-2046f9cb_20200822.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res101_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res101_coco_512x512.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res101_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res101_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.603
       AP@0.5: 0.831
       AP@0.75: 0.641
       AR: 0.668
       AR@0.5: 0.87
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/res101_coco_512x512-e0c95157_20200816.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res152_coco_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res152_coco_512x512.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/res152_coco_512x512.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--res152_coco_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.66
       AP@0.5: 0.86
       AP@0.75: 0.713
       AR: 0.709
       AR@0.5: 0.889
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/res152_coco_512x512-364eb38d_20200822.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/crowdpose/higherhrnet_crowdpose.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/crowdpose/higherhrnet_crowdpose.yml
@@ -1,44 +1,44 @@
 Collections:
-- Name: higherhrnet_crowdpose
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HigherHRNet
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/crowdpose/higherhrnet_crowdpose.md
+  Name: higherhrnet_crowdpose
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Cheng_HigherHRNet_Scale-Aware_Representation_Learning_for_Bottom-Up_Human_Pose_Estimation_CVPR_2020_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Li_CrowdPose_Efficient_Crowded_Scenes_Pose_Estimation_and_a_New_Benchmark_CVPR_2019_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/crowdpose/higherhrnet_crowdpose.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--crowdpose--higherhrnet_w32_crowdpose_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/crowdpose/higherhrnet_w32_crowdpose_512x512.py
   In Collection: higherhrnet_crowdpose
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/crowdpose/higherhrnet_w32_crowdpose_512x512.py
   Metadata:
     Training Data: CrowdPose
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--crowdpose--higherhrnet_w32_crowdpose_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: CrowdPose
+  - Dataset: CrowdPose
     Metrics:
       AP: 0.655
+      AP (E): 0.728
+      AP (H): 0.577
+      AP (M): 0.66
       AP@0.5: 0.859
       AP@0.75: 0.705
-      AP (E): 0.728
-      AP (M): 0.66
-      AP (H): 0.577
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_crowdpose_512x512-1aa4a132_20201017.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--crowdpose--higherhrnet_w32_crowdpose_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/crowdpose/higherhrnet_w32_crowdpose_512x512.py
   In Collection: higherhrnet_crowdpose
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/crowdpose/higherhrnet_w32_crowdpose_512x512.py
   Metadata:
     Training Data: CrowdPose
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--crowdpose--higherhrnet_w32_crowdpose_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: CrowdPose
+  - Dataset: CrowdPose
     Metrics:
       AP: 0.661
+      AP (E): 0.742
+      AP (H): 0.566
+      AP (M): 0.67
       AP@0.5: 0.864
       AP@0.75: 0.71
-      AP (E): 0.742
-      AP (M): 0.67
-      AP (H): 0.566
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_crowdpose_512x512-1aa4a132_20201017.pth

--- a/configs/body/2d_kpt_sview_rgb_img/associative_embedding/mhp/hrnet_mhp.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/associative_embedding/mhp/hrnet_mhp.yml
@@ -1,42 +1,42 @@
 Collections:
-- Name: hrnet_mhp
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/mhp/hrnet_mhp.md
+  Name: hrnet_mhp
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://dl.acm.org/doi/abs/10.1145/3240508.3240509
+  README: configs/body/2d_kpt_sview_rgb_img/associative_embedding/mhp/hrnet_mhp.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_mhp_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_mhp_512x512.py
   In Collection: hrnet_mhp
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_mhp_512x512.py
   Metadata:
     Training Data: MHP
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_mhp_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MHP
+  - Dataset: MHP
     Metrics:
       AP: 0.583
       AP@0.5: 0.895
       AP@0.75: 0.666
       AR: 0.656
       AR@0.5: 0.931
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w48_mhp_512x512-85a6ab6f_20201229.pth
-- Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_mhp_512x512
+- Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_mhp_512x512.py
   In Collection: hrnet_mhp
-  Config: configs/body/2d_kpt_sview_rgb_img/associative_embedding/coco/hrnet_w48_mhp_512x512.py
   Metadata:
     Training Data: MHP
+  Name: body--2d_kpt_sview_rgb_img--associative_embedding--coco--hrnet_w48_mhp_512x512
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MHP
+  - Dataset: MHP
     Metrics:
       AP: 0.592
       AP@0.5: 0.898
       AP@0.75: 0.673
       AR: 0.664
       AR@0.5: 0.932
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w48_mhp_512x512-85a6ab6f_20201229.pth

--- a/configs/body/2d_kpt_sview_rgb_img/deeppose/coco/resnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/deeppose/coco/resnet_coco.yml
@@ -1,57 +1,57 @@
 Collections:
-- Name: resnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - DeepPose
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/deeppose/coco/resnet_coco.md
+  Name: resnet_coco
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/deeppose/coco/resnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--deeppose--coco--res50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/deeppose/coco/res50_coco_256x192.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/deeppose/coco/res50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--deeppose--coco--res50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.526
       AP@0.5: 0.816
       AP@0.75: 0.586
       AR: 0.638
       AR@0.5: 0.887
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/deeppose/deeppose_res50_coco_256x192-f6de6c0e_20210205.pth
-- Name: body--2d_kpt_sview_rgb_img--deeppose--coco--res101_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/deeppose/coco/res101_coco_256x192.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/deeppose/coco/res101_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--deeppose--coco--res101_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.56
       AP@0.5: 0.832
       AP@0.75: 0.628
       AR: 0.668
       AR@0.5: 0.9
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/deeppose/deeppose_res101_coco_256x192-2f247111_20210205.pth
-- Name: body--2d_kpt_sview_rgb_img--deeppose--coco--res152_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/deeppose/coco/res152_coco_256x192.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/deeppose/coco/res152_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--deeppose--coco--res152_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.583
       AP@0.5: 0.843
       AP@0.75: 0.659
       AR: 0.686
       AR@0.5: 0.907
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/deeppose/deeppose_res152_coco_256x192-7df89a88_20210205.pth

--- a/configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/resnet_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/resnet_mpii.yml
@@ -1,48 +1,48 @@
 Collections:
-- Name: resnet_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - DeepPose
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/resnet_mpii.md
+  Name: resnet_mpii
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/resnet_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--deeppose--mpii--res50_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/res50_mpii_256x256.py
   In Collection: resnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/res50_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--deeppose--mpii--res50_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.825
       Mean@0.1: 0.174
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/deeppose/deeppose_res50_mpii_256x256-c63cd0b6_20210203.pth
-- Name: body--2d_kpt_sview_rgb_img--deeppose--mpii--res101_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/res101_mpii_256x256.py
   In Collection: resnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/res101_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--deeppose--mpii--res101_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.841
       Mean@0.1: 0.193
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/deeppose/deeppose_res101_mpii_256x256-87516a90_20210205.pth
-- Name: body--2d_kpt_sview_rgb_img--deeppose--mpii--res152_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/res152_mpii_256x256.py
   In Collection: resnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/deeppose/mpii/res152_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--deeppose--mpii--res152_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.85
       Mean@0.1: 0.198
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/deeppose/deeppose_res152_mpii_256x256-15f5e6f9_20210205.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/hrnet_aic.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/hrnet_aic.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: hrnet_aic
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/hrnet_aic.md
+  Name: hrnet_aic
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://arxiv.org/abs/1711.06475
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/hrnet_aic.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--aic--hrnet_w32_aic_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/hrnet_w32_aic_256x192.py
   In Collection: hrnet_aic
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/hrnet_w32_aic_256x192.py
   Metadata:
     Training Data: AI Challenger
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--aic--hrnet_w32_aic_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: AI Challenger
+  - Dataset: AI Challenger
     Metrics:
       AP: 0.323
       AP@0.5: 0.762
       AP@0.75: 0.219
       AR: 0.366
       AR@0.5: 0.789
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_aic_256x192-30a4e465_20200826.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/resnet_aic.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/resnet_aic.yml
@@ -1,27 +1,27 @@
 Collections:
-- Name: resnet_aic
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/resnet_aic.md
+  Name: resnet_aic
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://arxiv.org/abs/1711.06475
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/resnet_aic.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--aic--res101_aic_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/res101_aic_256x192.py
   In Collection: resnet_aic
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/aic/res101_aic_256x192.py
   Metadata:
     Training Data: AI Challenger
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--aic--res101_aic_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: AI Challenger
+  - Dataset: AI Challenger
     Metrics:
       AP: 0.294
       AP@0.5: 0.736
       AP@0.75: 0.174
       AR: 0.337
       AR@0.5: 0.763
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_aic_256x192-79b35445_20200826.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/alexnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/alexnet_coco.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: alexnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - AlexNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/alexnet_coco.md
+  Name: alexnet_coco
   Paper:
   - https://proceedings.neurips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/alexnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--alexnet_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/alexnet_coco_256x192.py
   In Collection: alexnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/alexnet_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--alexnet_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.397
       AP@0.5: 0.758
       AP@0.75: 0.381
       AR: 0.478
       AR@0.5: 0.822
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/alexnet/alexnet_coco_256x192-a7b1fd15_20200727.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/cpm_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/cpm_coco.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: cpm_coco
-  Metadata:
+- Metadata:
     Architecture:
     - CPM
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/cpm_coco.md
+  Name: cpm_coco
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2016/html/Wei_Convolutional_Pose_Machines_CVPR_2016_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/cpm_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--cpm_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/cpm_coco_256x192.py
   In Collection: cpm_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/cpm_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--cpm_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.623
       AP@0.5: 0.859
       AP@0.75: 0.704
       AR: 0.686
       AR@0.5: 0.903
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/cpm/cpm_coco_256x192-aa4ba095_20200817.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--cpm_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/cpm_coco_384x288.py
   In Collection: cpm_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/cpm_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--cpm_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.65
       AP@0.5: 0.864
       AP@0.75: 0.725
       AR: 0.708
       AR@0.5: 0.905
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/cpm/cpm_coco_384x288-80feb4bc_20200821.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hourglass_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hourglass_coco.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: hourglass_coco
-  Metadata:
+- Metadata:
     Architecture:
     - Hourglass
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hourglass_coco.md
+  Name: hourglass_coco
   Paper:
   - https://link.springer.com/chapter/10.1007/978-3-319-46484-8_29
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hourglass_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hourglass52_coco_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hourglass52_coco_256x256.py
   In Collection: hourglass_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hourglass52_coco_256x256.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hourglass52_coco_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.726
       AP@0.5: 0.896
       AP@0.75: 0.799
       AR: 0.78
       AR@0.5: 0.934
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hourglass/hourglass52_coco_256x256-4ec713ba_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hourglass52_coco_384x384
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hourglass52_coco_384x384.py
   In Collection: hourglass_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hourglass52_coco_384x384.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hourglass52_coco_384x384
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.746
       AP@0.5: 0.9
       AP@0.75: 0.813
       AR: 0.797
       AR@0.5: 0.939
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hourglass/hourglass52_coco_384x384-be91ba2b_20200812.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_augmentation_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_augmentation_coco.yml
@@ -1,56 +1,56 @@
 Collections:
-- Name: hrnet_augmentation_coco
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_augmentation_coco.md
+  Name: hrnet_augmentation_coco
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://www.mdpi.com/649002
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_augmentation_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_coarsedropout
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_coarsedropout.py
   In Collection: hrnet_augmentation_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_coarsedropout.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_coarsedropout
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.753
       AP@0.5: 0.908
       AP@0.75: 0.822
       AR: 0.806
       AR@0.5: 0.946
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/augmentation/hrnet_w32_coco_256x192_coarsedropout-0f16a0ce_20210320.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_gridmask
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_gridmask.py
   In Collection: hrnet_augmentation_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_gridmask.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_gridmask
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.752
       AP@0.5: 0.906
       AP@0.75: 0.825
       AR: 0.804
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/augmentation/hrnet_w32_coco_256x192_gridmask-868180df_20210320.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_photometric
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_photometric.py
   In Collection: hrnet_augmentation_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_photometric.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_photometric
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.753
       AP@0.5: 0.909
       AP@0.75: 0.825
       AR: 0.805
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/augmentation/hrnet_w32_coco_256x192_photometric-308cf591_20210320.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_coco.yml
@@ -1,70 +1,70 @@
 Collections:
-- Name: hrnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_coco.md
+  Name: hrnet_coco
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192.py
   In Collection: hrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.746
       AP@0.5: 0.904
       AP@0.75: 0.819
       AR: 0.799
       AR@0.5: 0.942
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_256x192-c78dce93_20200708.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_384x288.py
   In Collection: hrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.76
       AP@0.5: 0.906
       AP@0.75: 0.829
       AR: 0.81
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_384x288-d9f0d786_20200708.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192.py
   In Collection: hrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.756
       AP@0.5: 0.907
       AP@0.75: 0.825
       AR: 0.806
       AR@0.5: 0.942
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_256x192-b9e0b3ab_20200708.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_384x288.py
   In Collection: hrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.767
       AP@0.5: 0.91
       AP@0.75: 0.831
       AR: 0.816
       AR@0.5: 0.946
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_384x288-314c8528_20200708.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_dark_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_dark_coco.yml
@@ -1,72 +1,72 @@
 Collections:
-- Name: hrnet_dark_coco
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
     - DarkPose
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_dark_coco.md
+  Name: hrnet_dark_coco
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_dark_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_dark.py
   In Collection: hrnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.757
       AP@0.5: 0.907
       AP@0.75: 0.823
       AR: 0.808
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_256x192_dark-07f147eb_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_384x288_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_384x288_dark.py
   In Collection: hrnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_384x288_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_384x288_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.766
       AP@0.5: 0.907
       AP@0.75: 0.831
       AR: 0.815
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_384x288_dark-307dafc2_20210203.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_256x192_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192_dark.py
   In Collection: hrnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_256x192_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.764
       AP@0.5: 0.907
       AP@0.75: 0.83
       AR: 0.814
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_256x192_dark-8cba3197_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_384x288_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_384x288_dark.py
   In Collection: hrnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_384x288_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_384x288_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.772
       AP@0.5: 0.91
       AP@0.75: 0.836
       AR: 0.82
       AR@0.5: 0.946
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_384x288_dark-e881a4b6_20210203.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_fp16_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_fp16_coco.yml
@@ -1,26 +1,26 @@
 Collections:
-- Name: hrnet_fp16_coco
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_fp16_coco.md
+  Name: hrnet_fp16_coco
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://arxiv.org/abs/1710.03740
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_fp16_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_fp16_dynamic
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_fp16_dynamic.py
   In Collection: hrnet_fp16_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_fp16_dynamic.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_fp16_dynamic
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.746
       AP@0.5: 0.905
       AP@0.75: 0.88
       AR: 0.8
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: hrnet_w32_coco_256x192_fp16_dynamic-290efc2e_20210430.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_udp_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_udp_coco.yml
@@ -1,87 +1,87 @@
 Collections:
-- Name: hrnet_udp_coco
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
     - UDP
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_udp_coco.md
+  Name: hrnet_udp_coco
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Huang_The_Devil_Is_in_the_Details_Delving_Into_Unbiased_Data_CVPR_2020_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_udp_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_udp
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_udp.py
   In Collection: hrnet_udp_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_udp.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_udp
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.76
       AP@0.5: 0.907
       AP@0.75: 0.827
       AR: 0.811
       AR@0.5: 0.945
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/udp/hrnet_w32_coco_256x192_udp-aba0be42_20210220.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_384x288_udp
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_384x288_udp.py
   In Collection: hrnet_udp_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_384x288_udp.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_384x288_udp
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.769
       AP@0.5: 0.908
       AP@0.75: 0.833
       AR: 0.817
       AR@0.5: 0.944
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/udp/hrnet_w32_coco_384x288_udp-e97c1a0f_20210223.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_256x192_udp
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192_udp.py
   In Collection: hrnet_udp_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192_udp.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_256x192_udp
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.767
       AP@0.5: 0.906
       AP@0.75: 0.834
       AR: 0.817
       AR@0.5: 0.945
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/udp/hrnet_w48_coco_256x192_udp-2554c524_20210223.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_384x288_udp
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_384x288_udp.py
   In Collection: hrnet_udp_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_384x288_udp.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w48_coco_384x288_udp
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.772
       AP@0.5: 0.91
       AP@0.75: 0.835
       AR: 0.82
       AR@0.5: 0.945
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/udp/hrnet_w48_coco_384x288_udp-0f89c63e_20210223.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_udp_regress
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_udp_regress.py
   In Collection: hrnet_udp_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_udp_regress.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--hrnet_w32_coco_256x192_udp_regress
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.758
       AP@0.5: 0.908
       AP@0.75: 0.823
       AR: 0.812
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/udp/hrnet_w32_coco_256x192_udp_regress-be2dbba4_20210222.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_coco.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: litehrnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - LiteHRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_coco.md
+  Name: litehrnet_coco
   Paper:
   - https://arxiv.org/abs/2104.06403
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--litehrnet_30_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_30_coco_256x192.py
   In Collection: litehrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_30_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--litehrnet_30_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.675
       AP@0.5: 0.881
       AP@0.75: 0.754
       AR: 0.736
       AR@0.5: 0.924
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/litehrnet/litehrnet30_coco_256x192-4176555b_20210626.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--litehrnet_30_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_30_coco_384x288.py
   In Collection: litehrnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_30_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--litehrnet_30_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.7
       AP@0.5: 0.884
       AP@0.75: 0.776
       AR: 0.758
       AR@0.5: 0.928
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/litehrnet/litehrnet30_coco_384x288-a3aef5c4_20210626.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mobilenetv2_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mobilenetv2_coco.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: mobilenetv2_coco
-  Metadata:
+- Metadata:
     Architecture:
     - MobilenetV2
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mobilenetv2_coco.md
+  Name: mobilenetv2_coco
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Sandler_MobileNetV2_Inverted_Residuals_CVPR_2018_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mobilenetv2_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--mobilenetv2_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mobilenetv2_coco_256x192.py
   In Collection: mobilenetv2_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mobilenetv2_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--mobilenetv2_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.646
       AP@0.5: 0.874
       AP@0.75: 0.723
       AR: 0.707
       AR@0.5: 0.917
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/mobilenetv2/mobilenetv2_coco_256x192-d1e58e7b_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--mobilenetv2_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mobilenetv2_coco_384x288.py
   In Collection: mobilenetv2_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mobilenetv2_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--mobilenetv2_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.673
       AP@0.5: 0.879
       AP@0.75: 0.743
       AR: 0.729
       AR@0.5: 0.916
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/mobilenetv2/mobilenetv2_coco_384x288-26be4816_20200727.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mspn_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mspn_coco.yml
@@ -1,70 +1,70 @@
 Collections:
-- Name: mspn_coco
-  Metadata:
+- Metadata:
     Architecture:
     - MSPN
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mspn_coco.md
+  Name: mspn_coco
   Paper:
   - https://arxiv.org/abs/1901.00148
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mspn_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--mspn50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mspn50_coco_256x192.py
   In Collection: mspn_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mspn50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--mspn50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.723
       AP@0.5: 0.895
       AP@0.75: 0.794
       AR: 0.788
       AR@0.5: 0.933
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/mspn/mspn50_coco_256x192-8fbfb5d0_20201123.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--2xmspn50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/2xmspn50_coco_256x192.py
   In Collection: mspn_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/2xmspn50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--2xmspn50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.754
       AP@0.5: 0.903
       AP@0.75: 0.825
       AR: 0.815
       AR@0.5: 0.941
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/mspn/2xmspn50_coco_256x192-c8765a5c_20201123.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--3xmspn50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/3xmspn50_coco_256x192.py
   In Collection: mspn_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/3xmspn50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--3xmspn50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.758
       AP@0.5: 0.904
       AP@0.75: 0.83
       AR: 0.821
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/mspn/3xmspn50_coco_256x192-e348f18e_20201123.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--4xmspn50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/4xmspn50_coco_256x192.py
   In Collection: mspn_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/4xmspn50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--4xmspn50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.764
       AP@0.5: 0.906
       AP@0.75: 0.835
       AR: 0.826
       AR@0.5: 0.944
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/mspn/4xmspn50_coco_256x192-7b837afb_20201123.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest_coco.yml
@@ -1,130 +1,130 @@
 Collections:
-- Name: resnest_coco
-  Metadata:
+- Metadata:
     Architecture:
     - ResNeSt
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest_coco.md
+  Name: resnest_coco
   Paper:
   - https://arxiv.org/abs/2004.08955
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest50_coco_256x192.py
   In Collection: resnest_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.721
       AP@0.5: 0.899
       AP@0.75: 0.802
       AR: 0.776
       AR@0.5: 0.938
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnest/resnest50_coco_256x192-6e65eece_20210320.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest50_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest50_coco_384x288.py
   In Collection: resnest_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest50_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest50_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.737
       AP@0.5: 0.9
       AP@0.75: 0.811
       AR: 0.789
       AR@0.5: 0.938
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnest/resnest50_coco_384x288-dcd20436_20210320.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest101_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest101_coco_256x192.py
   In Collection: resnest_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest101_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest101_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.725
       AP@0.5: 0.899
       AP@0.75: 0.807
       AR: 0.781
       AR@0.5: 0.939
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnest/resnest101_coco_256x192-2ffcdc9d_20210320.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest101_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest101_coco_384x288.py
   In Collection: resnest_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest101_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest101_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.746
       AP@0.5: 0.906
       AP@0.75: 0.82
       AR: 0.798
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnest/resnest101_coco_384x288-80660658_20210320.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest200_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest200_coco_256x192.py
   In Collection: resnest_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest200_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest200_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.732
       AP@0.5: 0.905
       AP@0.75: 0.812
       AR: 0.787
       AR@0.5: 0.942
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnest/resnest200_coco_256x192-db007a48_20210517.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest200_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest200_coco_384x288.py
   In Collection: resnest_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest200_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest200_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.754
       AP@0.5: 0.908
       AP@0.75: 0.827
       AR: 0.807
       AR@0.5: 0.945
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnest/resnest200_coco_384x288-b5bb76cb_20210517.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest269_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest269_coco_256x192.py
   In Collection: resnest_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest269_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest269_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.738
       AP@0.5: 0.907
       AP@0.75: 0.819
       AR: 0.793
       AR@0.5: 0.945
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnest/resnest269_coco_256x192-2a7882ac_20210517.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest269_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest269_coco_384x288.py
   In Collection: resnest_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnest269_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnest269_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.755
       AP@0.5: 0.908
       AP@0.75: 0.828
       AR: 0.806
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnest/resnest269_coco_384x288-b142b9fb_20210517.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_coco.yml
@@ -1,102 +1,102 @@
 Collections:
-- Name: resnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_coco.md
+  Name: resnet_coco
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_256x192.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.718
       AP@0.5: 0.898
       AP@0.75: 0.795
       AR: 0.773
       AR@0.5: 0.937
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_coco_256x192-ec54d7f3_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_384x288.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.731
       AP@0.5: 0.9
       AP@0.75: 0.799
       AR: 0.783
       AR@0.5: 0.931
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_coco_384x288-e6f795e9_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_256x192.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.726
       AP@0.5: 0.899
       AP@0.75: 0.806
       AR: 0.781
       AR@0.5: 0.939
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_coco_256x192-6e6babf0_20200708.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_384x288.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.748
       AP@0.5: 0.905
       AP@0.75: 0.817
       AR: 0.798
       AR@0.5: 0.94
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_coco_384x288-8c71bdc9_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_256x192.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.735
       AP@0.5: 0.905
       AP@0.75: 0.812
       AR: 0.79
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_coco_256x192-f6e307c2_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_384x288.py
   In Collection: resnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.75
       AP@0.5: 0.908
       AP@0.75: 0.821
       AR: 0.8
       AR@0.5: 0.942
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_coco_384x288-3860d4c9_20200709.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_dark_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_dark_coco.yml
@@ -1,104 +1,104 @@
 Collections:
-- Name: resnet_dark_coco
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
     - DarkPose
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_dark_coco.md
+  Name: resnet_dark_coco
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_dark_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_256x192_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_256x192_dark.py
   In Collection: resnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_256x192_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_256x192_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.724
       AP@0.5: 0.898
       AP@0.75: 0.8
       AR: 0.777
       AR@0.5: 0.936
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_coco_256x192_dark-43379d20_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_384x288_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_384x288_dark.py
   In Collection: resnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_384x288_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_384x288_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.735
       AP@0.5: 0.9
       AP@0.75: 0.801
       AR: 0.785
       AR@0.5: 0.937
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_coco_384x288_dark-33d3e5e5_20210203.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_256x192_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_256x192_dark.py
   In Collection: resnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_256x192_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_256x192_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.732
       AP@0.5: 0.899
       AP@0.75: 0.808
       AR: 0.786
       AR@0.5: 0.938
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_coco_256x192_dark-64d433e6_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_384x288_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_384x288_dark.py
   In Collection: resnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_384x288_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_384x288_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.749
       AP@0.5: 0.902
       AP@0.75: 0.816
       AR: 0.799
       AR@0.5: 0.939
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_coco_384x288_dark-cb45c88d_20210203.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_256x192_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_256x192_dark.py
   In Collection: resnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_256x192_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_256x192_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.745
       AP@0.5: 0.905
       AP@0.75: 0.821
       AR: 0.797
       AR@0.5: 0.942
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_coco_256x192_dark-ab4840d5_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_384x288_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_384x288_dark.py
   In Collection: resnet_dark_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_384x288_dark.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_384x288_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.757
       AP@0.5: 0.909
       AP@0.75: 0.826
       AR: 0.806
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_coco_384x288_dark-d3b8ebd7_20210203.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_fp16_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_fp16_coco.yml
@@ -1,28 +1,28 @@
 Collections:
-- Name: resnet_fp16_coco
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_fp16_coco.md
+  Name: resnet_fp16_coco
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://arxiv.org/abs/1710.03740
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnet_fp16_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_256x192_fp16_dynamic
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_256x192_fp16_dynamic.py
   In Collection: resnet_fp16_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_256x192_fp16_dynamic.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_256x192_fp16_dynamic
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.717
       AP@0.5: 0.898
       AP@0.75: 0.793
       AR: 0.772
       AR@0.5: 0.936
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_coco_256x192_fp16_dynamic-6edb79f3_20210430.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d_coco.yml
@@ -1,100 +1,100 @@
 Collections:
-- Name: resnetv1d_coco
-  Metadata:
+- Metadata:
     Architecture:
     - ResNetV1D
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d_coco.md
+  Name: resnetv1d_coco
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/He_Bag_of_Tricks_for_Image_Classification_with_Convolutional_Neural_Networks_CVPR_2019_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d50_coco_256x192.py
   In Collection: resnetv1d_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.722
       AP@0.5: 0.897
       AP@0.75: 0.799
       AR: 0.777
       AR@0.5: 0.933
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnetv1d/resnetv1d50_coco_256x192-a243b840_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d50_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d50_coco_384x288.py
   In Collection: resnetv1d_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d50_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d50_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.73
       AP@0.5: 0.9
       AP@0.75: 0.799
       AR: 0.78
       AR@0.5: 0.934
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnetv1d/resnetv1d50_coco_384x288-01f3fbb9_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d101_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d101_coco_256x192.py
   In Collection: resnetv1d_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d101_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d101_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.731
       AP@0.5: 0.899
       AP@0.75: 0.809
       AR: 0.786
       AR@0.5: 0.938
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnetv1d/resnetv1d101_coco_256x192-5bd08cab_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d101_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d101_coco_384x288.py
   In Collection: resnetv1d_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d101_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d101_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.748
       AP@0.5: 0.902
       AP@0.75: 0.816
       AR: 0.799
       AR@0.5: 0.939
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnetv1d/resnetv1d101_coco_384x288-5f9e421d_20200730.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d152_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d152_coco_256x192.py
   In Collection: resnetv1d_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d152_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d152_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.737
       AP@0.5: 0.902
       AP@0.75: 0.812
       AR: 0.791
       AR@0.5: 0.94
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnetv1d/resnetv1d152_coco_256x192-c4df51dc_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d152_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d152_coco_384x288.py
   In Collection: resnetv1d_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnetv1d152_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnetv1d152_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.752
       AP@0.5: 0.909
       AP@0.75: 0.821
       AR: 0.802
       AR@0.5: 0.944
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnetv1d/resnetv1d152_coco_384x288-626c622d_20200730.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext_coco.yml
@@ -1,100 +1,100 @@
 Collections:
-- Name: resnext_coco
-  Metadata:
+- Metadata:
     Architecture:
     - ResNext
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext_coco.md
+  Name: resnext_coco
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2017/html/Xie_Aggregated_Residual_Transformations_CVPR_2017_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext50_coco_256x192.py
   In Collection: resnext_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.714
       AP@0.5: 0.898
       AP@0.75: 0.789
       AR: 0.771
       AR@0.5: 0.937
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnext/resnext50_coco_256x192-dcff15f6_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext50_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext50_coco_384x288.py
   In Collection: resnext_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext50_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext50_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.724
       AP@0.5: 0.899
       AP@0.75: 0.794
       AR: 0.777
       AR@0.5: 0.935
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnext/resnext50_coco_384x288-412c848f_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext101_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext101_coco_256x192.py
   In Collection: resnext_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext101_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext101_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.726
       AP@0.5: 0.9
       AP@0.75: 0.801
       AR: 0.782
       AR@0.5: 0.94
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnext/resnext101_coco_256x192-c7eba365_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext101_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext101_coco_384x288.py
   In Collection: resnext_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext101_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext101_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.743
       AP@0.5: 0.903
       AP@0.75: 0.815
       AR: 0.795
       AR@0.5: 0.939
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnext/resnext101_coco_384x288-f5eabcd6_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext152_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext152_coco_256x192.py
   In Collection: resnext_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext152_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext152_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.73
       AP@0.5: 0.904
       AP@0.75: 0.808
       AR: 0.786
       AR@0.5: 0.94
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnext/resnext152_coco_256x192-102449aa_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext152_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext152_coco_384x288.py
   In Collection: resnext_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/resnext152_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--resnext152_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.742
       AP@0.5: 0.902
       AP@0.75: 0.81
       AR: 0.794
       AR@0.5: 0.939
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnext/resnext152_coco_384x288-806176df_20200727.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/rsn_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/rsn_coco.yml
@@ -1,70 +1,70 @@
 Collections:
-- Name: rsn_coco
-  Metadata:
+- Metadata:
     Architecture:
     - RSN
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/rsn_coco.md
+  Name: rsn_coco
   Paper:
   - https://link.springer.com/chapter/10.1007/978-3-030-58580-8_27
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/rsn_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--rsn18_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/rsn18_coco_256x192.py
   In Collection: rsn_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/rsn18_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--rsn18_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.704
       AP@0.5: 0.887
       AP@0.75: 0.779
       AR: 0.771
       AR@0.5: 0.926
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/rsn/rsn18_coco_256x192-72f4b4a7_20201127.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--rsn50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/rsn50_coco_256x192.py
   In Collection: rsn_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/rsn50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--rsn50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.723
       AP@0.5: 0.896
       AP@0.75: 0.8
       AR: 0.788
       AR@0.5: 0.934
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/rsn/rsn50_coco_256x192-72ffe709_20201127.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--2xrsn50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/2xrsn50_coco_256x192.py
   In Collection: rsn_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/2xrsn50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--2xrsn50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.745
       AP@0.5: 0.899
       AP@0.75: 0.818
       AR: 0.809
       AR@0.5: 0.939
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/rsn/2xrsn50_coco_256x192-50648f0e_20201127.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--3xrsn50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/3xrsn50_coco_256x192.py
   In Collection: rsn_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/3xrsn50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--3xrsn50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.75
       AP@0.5: 0.9
       AP@0.75: 0.823
       AR: 0.813
       AR@0.5: 0.94
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/rsn/3xrsn50_coco_256x192-58f57a68_20201127.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet_coco.yml
@@ -1,70 +1,70 @@
 Collections:
-- Name: scnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - SCNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet_coco.md
+  Name: scnet_coco
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Liu_Improving_Convolutional_Networks_With_Self-Calibrated_Convolutions_CVPR_2020_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--scnet50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet50_coco_256x192.py
   In Collection: scnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--scnet50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.728
       AP@0.5: 0.899
       AP@0.75: 0.807
       AR: 0.784
       AR@0.5: 0.938
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/scnet/scnet50_coco_256x192-6920f829_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--scnet50_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet50_coco_384x288.py
   In Collection: scnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet50_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--scnet50_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.751
       AP@0.5: 0.906
       AP@0.75: 0.818
       AR: 0.802
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/scnet/scnet50_coco_384x288-9cacd0ea_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--scnet101_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet101_coco_256x192.py
   In Collection: scnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet101_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--scnet101_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.733
       AP@0.5: 0.903
       AP@0.75: 0.813
       AR: 0.79
       AR@0.5: 0.941
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/scnet/scnet101_coco_256x192-6d348ef9_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--scnet101_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet101_coco_384x288.py
   In Collection: scnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/scnet101_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--scnet101_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.752
       AP@0.5: 0.906
       AP@0.75: 0.823
       AR: 0.804
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/scnet/scnet101_coco_384x288-0b6e631b_20200709.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet_coco.yml
@@ -1,100 +1,100 @@
 Collections:
-- Name: seresnet_coco
-  Metadata:
+- Metadata:
     Architecture:
     - SEResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet_coco.md
+  Name: seresnet_coco
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Hu_Squeeze-and-Excitation_Networks_CVPR_2018_paper
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet50_coco_256x192.py
   In Collection: seresnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.728
       AP@0.5: 0.9
       AP@0.75: 0.809
       AR: 0.784
       AR@0.5: 0.94
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/seresnet/seresnet50_coco_256x192-25058b66_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet50_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet50_coco_384x288.py
   In Collection: seresnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet50_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet50_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.748
       AP@0.5: 0.905
       AP@0.75: 0.819
       AR: 0.799
       AR@0.5: 0.941
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/seresnet/seresnet50_coco_384x288-bc0b7680_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet101_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet101_coco_256x192.py
   In Collection: seresnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet101_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet101_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.734
       AP@0.5: 0.904
       AP@0.75: 0.815
       AR: 0.79
       AR@0.5: 0.942
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/seresnet/seresnet101_coco_256x192-83f29c4d_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet101_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet101_coco_384x288.py
   In Collection: seresnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet101_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet101_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.753
       AP@0.5: 0.907
       AP@0.75: 0.823
       AR: 0.805
       AR@0.5: 0.943
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/seresnet/seresnet101_coco_384x288-48de1709_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet152_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet152_coco_256x192.py
   In Collection: seresnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet152_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet152_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.73
       AP@0.5: 0.899
       AP@0.75: 0.81
       AR: 0.786
       AR@0.5: 0.94
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/seresnet/seresnet152_coco_256x192-1c628d79_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet152_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet152_coco_384x288.py
   In Collection: seresnet_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/seresnet152_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--seresnet152_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.753
       AP@0.5: 0.906
       AP@0.75: 0.823
       AR: 0.806
       AR@0.5: 0.945
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/seresnet/seresnet152_coco_384x288-58b23ee8_20200727.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv1_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv1_coco.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: shufflenetv1_coco
-  Metadata:
+- Metadata:
     Architecture:
     - ShufflenetV1
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv1_coco.md
+  Name: shufflenetv1_coco
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Zhang_ShuffleNet_An_Extremely_CVPR_2018_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv1_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--shufflenetv1_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv1_coco_256x192.py
   In Collection: shufflenetv1_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv1_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--shufflenetv1_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.585
       AP@0.5: 0.845
       AP@0.75: 0.65
       AR: 0.651
       AR@0.5: 0.894
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/shufflenetv1/shufflenetv1_coco_256x192-353bc02c_20200727.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--shufflenetv1_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv1_coco_384x288.py
   In Collection: shufflenetv1_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv1_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--shufflenetv1_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.622
       AP@0.5: 0.859
       AP@0.75: 0.685
       AR: 0.684
       AR@0.5: 0.901
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/shufflenetv1/shufflenetv1_coco_384x288-b2930b24_20200804.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv2_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv2_coco.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: shufflenetv2_coco
-  Metadata:
+- Metadata:
     Architecture:
     - ShufflenetV2
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv2_coco.md
+  Name: shufflenetv2_coco
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Ningning_Light-weight_CNN_Architecture_ECCV_2018_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv2_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--shufflenetv2_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv2_coco_256x192.py
   In Collection: shufflenetv2_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv2_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--shufflenetv2_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.599
       AP@0.5: 0.854
       AP@0.75: 0.663
       AR: 0.664
       AR@0.5: 0.899
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/shufflenetv2/shufflenetv2_coco_256x192-0aba71c7_20200921.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--shufflenetv2_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv2_coco_384x288.py
   In Collection: shufflenetv2_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/shufflenetv2_coco_384x288.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--shufflenetv2_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.636
       AP@0.5: 0.865
       AP@0.75: 0.705
       AR: 0.697
       AR@0.5: 0.909
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/shufflenetv2/shufflenetv2_coco_384x288-fb38ac3a_20200921.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vgg_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vgg_coco.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: vgg_coco
-  Metadata:
+- Metadata:
     Architecture:
     - VGG
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vgg_coco.md
+  Name: vgg_coco
   Paper:
   - https://arxiv.org/abs/1409.1556
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vgg_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--vgg16_bn_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vgg16_bn_coco_256x192.py
   In Collection: vgg_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vgg16_bn_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--vgg16_bn_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.698
       AP@0.5: 0.89
       AP@0.75: 0.768
       AR: 0.754
       AR@0.5: 0.929
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/vgg/vgg16_bn_coco_256x192-7e7c58d6_20210517.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_coco.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_coco.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: vipnas_coco
-  Metadata:
+- Metadata:
     Architecture:
     - ViPNAS
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_coco.md
+  Name: vipnas_coco
   Paper:
   - https://arxiv.org/abs/2105.10154
   - https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_coco.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--s_vipnas_res50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/s_vipnas_res50_coco_256x192.py
   In Collection: vipnas_coco
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/s_vipnas_res50_coco_256x192.py
   Metadata:
     Training Data: COCO
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--s_vipnas_res50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: COCO
+  - Dataset: COCO
     Metrics:
       AP: 0.711
       AP@0.5: 0.893
       AP@0.75: 0.789
       AR: 0.769
       AR@0.5: 0.769
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/vipnas/vipnas_res50_coco_256x192-cc43b466_20210624.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/hrnet_crowdpose.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/hrnet_crowdpose.yml
@@ -1,26 +1,26 @@
 Collections:
-- Name: hrnet_crowdpose
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/hrnet_crowdpose.md
+  Name: hrnet_crowdpose
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Li_CrowdPose_Efficient_Crowded_Scenes_Pose_Estimation_and_a_New_Benchmark_CVPR_2019_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/hrnet_crowdpose.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--hrnet_w32_crowdpose_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/hrnet_w32_crowdpose_256x192.py
   In Collection: hrnet_crowdpose
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/hrnet_w32_crowdpose_256x192.py
   Metadata:
     Training Data: CrowdPose
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--hrnet_w32_crowdpose_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: CrowdPose
+  - Dataset: CrowdPose
     Metrics:
       AP: 0.675
+      AP (E): 0.77
+      AP (H): 0.553
+      AP (M): 0.687
       AP@0.5: 0.825
       AP@0.75: 0.729
-      AP (E): 0.77
-      AP (M): 0.687
-      AP (H): 0.553
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_crowdpose_256x192-960be101_20201227.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/resnet_crowdpose.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/resnet_crowdpose.yml
@@ -1,76 +1,76 @@
 Collections:
-- Name: resnet_crowdpose
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/resnet_crowdpose.md
+  Name: resnet_crowdpose
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Li_CrowdPose_Efficient_Crowded_Scenes_Pose_Estimation_and_a_New_Benchmark_CVPR_2019_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/resnet_crowdpose.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--res50_crowdpose_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/res50_crowdpose_256x192.py
   In Collection: resnet_crowdpose
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/res50_crowdpose_256x192.py
   Metadata:
     Training Data: CrowdPose
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--res50_crowdpose_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: CrowdPose
+  - Dataset: CrowdPose
     Metrics:
       AP: 0.637
+      AP (E): 0.739
+      AP (H): 0.506
+      AP (M): 0.65
       AP@0.5: 0.808
       AP@0.75: 0.692
-      AP (E): 0.739
-      AP (M): 0.65
-      AP (H): 0.506
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_crowdpose_256x192-c6a526b6_20201227.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--res101_crowdpose_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/res101_crowdpose_256x192.py
   In Collection: resnet_crowdpose
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/res101_crowdpose_256x192.py
   Metadata:
     Training Data: CrowdPose
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--res101_crowdpose_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: CrowdPose
+  - Dataset: CrowdPose
     Metrics:
       AP: 0.647
+      AP (E): 0.744
+      AP (H): 0.522
+      AP (M): 0.658
       AP@0.5: 0.81
       AP@0.75: 0.703
-      AP (E): 0.744
-      AP (M): 0.658
-      AP (H): 0.522
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_crowdpose_256x192-8f5870f4_20201227.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--res101_crowdpose_320x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/res101_crowdpose_320x256.py
   In Collection: resnet_crowdpose
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/res101_crowdpose_320x256.py
   Metadata:
     Training Data: CrowdPose
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--res101_crowdpose_320x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: CrowdPose
+  - Dataset: CrowdPose
     Metrics:
       AP: 0.661
+      AP (E): 0.759
+      AP (H): 0.536
+      AP (M): 0.671
       AP@0.5: 0.821
       AP@0.75: 0.714
-      AP (E): 0.759
-      AP (M): 0.671
-      AP (H): 0.536
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_crowdpose_320x256-c88c512a_20201227.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--res152_crowdpose_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/res152_crowdpose_256x192.py
   In Collection: resnet_crowdpose
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/crowdpose/res152_crowdpose_256x192.py
   Metadata:
     Training Data: CrowdPose
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--crowdpose--res152_crowdpose_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: CrowdPose
+  - Dataset: CrowdPose
     Metrics:
       AP: 0.656
+      AP (E): 0.754
+      AP (H): 0.532
+      AP (M): 0.666
       AP@0.5: 0.818
       AP@0.75: 0.712
-      AP (E): 0.754
-      AP (M): 0.666
-      AP (H): 0.532
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_crowdpose_256x192-dbd49aba_20201227.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/h36m/hrnet_h36m.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/h36m/hrnet_h36m.yml
@@ -1,34 +1,34 @@
 Collections:
-- Name: hrnet_h36m
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/h36m/hrnet_h36m.md
+  Name: hrnet_h36m
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://ieeexplore.ieee.org/abstract/document/6682899/
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/h36m/hrnet_h36m.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--h36m--hrnet_w32_h36m_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/h36m/hrnet_w32_h36m_256x256.py
   In Collection: hrnet_h36m
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/h36m/hrnet_w32_h36m_256x256.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--h36m--hrnet_w32_h36m_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       EPE: 9.43
       PCK: 0.911
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_h36m_256x256-d3206675_20210621.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--h36m--hrnet_w48_h36m_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/h36m/hrnet_w48_h36m_256x256.py
   In Collection: hrnet_h36m
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/h36m/hrnet_w48_h36m_256x256.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--h36m--hrnet_w48_h36m_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       EPE: 7.36
       PCK: 0.932
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_h36m_256x256-78e88d08_20210621.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb.yml
@@ -1,118 +1,118 @@
 Collections:
-- Name: cpm_jhmdb
-  Metadata:
+- Metadata:
     Architecture:
     - CPM
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb.md
+  Name: cpm_jhmdb
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2016/html/Wei_Convolutional_Pose_Machines_CVPR_2016_paper.html
   - https://www.cv-foundation.org/openaccess/content_iccv_2013/html/Jhuang_Towards_Understanding_Action_2013_ICCV_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub1_368x368
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub1_368x368.py
   In Collection: cpm_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub1_368x368.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub1_368x368
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 96.1
-      Sho: 91.9
+      Ank: 87.3
       Elb: 81.0
-      Wri: 78.9
+      Head: 96.1
       Hip: 96.6
       Knee: 90.8
-      Ank: 87.3
       Mean: 89.5
+      Sho: 91.9
+      Wri: 78.9
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/cpm/cpm_jhmdb_sub1_368x368-2d2585c9_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub2_368x368
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub2_368x368.py
   In Collection: cpm_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub2_368x368.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub2_368x368
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 98.1
-      Sho: 93.6
+      Ank: 84.7
       Elb: 77.1
-      Wri: 70.9
+      Head: 98.1
       Hip: 94.0
       Knee: 89.1
-      Ank: 84.7
       Mean: 87.4
+      Sho: 93.6
+      Wri: 70.9
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/cpm/cpm_jhmdb_sub2_368x368-fc742f1f_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub3_368x368
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub3_368x368.py
   In Collection: cpm_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub3_368x368.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub3_368x368
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 97.9
-      Sho: 94.9
+      Ank: 86.2
       Elb: 87.3
-      Wri: 84.0
+      Head: 97.9
       Hip: 98.6
       Knee: 94.4
-      Ank: 86.2
       Mean: 92.4
+      Sho: 94.9
+      Wri: 84.0
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/cpm/cpm_jhmdb_sub3_368x368-49337155_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub1_368x368
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub1_368x368.py
   In Collection: cpm_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub1_368x368.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub1_368x368
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 89.0
-      Sho: 63.0
+      Ank: 61.2
       Elb: 54.0
-      Wri: 54.9
+      Head: 89.0
       Hip: 68.2
       Knee: 63.1
-      Ank: 61.2
       Mean: 66.0
+      Sho: 63.0
+      Wri: 54.9
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/cpm/cpm_jhmdb_sub1_368x368-2d2585c9_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub2_368x368
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub2_368x368.py
   In Collection: cpm_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub2_368x368.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub2_368x368
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 90.3
-      Sho: 57.9
+      Ank: 62.4
       Elb: 46.8
-      Wri: 44.3
+      Head: 90.3
       Hip: 60.8
       Knee: 58.2
-      Ank: 62.4
       Mean: 61.1
+      Sho: 57.9
+      Wri: 44.3
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/cpm/cpm_jhmdb_sub2_368x368-fc742f1f_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub3_368x368
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub3_368x368.py
   In Collection: cpm_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/cpm_jhmdb_sub3_368x368.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--cpm_jhmdb_sub3_368x368
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 91.0
-      Sho: 72.6
+      Ank: 65.8
       Elb: 59.9
-      Wri: 54.0
+      Head: 91.0
       Hip: 73.2
       Knee: 68.5
-      Ank: 65.8
       Mean: 70.3
+      Sho: 72.6
+      Wri: 54.0
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/cpm/cpm_jhmdb_sub3_368x368-49337155_20201122.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/resnet_jhmdb.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/resnet_jhmdb.yml
@@ -1,228 +1,228 @@
 Collections:
-- Name: resnet_jhmdb
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/resnet_jhmdb.md
+  Name: resnet_jhmdb
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://www.cv-foundation.org/openaccess/content_iccv_2013/html/Jhuang_Towards_Understanding_Action_2013_ICCV_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/resnet_jhmdb.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub1_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub1_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub1_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub1_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 99.1
-      Sho: 98.0
+      Ank: 92.8
       Elb: 93.8
-      Wri: 91.3
+      Head: 99.1
       Hip: 99.4
       Knee: 96.5
-      Ank: 92.8
       Mean: 96.1
+      Sho: 98.0
+      Wri: 91.3
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_jhmdb_sub1_256x256-932cb3b4_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub2_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub2_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub2_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub2_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 99.3
-      Sho: 97.1
+      Ank: 94.1
       Elb: 90.6
-      Wri: 87.0
+      Head: 99.3
       Hip: 98.9
       Knee: 96.3
-      Ank: 94.1
       Mean: 95.0
+      Sho: 97.1
+      Wri: 87.0
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_jhmdb_sub2_256x256-83d606f7_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub3_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub3_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub3_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub3_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 99.0
-      Sho: 97.9
+      Ank: 94.7
       Elb: 94.0
-      Wri: 91.6
+      Head: 99.0
       Hip: 99.7
       Knee: 98.0
-      Ank: 94.7
       Mean: 96.7
+      Sho: 97.9
+      Wri: 91.6
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_jhmdb_sub3_256x256-c4ec1a0b_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub1_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub1_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub1_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub1_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 99.1
-      Sho: 98.5
+      Ank: 92.5
       Elb: 94.6
-      Wri: 92.0
+      Head: 99.1
       Hip: 99.4
       Knee: 94.6
-      Ank: 92.5
       Mean: 96.1
+      Sho: 98.5
+      Wri: 92.0
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_2deconv_jhmdb_sub1_256x256-f0574a52_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub2_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub2_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub2_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub2_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 99.3
-      Sho: 97.8
+      Ank: 93.8
       Elb: 91.0
-      Wri: 87.0
+      Head: 99.3
       Hip: 99.1
       Knee: 96.5
-      Ank: 93.8
       Mean: 95.2
+      Sho: 97.8
+      Wri: 87.0
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_2deconv_jhmdb_sub2_256x256-f63af0ff_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub3_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub3_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub3_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub3_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 98.8
-      Sho: 98.4
+      Ank: 93.8
       Elb: 94.3
-      Wri: 92.1
+      Head: 98.8
       Hip: 99.8
       Knee: 97.5
-      Ank: 93.8
       Mean: 96.7
+      Sho: 98.4
+      Wri: 92.1
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_2deconv_jhmdb_sub3_256x256-c4bc2ddb_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub1_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub1_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub1_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub1_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 93.3
-      Sho: 83.2
+      Ank: 78.9
       Elb: 74.4
-      Wri: 72.7
+      Head: 93.3
       Hip: 85.0
       Knee: 81.2
-      Ank: 78.9
       Mean: 81.9
+      Sho: 83.2
+      Wri: 72.7
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_jhmdb_sub1_256x256-932cb3b4_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub2_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub2_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub2_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub2_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 94.1
-      Sho: 74.9
+      Ank: 78.6
       Elb: 64.5
-      Wri: 62.5
+      Head: 94.1
       Hip: 77.9
       Knee: 71.9
-      Ank: 78.6
       Mean: 75.5
+      Sho: 74.9
+      Wri: 62.5
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_jhmdb_sub2_256x256-83d606f7_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub3_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub3_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_jhmdb_sub3_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_jhmdb_sub3_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 97.0
-      Sho: 82.2
+      Ank: 84.2
       Elb: 74.9
-      Wri: 70.7
+      Head: 97.0
       Hip: 84.7
       Knee: 83.7
-      Ank: 84.2
       Mean: 82.9
+      Sho: 82.2
+      Wri: 70.7
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_jhmdb_sub3_256x256-c4ec1a0b_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub1_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub1_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub1_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub1_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 92.4
-      Sho: 80.6
+      Ank: 75.0
       Elb: 73.2
-      Wri: 70.5
+      Head: 92.4
       Hip: 82.3
       Knee: 75.4
-      Ank: 75.0
       Mean: 79.2
+      Sho: 80.6
+      Wri: 70.5
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_2deconv_jhmdb_sub1_256x256-f0574a52_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub2_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub2_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub2_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub2_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 93.4
-      Sho: 73.6
+      Ank: 75.5
       Elb: 63.8
-      Wri: 60.5
+      Head: 93.4
       Hip: 75.1
       Knee: 68.4
-      Ank: 75.5
       Mean: 73.7
+      Sho: 73.6
+      Wri: 60.5
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_2deconv_jhmdb_sub2_256x256-f63af0ff_20201122.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub3_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub3_256x256.py
   In Collection: resnet_jhmdb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/jhmdb/res50_2deconv_jhmdb_sub3_256x256.py
   Metadata:
     Training Data: JHMDB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--jhmdb--res50_2deconv_jhmdb_sub3_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: JHMDB
+  - Dataset: JHMDB
     Metrics:
-      Head: 96.1
-      Sho: 81.2
+      Ank: 81.5
       Elb: 72.6
-      Wri: 67.9
+      Head: 96.1
       Hip: 83.6
       Knee: 80.9
-      Ank: 81.5
       Mean: 81.2
+      Sho: 81.2
+      Wri: 67.9
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_2deconv_jhmdb_sub3_256x256-c4bc2ddb_20201122.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mhp/resnet_mhp.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mhp/resnet_mhp.yml
@@ -1,27 +1,27 @@
 Collections:
-- Name: resnet_mhp
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mhp/resnet_mhp.md
+  Name: resnet_mhp
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://dl.acm.org/doi/abs/10.1145/3240508.3240509
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mhp/resnet_mhp.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mhp--res50_mhp_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mhp/res50_mhp_256x192.py
   In Collection: resnet_mhp
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mhp/res50_mhp_256x192.py
   Metadata:
     Training Data: MHP
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mhp--res50_mhp_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MHP
+  - Dataset: MHP
     Metrics:
       AP: 0.583
       AP@0.5: 0.897
       AP@0.75: 0.669
       AR: 0.636
       AR@0.5: 0.918
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_mhp_256x192-28c5b818_20201229.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/cpm_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/cpm_mpii.yml
@@ -1,22 +1,22 @@
 Collections:
-- Name: cpm_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - CPM
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/cpm_mpii.md
+  Name: cpm_mpii
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2016/html/Wei_Convolutional_Pose_Machines_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/cpm_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--cpm_mpii_368x368
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/cpm_mpii_368x368.py
   In Collection: cpm_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/cpm_mpii_368x368.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--cpm_mpii_368x368
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.876
       Mean@0.1: 0.285
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/cpm/cpm_mpii_368x368-116e62b8_20200822.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hourglass_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hourglass_mpii.yml
@@ -1,34 +1,34 @@
 Collections:
-- Name: hourglass_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - Hourglass
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hourglass_mpii.md
+  Name: hourglass_mpii
   Paper:
   - https://link.springer.com/chapter/10.1007/978-3-319-46484-8_29
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hourglass_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hourglass52_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hourglass52_mpii_256x256.py
   In Collection: hourglass_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hourglass52_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hourglass52_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.889
       Mean@0.1: 0.317
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hourglass/hourglass52_mpii_256x256-ae358435_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hourglass52_mpii_384x384
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hourglass52_mpii_384x384.py
   In Collection: hourglass_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hourglass52_mpii_384x384.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hourglass52_mpii_384x384
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.894
       Mean@0.1: 0.366
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hourglass/hourglass52_mpii_384x384-04090bc3_20200812.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_dark_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_dark_mpii.yml
@@ -1,36 +1,36 @@
 Collections:
-- Name: hrnet_dark_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
     - DarkPose
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_dark_mpii.md
+  Name: hrnet_dark_mpii
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_dark_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hrnet_w32_mpii_256x256_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_w32_mpii_256x256_dark.py
   In Collection: hrnet_dark_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_w32_mpii_256x256_dark.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hrnet_w32_mpii_256x256_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.904
       Mean@0.1: 0.354
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_mpii_256x256_dark-f1601c5b_20200927.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hrnet_w48_mpii_256x256_dark
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_w48_mpii_256x256_dark.py
   In Collection: hrnet_dark_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_w48_mpii_256x256_dark.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hrnet_w48_mpii_256x256_dark
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.905
       Mean@0.1: 0.36
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_mpii_256x256_dark-0decd39f_20200927.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_mpii.yml
@@ -1,34 +1,34 @@
 Collections:
-- Name: hrnet_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_mpii.md
+  Name: hrnet_mpii
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hrnet_w32_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_w32_mpii_256x256.py
   In Collection: hrnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_w32_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hrnet_w32_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.9
       Mean@0.1: 0.334
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_mpii_256x256-6c4f923f_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hrnet_w48_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_w48_mpii_256x256.py
   In Collection: hrnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/hrnet_w48_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--hrnet_w48_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.901
       Mean@0.1: 0.337
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_mpii_256x256-92cab7bd_20200812.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/litehrnet_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/litehrnet_mpii.yml
@@ -1,34 +1,34 @@
 Collections:
-- Name: litehrnet_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - LiteHRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/litehrnet_mpii.md
+  Name: litehrnet_mpii
   Paper:
   - https://arxiv.org/abs/2104.06403
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/litehrnet_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--litehrnet_18_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/litehrnet_18_mpii_256x256.py
   In Collection: litehrnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/litehrnet_18_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--litehrnet_18_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.859
       Mean@0.1: 0.26
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/litehrnet/litehrnet18_mpii_256x256-cabd7984_20210623.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--litehrnet_30_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/litehrnet_30_mpii_256x256.py
   In Collection: litehrnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/litehrnet_30_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--litehrnet_30_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.869
       Mean@0.1: 0.271
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/litehrnet/litehrnet30_mpii_256x256-faae8bd8_20210622.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/mobilenetv2_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/mobilenetv2_mpii.yml
@@ -1,22 +1,22 @@
 Collections:
-- Name: mobilenetv2_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - MobilenetV2
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/mobilenetv2_mpii.md
+  Name: mobilenetv2_mpii
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Sandler_MobileNetV2_Inverted_Residuals_CVPR_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/mobilenetv2_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mobilenet_v2--mpii--mobilenet_v2_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mobilenet_v2/mpii/mobilenet_v2_mpii_256x256.py
   In Collection: mobilenetv2_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mobilenet_v2/mpii/mobilenet_v2_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mobilenet_v2--mpii--mobilenet_v2_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.854
       Mean@0.1: 0.235
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/mobilenetv2/mobilenetv2_mpii_256x256-e068afa7_20200812.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnet_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnet_mpii.yml
@@ -1,48 +1,48 @@
 Collections:
-- Name: resnet_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnet_mpii.md
+  Name: resnet_mpii
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnet_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--res50_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/res50_mpii_256x256.py
   In Collection: resnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/res50_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--res50_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.882
       Mean@0.1: 0.286
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_mpii_256x256-418ffc88_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--res101_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/res101_mpii_256x256.py
   In Collection: resnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/res101_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--res101_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.888
       Mean@0.1: 0.29
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_mpii_256x256-416f5d71_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--res152_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/res152_mpii_256x256.py
   In Collection: resnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/res152_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--res152_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.889
       Mean@0.1: 0.303
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_mpii_256x256-3ecba29d_20200812.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d_mpii.yml
@@ -1,46 +1,46 @@
 Collections:
-- Name: resnetv1d_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - ResNetV1D
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d_mpii.md
+  Name: resnetv1d_mpii
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/He_Bag_of_Tricks_for_Image_Classification_with_Convolutional_Neural_Networks_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--resnetv1d50_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d50_mpii_256x256.py
   In Collection: resnetv1d_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d50_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--resnetv1d50_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.881
       Mean@0.1: 0.29
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnetv1d/resnetv1d50_mpii_256x256-2337a92e_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--resnetv1d101_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d101_mpii_256x256.py
   In Collection: resnetv1d_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d101_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--resnetv1d101_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.883
       Mean@0.1: 0.295
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnetv1d/resnetv1d101_mpii_256x256-2851d710_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--resnetv1d152_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d152_mpii_256x256.py
   In Collection: resnetv1d_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnetv1d152_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--resnetv1d152_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.888
       Mean@0.1: 0.3
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnetv1d/resnetv1d152_mpii_256x256-8b10a87c_20200812.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnext_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnext_mpii.yml
@@ -1,22 +1,22 @@
 Collections:
-- Name: resnext_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - ResNext
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnext_mpii.md
+  Name: resnext_mpii
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2017/html/Xie_Aggregated_Residual_Transformations_CVPR_2017_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnext_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--resnext152_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnext152_mpii_256x256.py
   In Collection: resnext_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/resnext152_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--resnext152_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.887
       Mean@0.1: 0.294
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnext/resnext152_mpii_256x256-df302719_20200927.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/scnet_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/scnet_mpii.yml
@@ -1,34 +1,34 @@
 Collections:
-- Name: scnet_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - SCNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/scnet_mpii.md
+  Name: scnet_mpii
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Liu_Improving_Convolutional_Networks_With_Self-Calibrated_Convolutions_CVPR_2020_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/scnet_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--scnet50_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/scnet50_mpii_256x256.py
   In Collection: scnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/scnet50_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--scnet50_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.888
       Mean@0.1: 0.29
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/scnet/scnet50_mpii_256x256-a54b6af5_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--scnet101_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/scnet101_mpii_256x256.py
   In Collection: scnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/scnet101_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--scnet101_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.886
       Mean@0.1: 0.293
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/scnet/scnet101_mpii_256x256-b4c2d184_20200812.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet_mpii.yml
@@ -1,46 +1,46 @@
 Collections:
-- Name: seresnet_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - SEResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet_mpii.md
+  Name: seresnet_mpii
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Hu_Squeeze-and-Excitation_Networks_CVPR_2018_paper
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--seresnet50_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet50_mpii_256x256.py
   In Collection: seresnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet50_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--seresnet50_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.884
       Mean@0.1: 0.292
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/seresnet/seresnet50_mpii_256x256-1bb21f79_20200927.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--seresnet101_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet101_mpii_256x256.py
   In Collection: seresnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet101_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--seresnet101_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.884
       Mean@0.1: 0.295
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/seresnet/seresnet101_mpii_256x256-0ba14ff5_20200927.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--seresnet152_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet152_mpii_256x256.py
   In Collection: seresnet_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/seresnet152_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--seresnet152_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.884
       Mean@0.1: 0.287
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/seresnet/seresnet152_mpii_256x256-6ea1e774_20200927.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv1_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv1_mpii.yml
@@ -1,22 +1,22 @@
 Collections:
-- Name: shufflenetv1_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - ShufflenetV1
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv1_mpii.md
+  Name: shufflenetv1_mpii
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Zhang_ShuffleNet_An_Extremely_CVPR_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv1_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--shufflenetv1_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv1_mpii_256x256.py
   In Collection: shufflenetv1_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv1_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--shufflenetv1_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.823
       Mean@0.1: 0.195
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/shufflenetv1/shufflenetv1_mpii_256x256-dcc1c896_20200925.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv2_mpii.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv2_mpii.yml
@@ -1,22 +1,22 @@
 Collections:
-- Name: shufflenetv2_mpii
-  Metadata:
+- Metadata:
     Architecture:
     - ShufflenetV2
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv2_mpii.md
+  Name: shufflenetv2_mpii
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Ningning_Light-weight_CNN_Architecture_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Andriluka_2D_Human_Pose_2014_CVPR_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv2_mpii.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--shufflenetv2_mpii_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv2_mpii_256x256.py
   In Collection: shufflenetv2_mpii
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii/shufflenetv2_mpii_256x256.py
   Metadata:
     Training Data: MPII
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii--shufflenetv2_mpii_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII
+  - Dataset: MPII
     Metrics:
       Mean: 0.828
       Mean@0.1: 0.205
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/shufflenetv2/shufflenetv2_mpii_256x256-4fb9df2d_20200925.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/resnet_mpii_trb.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/resnet_mpii_trb.yml
@@ -1,51 +1,51 @@
 Collections:
-- Name: resnet_mpii_trb
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/resnet_mpii_trb.md
+  Name: resnet_mpii_trb
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_ICCV_2019/html/Duan_TRB_A_Novel_Triplet_Representation_for_Understanding_2D_Human_Body_ICCV_2019_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/resnet_mpii_trb.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii_trb--res50_mpii_trb_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/res50_mpii_trb_256x256.py
   In Collection: resnet_mpii_trb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/res50_mpii_trb_256x256.py
   Metadata:
     Training Data: MPII-TRB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii_trb--res50_mpii_trb_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII-TRB
+  - Dataset: MPII-TRB
     Metrics:
-      Skeleton Acc: 0.887
       Contour Acc: 0.858
       Mean Acc: 0.868
+      Skeleton Acc: 0.887
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_mpii_trb_256x256-896036b8_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii_trb--res101_mpii_trb_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/res101_mpii_trb_256x256.py
   In Collection: resnet_mpii_trb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/res101_mpii_trb_256x256.py
   Metadata:
     Training Data: MPII-TRB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii_trb--res101_mpii_trb_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII-TRB
+  - Dataset: MPII-TRB
     Metrics:
-      Skeleton Acc: 0.89
       Contour Acc: 0.863
       Mean Acc: 0.873
+      Skeleton Acc: 0.89
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_mpii_trb_256x256-cfad2f05_20200812.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii_trb--res152_mpii_trb_256x256
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/res152_mpii_trb_256x256.py
   In Collection: resnet_mpii_trb
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/mpii_trb/res152_mpii_trb_256x256.py
   Metadata:
     Training Data: MPII-TRB
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--mpii_trb--res152_mpii_trb_256x256
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: MPII-TRB
+  - Dataset: MPII-TRB
     Metrics:
-      Skeleton Acc: 0.897
       Contour Acc: 0.868
       Mean Acc: 0.879
+      Skeleton Acc: 0.897
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_mpii_trb_256x256-dd369ce6_20200812.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/ochuman/resnet_ochuman.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/ochuman/resnet_ochuman.yml
@@ -1,102 +1,102 @@
 Collections:
-- Name: resnet_ochuman
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/ochuman/resnet_ochuman.md
+  Name: resnet_ochuman
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Zhang_Pose2Seg_Detection_Free_Human_Instance_Segmentation_CVPR_2019_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/ochuman/resnet_ochuman.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_256x192.py
   In Collection: resnet_ochuman
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_256x192.py
   Metadata:
     Training Data: OCHuman
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: OCHuman
+  - Dataset: OCHuman
     Metrics:
       AP: 0.546
       AP@0.5: 0.726
       AP@0.75: 0.593
       AR: 0.592
       AR@0.5: 0.755
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_coco_256x192-ec54d7f3_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_384x288.py
   In Collection: resnet_ochuman
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res50_coco_384x288.py
   Metadata:
     Training Data: OCHuman
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res50_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: OCHuman
+  - Dataset: OCHuman
     Metrics:
       AP: 0.539
       AP@0.5: 0.723
       AP@0.75: 0.574
       AR: 0.588
       AR@0.5: 0.756
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_coco_384x288-e6f795e9_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_256x192.py
   In Collection: resnet_ochuman
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_256x192.py
   Metadata:
     Training Data: OCHuman
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: OCHuman
+  - Dataset: OCHuman
     Metrics:
       AP: 0.559
       AP@0.5: 0.724
       AP@0.75: 0.606
       AR: 0.605
       AR@0.5: 0.751
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_coco_256x192-6e6babf0_20200708.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_384x288.py
   In Collection: resnet_ochuman
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res101_coco_384x288.py
   Metadata:
     Training Data: OCHuman
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res101_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: OCHuman
+  - Dataset: OCHuman
     Metrics:
       AP: 0.571
       AP@0.5: 0.715
       AP@0.75: 0.615
       AR: 0.615
       AR@0.5: 0.748
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_coco_384x288-8c71bdc9_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_256x192.py
   In Collection: resnet_ochuman
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_256x192.py
   Metadata:
     Training Data: OCHuman
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: OCHuman
+  - Dataset: OCHuman
     Metrics:
       AP: 0.57
       AP@0.5: 0.725
       AP@0.75: 0.617
       AR: 0.616
       AR@0.5: 0.754
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_coco_256x192-f6e307c2_20200709.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_384x288
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_384x288.py
   In Collection: resnet_ochuman
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/res152_coco_384x288.py
   Metadata:
     Training Data: OCHuman
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--coco--res152_coco_384x288
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: OCHuman
+  - Dataset: OCHuman
     Metrics:
       AP: 0.582
       AP@0.5: 0.723
       AP@0.75: 0.627
       AR: 0.627
       AR@0.5: 0.752
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_coco_384x288-3860d4c9_20200709.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/hrnet_posetrack18.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/hrnet_posetrack18.yml
@@ -1,46 +1,46 @@
 Collections:
-- Name: hrnet_posetrack18
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/hrnet_posetrack18.md
+  Name: hrnet_posetrack18
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Andriluka_PoseTrack_A_Benchmark_CVPR_2018_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/hrnet_posetrack18.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--posetrack18--hrnet_w32_posetrack18_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/hrnet_w32_posetrack18_256x192.py
   In Collection: hrnet_posetrack18
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/hrnet_w32_posetrack18_256x192.py
   Metadata:
     Training Data: PoseTrack18
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--posetrack18--hrnet_w32_posetrack18_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: PoseTrack18
+  - Dataset: PoseTrack18
     Metrics:
-      Head: 87.4
-      Shou: 88.6
+      Ankl: 78.8
       Elb: 84.3
-      Wri: 78.5
+      Head: 87.4
       Hip: 79.7
       Knee: 81.8
-      Ankl: 78.8
+      Shou: 88.6
       Total: 83.0
+      Wri: 78.5
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_posetrack18_256x192-1ee951c4_20201028.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--posetrack18--hrnet_w32_posetrack18_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/hrnet_w32_posetrack18_256x192.py
   In Collection: hrnet_posetrack18
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/hrnet_w32_posetrack18_256x192.py
   Metadata:
     Training Data: PoseTrack18
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--posetrack18--hrnet_w32_posetrack18_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: PoseTrack18
+  - Dataset: PoseTrack18
     Metrics:
-      Head: 78.0
-      Shou: 82.9
+      Ankl: 70.2
       Elb: 79.5
-      Wri: 73.8
+      Head: 78.0
       Hip: 76.9
       Knee: 76.6
-      Ankl: 70.2
+      Shou: 82.9
       Total: 76.9
+      Wri: 73.8
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_posetrack18_256x192-1ee951c4_20201028.pth

--- a/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/resnet_posetrack18.yml
+++ b/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/resnet_posetrack18.yml
@@ -1,48 +1,48 @@
 Collections:
-- Name: resnet_posetrack18
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/resnet_posetrack18.md
+  Name: resnet_posetrack18
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Andriluka_PoseTrack_A_Benchmark_CVPR_2018_paper.html
+  README: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/resnet_posetrack18.md
 Models:
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--posetrack18--res50_posetrack18_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/res50_posetrack18_256x192.py
   In Collection: resnet_posetrack18
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/res50_posetrack18_256x192.py
   Metadata:
     Training Data: PoseTrack18
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--posetrack18--res50_posetrack18_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: PoseTrack18
+  - Dataset: PoseTrack18
     Metrics:
-      Head: 86.5
-      Shou: 87.5
+      Ankl: 74.0
       Elb: 82.3
-      Wri: 75.6
+      Head: 86.5
       Hip: 79.9
       Knee: 78.6
-      Ankl: 74.0
+      Shou: 87.5
       Total: 81.0
+      Wri: 75.6
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_posetrack18_256x192-a62807c7_20201028.pth
-- Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--posetrack18--res50_posetrack18_256x192
+- Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/res50_posetrack18_256x192.py
   In Collection: resnet_posetrack18
-  Config: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/posetrack18/res50_posetrack18_256x192.py
   Metadata:
     Training Data: PoseTrack18
+  Name: body--2d_kpt_sview_rgb_img--topdown_heatmap--posetrack18--res50_posetrack18_256x192
   Results:
-  - Task: Image-based Human Body 2D Pose Estimation
-    Dataset: PoseTrack18
+  - Dataset: PoseTrack18
     Metrics:
-      Head: 78.9
-      Shou: 81.9
+      Ankl: 66.4
       Elb: 77.8
-      Wri: 70.8
+      Head: 78.9
       Hip: 75.3
       Knee: 73.2
-      Ankl: 66.4
+      Shou: 81.9
       Total: 75.2
+      Wri: 70.8
+    Task: Image-based Human Body 2D Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_posetrack18_256x192-a62807c7_20201028.pth

--- a/configs/body/3d_kpt_sview_rgb_img/pose_lift/h36m/simplebaseline3d_h36m.yml
+++ b/configs/body/3d_kpt_sview_rgb_img/pose_lift/h36m/simplebaseline3d_h36m.yml
@@ -1,22 +1,22 @@
 Collections:
-- Name: simplebaseline3d_h36m
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline3D
-  README: configs/body/3d_kpt_sview_rgb_img/pose_lift/h36m/simplebaseline3d_h36m.md
+  Name: simplebaseline3d_h36m
   Paper:
   - http://openaccess.thecvf.com/content_iccv_2017/html/Martinez_A_Simple_yet_ICCV_2017_paper.html
   - https://ieeexplore.ieee.org/abstract/document/6682899/
+  README: configs/body/3d_kpt_sview_rgb_img/pose_lift/h36m/simplebaseline3d_h36m.md
 Models:
-- Name: body--3d_kpt_sview_rgb_img--pose_lift--h36m--simplebaseline3d_h36m
+- Config: configs/body/3d_kpt_sview_rgb_img/pose_lift/h36m/simplebaseline3d_h36m.py
   In Collection: simplebaseline3d_h36m
-  Config: configs/body/3d_kpt_sview_rgb_img/pose_lift/h36m/simplebaseline3d_h36m.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--3d_kpt_sview_rgb_img--pose_lift--h36m--simplebaseline3d_h36m
   Results:
-  - Task: Single-view 3D Human Body Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       MPJPE: 43.4
       P-MPJPE: 34.3
+    Task: Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/simple_baseline/simple3Dbaseline_h36m-f0ad73a4_20210419.pth

--- a/configs/body/3d_kpt_sview_rgb_img/pose_lift/mpi_inf_3dhp/simplebaseline3d_mpi-inf-3dhp.yml
+++ b/configs/body/3d_kpt_sview_rgb_img/pose_lift/mpi_inf_3dhp/simplebaseline3d_mpi-inf-3dhp.yml
@@ -1,24 +1,24 @@
 Collections:
-- Name: simplebaseline3d_mpi-inf-3dhp
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline3D
-  README: configs/body/3d_kpt_sview_rgb_img/pose_lift/mpi_inf_3dhp/simplebaseline3d_mpi-inf-3dhp.md
+  Name: simplebaseline3d_mpi-inf-3dhp
   Paper:
   - http://openaccess.thecvf.com/content_iccv_2017/html/Martinez_A_Simple_yet_ICCV_2017_paper.html
   - https://ieeexplore.ieee.org/abstract/document/8374605/
+  README: configs/body/3d_kpt_sview_rgb_img/pose_lift/mpi_inf_3dhp/simplebaseline3d_mpi-inf-3dhp.md
 Models:
-- Name: body--3d_kpt_sview_rgb_img--pose_lift--mpi_inf_3dhp--simplebaseline3d_mpi-inf-3dhp
+- Config: configs/body/3d_kpt_sview_rgb_img/pose_lift/mpi_inf_3dhp/simplebaseline3d_mpi-inf-3dhp.py
   In Collection: simplebaseline3d_mpi-inf-3dhp
-  Config: configs/body/3d_kpt_sview_rgb_img/pose_lift/mpi_inf_3dhp/simplebaseline3d_mpi-inf-3dhp.py
   Metadata:
     Training Data: MPI-INF-3DHP
+  Name: body--3d_kpt_sview_rgb_img--pose_lift--mpi_inf_3dhp--simplebaseline3d_mpi-inf-3dhp
   Results:
-  - Task: Single-view 3D Human Body Pose Estimation
-    Dataset: MPI-INF-3DHP
+  - Dataset: MPI-INF-3DHP
     Metrics:
+      3DAUC: 52.0
+      3DPCK: 85.0
       MPJPE: 84.3
       P-MPJPE: 53.2
-      3DPCK: 85.0
-      3DAUC: 52.0
+    Task: Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/simplebaseline3d/simplebaseline3d_mpi-inf-3dhp-b75546f6_20210603.pth

--- a/configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m.yml
+++ b/configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m.yml
@@ -1,96 +1,96 @@
 Collections:
-- Name: videopose3d_h36m
-  Metadata:
+- Metadata:
     Architecture:
     - VideoPose3D
-  README: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m.md
+  Name: videopose3d_h36m
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Pavllo_3D_Human_Pose_Estimation_in_Video_With_Temporal_Convolutions_and_CVPR_2019_paper.html
   - https://ieeexplore.ieee.org/abstract/document/6682899/
+  README: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m.md
 Models:
-- Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_27frames_fullconv_supervised
+- Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_27frames_fullconv_supervised.py
   In Collection: videopose3d_h36m
-  Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_27frames_fullconv_supervised.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_27frames_fullconv_supervised
   Results:
-  - Task: Video-based Single-view 3D Human Body Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       MPJPE: 40.0
       P-MPJPE: 30.1
+    Task: Video-based Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/videopose/videopose_h36m_27frames_fullconv_supervised-fe8fbba9_20210527.pth
-- Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_81frames_fullconv_supervised
+- Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_81frames_fullconv_supervised.py
   In Collection: videopose3d_h36m
-  Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_81frames_fullconv_supervised.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_81frames_fullconv_supervised
   Results:
-  - Task: Video-based Single-view 3D Human Body Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       MPJPE: 38.9
       P-MPJPE: 29.2
+    Task: Video-based Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/videopose/videopose_h36m_81frames_fullconv_supervised-1f2d1104_20210527.pth
-- Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_243frames_fullconv_supervised
+- Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_243frames_fullconv_supervised.py
   In Collection: videopose3d_h36m
-  Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_243frames_fullconv_supervised.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_243frames_fullconv_supervised
   Results:
-  - Task: Video-based Single-view 3D Human Body Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       MPJPE: 37.6
       P-MPJPE: 28.3
+    Task: Video-based Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/videopose/videopose_h36m_243frames_fullconv_supervised-880bea25_20210527.pth
-- Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_1frame_fullconv_supervised_cpn_ft
+- Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_1frame_fullconv_supervised_cpn_ft.py
   In Collection: videopose3d_h36m
-  Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_1frame_fullconv_supervised_cpn_ft.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_1frame_fullconv_supervised_cpn_ft
   Results:
-  - Task: Video-based Single-view 3D Human Body Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       MPJPE: 52.9
       P-MPJPE: 41.3
+    Task: Video-based Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/videopose/videopose_h36m_1frame_fullconv_supervised_cpn_ft-5c3afaed_20210527.pth
-- Name: cbody3d--videopose--h36m--videopose3d_h36m_243frames_fullconv_supervised_cpn_ft
+- Config: cconfigs/body3d/videopose/h36m/videopose3d_h36m_243frames_fullconv_supervised_cpn_ft.py
   In Collection: videopose3d_h36m
-  Config: cconfigs/body3d/videopose/h36m/videopose3d_h36m_243frames_fullconv_supervised_cpn_ft.py
   Metadata:
     Training Data: Human3.6M
+  Name: cbody3d--videopose--h36m--videopose3d_h36m_243frames_fullconv_supervised_cpn_ft
   Results:
-  - Task: Video-based Single-view 3D Human Body Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       MPJPE: 47.9
       P-MPJPE: 38.0
+    Task: Video-based Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/videopose/videopose_h36m_243frames_fullconv_supervised_cpn_ft-88f5abbb_20210527.pth
-- Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_27frames_fullconv_semi-supervised
+- Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_27frames_fullconv_semi-supervised.py
   In Collection: videopose3d_h36m
-  Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_27frames_fullconv_semi-supervised.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_27frames_fullconv_semi-supervised
   Results:
-  - Task: Video-based Single-view 3D Human Body Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       MPJPE: 58.1
-      P-MPJPE: 42.8
       N-MPJPE: 54.7
+      P-MPJPE: 42.8
+    Task: Video-based Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/videopose/videopose_h36m_27frames_fullconv_semi-supervised-54aef83b_20210527.pth
-- Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_27frames_fullconv_semi-supervised_cpn_ft
+- Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_27frames_fullconv_semi-supervised_cpn_ft.py
   In Collection: videopose3d_h36m
-  Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/h36m/videopose3d_h36m_27frames_fullconv_semi-supervised_cpn_ft.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--h36m--videopose3d_h36m_27frames_fullconv_semi-supervised_cpn_ft
   Results:
-  - Task: Video-based Single-view 3D Human Body Pose Estimation
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       MPJPE: 67.4
-      P-MPJPE: 50.1
       N-MPJPE: 63.2
+      P-MPJPE: 50.1
+    Task: Video-based Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/videopose/videopose_h36m_27frames_fullconv_semi-supervised_cpn_ft-71be9cde_20210527.pth

--- a/configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/mpi_inf_3dhp/videopose3d_mpi-inf-3dhp.yml
+++ b/configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/mpi_inf_3dhp/videopose3d_mpi-inf-3dhp.yml
@@ -1,24 +1,24 @@
 Collections:
-- Name: videopose3d_mpi-inf-3dhp
-  Metadata:
+- Metadata:
     Architecture:
     - VideoPose3D
-  README: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/mpi_inf_3dhp/videopose3d_mpi-inf-3dhp.md
+  Name: videopose3d_mpi-inf-3dhp
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Pavllo_3D_Human_Pose_Estimation_in_Video_With_Temporal_Convolutions_and_CVPR_2019_paper.html
   - https://ieeexplore.ieee.org/abstract/document/8374605/
+  README: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/mpi_inf_3dhp/videopose3d_mpi-inf-3dhp.md
 Models:
-- Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--mpi_inf_3dhp--videopose3d_mpi-inf-3dhp_1frame_fullconv_supervised_gt
+- Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/mpi_inf_3dhp/videopose3d_mpi-inf-3dhp_1frame_fullconv_supervised_gt.py
   In Collection: videopose3d_mpi-inf-3dhp
-  Config: configs/body/3d_kpt_sview_rgb_vid/video_pose_lift/mpi_inf_3dhp/videopose3d_mpi-inf-3dhp_1frame_fullconv_supervised_gt.py
   Metadata:
     Training Data: MPI-INF-3DHP
+  Name: body--3d_kpt_sview_rgb_vid--video_pose_lift--mpi_inf_3dhp--videopose3d_mpi-inf-3dhp_1frame_fullconv_supervised_gt
   Results:
-  - Task: Video-based Single-view 3D Human Body Pose Estimation
-    Dataset: MPI-INF-3DHP
+  - Dataset: MPI-INF-3DHP
     Metrics:
+      3DAUC: 63.1
+      3DPCK: 94.1
       MPJPE: 58.3
       P-MPJPE: 40.6
-      3DPCK: 94.1
-      3DAUC: 63.1
+    Task: Video-based Single-view 3D Human Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/body3d/videopose/videopose_mpi-inf-3dhp_1frame_fullconv_supervised_gt-d6ed21ef_20210603.pth

--- a/configs/body/3d_mesh_sview_rgb_img/hmr/mixed/resnet_mixed.yml
+++ b/configs/body/3d_mesh_sview_rgb_img/hmr/mixed/resnet_mixed.yml
@@ -1,26 +1,26 @@
 Collections:
-- Name: resnet_mixed
-  Metadata:
+- Metadata:
     Architecture:
     - HMR
     - ResNet
-  README: configs/body/3d_mesh_sview_rgb_img/hmr/mixed/resnet_mixed.md
+  Name: resnet_mixed
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Kanazawa_End-to-End_Recovery_of_CVPR_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://ieeexplore.ieee.org/abstract/document/6682899/
+  README: configs/body/3d_mesh_sview_rgb_img/hmr/mixed/resnet_mixed.md
 Models:
-- Name: body--3d_mesh_sview_rgb_img--hmr--res50_mixed_224x224
+- Config: configs/body/3d_mesh_sview_rgb_img/hmr/res50_mixed_224x224.py
   In Collection: resnet_mixed
-  Config: configs/body/3d_mesh_sview_rgb_img/hmr/res50_mixed_224x224.py
   Metadata:
     Training Data: Human3.6M
+  Name: body--3d_mesh_sview_rgb_img--hmr--res50_mixed_224x224
   Results:
-  - Task: Human Body 3D Mesh Recovery
-    Dataset: Human3.6M
+  - Dataset: Human3.6M
     Metrics:
       MPJPE (P1): 80.75
-      MPJPE-PA (P1): 55.08
       MPJPE (P2): 80.35
+      MPJPE-PA (P1): 55.08
       MPJPE-PA (P2): 52.6
+    Task: Human Body 3D Mesh Recovery
   Weights: https://download.openmmlab.com/mmpose/mesh/hmr/hmr_mesh_224x224-c21e8229_20201015.pth

--- a/configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/resnet_wflw.yml
+++ b/configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/resnet_wflw.yml
@@ -1,29 +1,29 @@
 Collections:
-- Name: resnet_wflw
-  Metadata:
+- Metadata:
     Architecture:
     - DeepPose
     - ResNet
-  README: configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/resnet_wflw.md
+  Name: resnet_wflw
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Wu_Look_at_Boundary_CVPR_2018_paper.html
+  README: configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/resnet_wflw.md
 Models:
-- Name: face--2d_kpt_sview_rgb_img--deeppose--wflw--res50_wflw_256x256
+- Config: configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/res50_wflw_256x256.py
   In Collection: resnet_wflw
-  Config: configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/res50_wflw_256x256.py
   Metadata:
     Training Data: WFLW
+  Name: face--2d_kpt_sview_rgb_img--deeppose--wflw--res50_wflw_256x256
   Results:
-  - Task: 2D Face Landmark Detection
-    Dataset: WFLW
+  - Dataset: WFLW
     Metrics:
-      NME test: 4.85
-      NME pose: 8.5
-      NME illumination: 4.81
-      NME occlusion: 5.69
       NME blur: 5.45
-      NME makeup: 4.82
       NME expression: 5.2
+      NME illumination: 4.81
+      NME makeup: 4.82
+      NME occlusion: 5.69
+      NME pose: 8.5
+      NME test: 4.85
+    Task: 2D Face Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/face/deeppose/deeppose_res50_wflw_256x256-92d0ba7f_20210303.pth

--- a/configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/resnet_wingloss_wflw.yml
+++ b/configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/resnet_wingloss_wflw.yml
@@ -1,31 +1,31 @@
 Collections:
-- Name: resnet_wingloss_wflw
-  Metadata:
+- Metadata:
     Architecture:
     - DeepPose
     - ResNet
     - Wingloss
-  README: configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/resnet_wingloss_wflw.md
+  Name: resnet_wingloss_wflw
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Feng_Wing_Loss_for_CVPR_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Wu_Look_at_Boundary_CVPR_2018_paper.html
+  README: configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/resnet_wingloss_wflw.md
 Models:
-- Name: face--2d_kpt_sview_rgb_img--deeppose--wflw--res50_wflw_256x256_wingloss
+- Config: configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/res50_wflw_256x256_wingloss.py
   In Collection: resnet_wingloss_wflw
-  Config: configs/face/2d_kpt_sview_rgb_img/deeppose/wflw/res50_wflw_256x256_wingloss.py
   Metadata:
     Training Data: WFLW
+  Name: face--2d_kpt_sview_rgb_img--deeppose--wflw--res50_wflw_256x256_wingloss
   Results:
-  - Task: 2D Face Landmark Detection
-    Dataset: WFLW
+  - Dataset: WFLW
     Metrics:
-      NME test: 4.64
-      NME pose: 8.25
-      NME illumination: 4.59
-      NME occlusion: 5.56
       NME blur: 5.26
-      NME makeup: 4.59
       NME expression: 5.07
+      NME illumination: 4.59
+      NME makeup: 4.59
+      NME occlusion: 5.56
+      NME pose: 8.25
+      NME test: 4.64
+    Task: 2D Face Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/face/deeppose/deeppose_res50_wflw_256x256_wingloss-f82a5e53_20210303.pth

--- a/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/300w/hrnetv2_300w.yml
+++ b/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/300w/hrnetv2_300w.yml
@@ -1,10 +1,10 @@
 Collections:
-- Name: hrnetv2_300w
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
-  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/300w/hrnetv2_300w.md
+  Name: hrnetv2_300w
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - https://www.sciencedirect.com/science/article/pii/S0262885616000147
+  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/300w/hrnetv2_300w.md
 Models: []

--- a/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_aflw.yml
+++ b/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_aflw.yml
@@ -1,22 +1,22 @@
 Collections:
-- Name: hrnetv2_aflw
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
-  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_aflw.md
+  Name: hrnetv2_aflw
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - https://ieeexplore.ieee.org/abstract/document/6130513/
+  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_aflw.md
 Models:
-- Name: face--2d_kpt_sview_rgb_img--topdown_heatmap--aflw--hrnetv2_w18_aflw_256x256
+- Config: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_w18_aflw_256x256.py
   In Collection: hrnetv2_aflw
-  Config: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_w18_aflw_256x256.py
   Metadata:
     Training Data: AFLW
+  Name: face--2d_kpt_sview_rgb_img--topdown_heatmap--aflw--hrnetv2_w18_aflw_256x256
   Results:
-  - Task: 2D Face Landmark Detection
-    Dataset: AFLW
+  - Dataset: AFLW
     Metrics:
-      NME full: 1.41
       NME frontal: 1.27
+      NME full: 1.41
+    Task: 2D Face Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/face/hrnetv2/hrnetv2_w18_aflw_256x256-f2bbc62b_20210125.pth

--- a/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_dark_aflw.yml
+++ b/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_dark_aflw.yml
@@ -1,24 +1,24 @@
 Collections:
-- Name: hrnetv2_dark_aflw
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
     - DarkPose
-  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_dark_aflw.md
+  Name: hrnetv2_dark_aflw
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html
   - https://ieeexplore.ieee.org/abstract/document/6130513/
+  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_dark_aflw.md
 Models:
-- Name: face--2d_kpt_sview_rgb_img--topdown_heatmap--aflw--hrnetv2_w18_aflw_256x256_dark
+- Config: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_w18_aflw_256x256_dark.py
   In Collection: hrnetv2_dark_aflw
-  Config: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/aflw/hrnetv2_w18_aflw_256x256_dark.py
   Metadata:
     Training Data: AFLW
+  Name: face--2d_kpt_sview_rgb_img--topdown_heatmap--aflw--hrnetv2_w18_aflw_256x256_dark
   Results:
-  - Task: 2D Face Landmark Detection
-    Dataset: AFLW
+  - Dataset: AFLW
     Metrics:
-      NME full: 1.41
       NME frontal: 1.27
+      NME full: 1.41
+    Task: 2D Face Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/face/darkpose/hrnetv2_w18_aflw_256x256_dark-219606c0_20210125.pth

--- a/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/cofw/hrnetv2_cofw.yml
+++ b/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/cofw/hrnetv2_cofw.yml
@@ -1,10 +1,10 @@
 Collections:
-- Name: hrnetv2_cofw
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
-  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/cofw/hrnetv2_cofw.md
+  Name: hrnetv2_cofw
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_iccv_2013/html/Burgos-Artizzu_Robust_Face_Landmark_2013_ICCV_paper.html
+  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/cofw/hrnetv2_cofw.md
 Models: []

--- a/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_dark_wflw.yml
+++ b/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_dark_wflw.yml
@@ -1,29 +1,29 @@
 Collections:
-- Name: hrnetv2_dark_wflw
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
     - DarkPose
-  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_dark_wflw.md
+  Name: hrnetv2_dark_wflw
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Wu_Look_at_Boundary_CVPR_2018_paper.html
+  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_dark_wflw.md
 Models:
-- Name: face--2d_kpt_sview_rgb_img--topdown_heatmap--wflw--hrnetv2_w18_wflw_256x256_dark
+- Config: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_w18_wflw_256x256_dark.py
   In Collection: hrnetv2_dark_wflw
-  Config: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_w18_wflw_256x256_dark.py
   Metadata:
     Training Data: WFLW
+  Name: face--2d_kpt_sview_rgb_img--topdown_heatmap--wflw--hrnetv2_w18_wflw_256x256_dark
   Results:
-  - Task: 2D Face Landmark Detection
-    Dataset: WFLW
+  - Dataset: WFLW
     Metrics:
-      NME test: 3.98
-      NME pose: 6.99
-      NME illumination: 3.96
-      NME occlusion: 4.78
       NME blur: 4.57
-      NME makeup: 3.87
       NME expression: 4.3
+      NME illumination: 3.96
+      NME makeup: 3.87
+      NME occlusion: 4.78
+      NME pose: 6.99
+      NME test: 3.98
+    Task: 2D Face Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/face/darkpose/hrnetv2_w18_wflw_256x256_dark-3f8e0c2c_20210125.pth

--- a/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_wflw.yml
+++ b/configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_wflw.yml
@@ -1,27 +1,27 @@
 Collections:
-- Name: hrnetv2_wflw
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
-  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_wflw.md
+  Name: hrnetv2_wflw
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Wu_Look_at_Boundary_CVPR_2018_paper.html
+  README: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_wflw.md
 Models:
-- Name: face--2d_kpt_sview_rgb_img--topdown_heatmap--wflw--hrnetv2_w18_wflw_256x256
+- Config: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_w18_wflw_256x256.py
   In Collection: hrnetv2_wflw
-  Config: configs/face/2d_kpt_sview_rgb_img/topdown_heatmap/wflw/hrnetv2_w18_wflw_256x256.py
   Metadata:
     Training Data: WFLW
+  Name: face--2d_kpt_sview_rgb_img--topdown_heatmap--wflw--hrnetv2_w18_wflw_256x256
   Results:
-  - Task: 2D Face Landmark Detection
-    Dataset: WFLW
+  - Dataset: WFLW
     Metrics:
-      NME test: 4.06
-      NME pose: 6.98
-      NME illumination: 3.99
-      NME occlusion: 4.83
       NME blur: 4.59
-      NME makeup: 3.92
       NME expression: 4.33
+      NME illumination: 3.99
+      NME makeup: 3.92
+      NME occlusion: 4.83
+      NME pose: 6.98
+      NME test: 4.06
+    Task: 2D Face Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/face/hrnetv2/hrnetv2_w18_wflw_256x256-2bf032a6_20210125.pth

--- a/configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/resnet_deepfashion.yml
+++ b/configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/resnet_deepfashion.yml
@@ -1,52 +1,52 @@
 Collections:
-- Name: resnet_deepfashion
-  Metadata:
+- Metadata:
     Architecture:
     - DeepPose
     - ResNet
-  README: configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/resnet_deepfashion.md
+  Name: resnet_deepfashion
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/Liu_DeepFashion_Powering_Robust_CVPR_2016_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-46475-6_15
+  README: configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/resnet_deepfashion.md
 Models:
-- Name: fashion--2d_kpt_sview_rgb_img--deeppose--deepfashion--res50_deepfashion_upper_256x192
+- Config: configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/res50_deepfashion_upper_256x192.py
   In Collection: resnet_deepfashion
-  Config: configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/res50_deepfashion_upper_256x192.py
   Metadata:
     Training Data: DeepFashion
+  Name: fashion--2d_kpt_sview_rgb_img--deeppose--deepfashion--res50_deepfashion_upper_256x192
   Results:
-  - Task: 2D Fashion Landmark Detection
-    Dataset: DeepFashion
+  - Dataset: DeepFashion
     Metrics:
-      PCK@0.2: 0.965
       AUC: 0.535
       EPE: 17.2
+      PCK@0.2: 0.965
+    Task: 2D Fashion Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/fashion/deeppose/deeppose_res50_deepfashion_upper_256x192-497799fb_20210309.pth
-- Name: fashion--2d_kpt_sview_rgb_img--deeppose--deepfashion--res50_deepfashion_lower_256x192
+- Config: configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/res50_deepfashion_lower_256x192.py
   In Collection: resnet_deepfashion
-  Config: configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/res50_deepfashion_lower_256x192.py
   Metadata:
     Training Data: DeepFashion
+  Name: fashion--2d_kpt_sview_rgb_img--deeppose--deepfashion--res50_deepfashion_lower_256x192
   Results:
-  - Task: 2D Fashion Landmark Detection
-    Dataset: DeepFashion
+  - Dataset: DeepFashion
     Metrics:
-      PCK@0.2: 0.971
       AUC: 0.678
       EPE: 11.8
+      PCK@0.2: 0.971
+    Task: 2D Fashion Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/fashion/deeppose/deeppose_res50_deepfashion_lower_256x192-94e0e653_20210309.pth
-- Name: fashion--2d_kpt_sview_rgb_img--deeppose--deepfashion--res50_deepfashion_full_256x192
+- Config: configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/res50_deepfashion_full_256x192.py
   In Collection: resnet_deepfashion
-  Config: configs/fashion/2d_kpt_sview_rgb_img/deeppose/deepfashion/res50_deepfashion_full_256x192.py
   Metadata:
     Training Data: DeepFashion
+  Name: fashion--2d_kpt_sview_rgb_img--deeppose--deepfashion--res50_deepfashion_full_256x192
   Results:
-  - Task: 2D Fashion Landmark Detection
-    Dataset: DeepFashion
+  - Dataset: DeepFashion
     Metrics:
-      PCK@0.2: 0.983
       AUC: 0.602
       EPE: 14.0
+      PCK@0.2: 0.983
+    Task: 2D Fashion Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/fashion/deeppose/deeppose_res50_deepfashion_full_256x192-4e0273e2_20210309.pth

--- a/configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/resnet_deepfashion.yml
+++ b/configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/resnet_deepfashion.yml
@@ -1,52 +1,52 @@
 Collections:
-- Name: resnet_deepfashion
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/resnet_deepfashion.md
+  Name: resnet_deepfashion
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/Liu_DeepFashion_Powering_Robust_CVPR_2016_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-319-46475-6_15
+  README: configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/resnet_deepfashion.md
 Models:
-- Name: fashion--2d_kpt_sview_rgb_img--topdown_heatmap--deepfashion--res50_deepfashion_upper_256x192
+- Config: configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/res50_deepfashion_upper_256x192.py
   In Collection: resnet_deepfashion
-  Config: configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/res50_deepfashion_upper_256x192.py
   Metadata:
     Training Data: DeepFashion
+  Name: fashion--2d_kpt_sview_rgb_img--topdown_heatmap--deepfashion--res50_deepfashion_upper_256x192
   Results:
-  - Task: 2D Fashion Landmark Detection
-    Dataset: DeepFashion
+  - Dataset: DeepFashion
     Metrics:
-      PCK@0.2: 0.954
       AUC: 0.578
       EPE: 16.8
+      PCK@0.2: 0.954
+    Task: 2D Fashion Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/fashion/resnet/res50_deepfashion_upper_256x192-41794f03_20210124.pth
-- Name: fashion--2d_kpt_sview_rgb_img--topdown_heatmap--deepfashion--res50_deepfashion_lower_256x192
+- Config: configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/res50_deepfashion_lower_256x192.py
   In Collection: resnet_deepfashion
-  Config: configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/res50_deepfashion_lower_256x192.py
   Metadata:
     Training Data: DeepFashion
+  Name: fashion--2d_kpt_sview_rgb_img--topdown_heatmap--deepfashion--res50_deepfashion_lower_256x192
   Results:
-  - Task: 2D Fashion Landmark Detection
-    Dataset: DeepFashion
+  - Dataset: DeepFashion
     Metrics:
-      PCK@0.2: 0.965
       AUC: 0.744
       EPE: 10.5
+      PCK@0.2: 0.965
+    Task: 2D Fashion Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/fashion/resnet/res50_deepfashion_lower_256x192-1292a839_20210124.pth
-- Name: fashion--2d_kpt_sview_rgb_img--topdown_heatmap--deepfashion--res50_deepfashion_full_256x192
+- Config: configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/res50_deepfashion_full_256x192.py
   In Collection: resnet_deepfashion
-  Config: configs/fashion/2d_kpt_sview_rgb_img/topdown_heatmap/deepfashion/res50_deepfashion_full_256x192.py
   Metadata:
     Training Data: DeepFashion
+  Name: fashion--2d_kpt_sview_rgb_img--topdown_heatmap--deepfashion--res50_deepfashion_full_256x192
   Results:
-  - Task: 2D Fashion Landmark Detection
-    Dataset: DeepFashion
+  - Dataset: DeepFashion
     Metrics:
-      PCK@0.2: 0.977
       AUC: 0.664
       EPE: 12.7
+      PCK@0.2: 0.977
+    Task: 2D Fashion Landmark Detection
   Weights: https://download.openmmlab.com/mmpose/fashion/resnet/res50_deepfashion_full_256x192-0dbd6e42_20210124.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/deeppose/onehand10k/resnet_onehand10k.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/deeppose/onehand10k/resnet_onehand10k.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: resnet_onehand10k
-  Metadata:
+- Metadata:
     Architecture:
     - DeepPose
     - ResNet
-  README: configs/hand/2d_kpt_sview_rgb_img/deeppose/onehand10k/resnet_onehand10k.md
+  Name: resnet_onehand10k
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://ieeexplore.ieee.org/abstract/document/8529221/
+  README: configs/hand/2d_kpt_sview_rgb_img/deeppose/onehand10k/resnet_onehand10k.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--deeppose--onehand10k--res50_onehand10k_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/deeppose/onehand10k/res50_onehand10k_256x256.py
   In Collection: resnet_onehand10k
-  Config: configs/hand/2d_kpt_sview_rgb_img/deeppose/onehand10k/res50_onehand10k_256x256.py
   Metadata:
     Training Data: OneHand10K
+  Name: hand--2d_kpt_sview_rgb_img--deeppose--onehand10k--res50_onehand10k_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: OneHand10K
+  - Dataset: OneHand10K
     Metrics:
-      PCK@0.2: 0.99
       AUC: 0.486
       EPE: 34.28
+      PCK@0.2: 0.99
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/deeppose/deeppose_res50_onehand10k_256x256-cbddf43a_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/deeppose/panoptic2d/resnet_panoptic2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/deeppose/panoptic2d/resnet_panoptic2d.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: resnet_panoptic2d
-  Metadata:
+- Metadata:
     Architecture:
     - DeepPose
     - ResNet
-  README: configs/hand/2d_kpt_sview_rgb_img/deeppose/panoptic2d/resnet_panoptic2d.md
+  Name: resnet_panoptic2d
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2017/html/Simon_Hand_Keypoint_Detection_CVPR_2017_paper.html
+  README: configs/hand/2d_kpt_sview_rgb_img/deeppose/panoptic2d/resnet_panoptic2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--deeppose--panoptic2d--res50_panoptic2d_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/deeppose/panoptic2d/res50_panoptic2d_256x256.py
   In Collection: resnet_panoptic2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/deeppose/panoptic2d/res50_panoptic2d_256x256.py
   Metadata:
     Training Data: CMU Panoptic HandDB
+  Name: hand--2d_kpt_sview_rgb_img--deeppose--panoptic2d--res50_panoptic2d_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: CMU Panoptic HandDB
+  - Dataset: CMU Panoptic HandDB
     Metrics:
-      PCKh@0.7: 0.999
       AUC: 0.686
       EPE: 9.36
+      PCKh@0.7: 0.999
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/deeppose/deeppose_res50_panoptic_256x256-8a745183_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/deeppose/rhd2d/resnet_rhd2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/deeppose/rhd2d/resnet_rhd2d.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: resnet_rhd2d
-  Metadata:
+- Metadata:
     Architecture:
     - DeepPose
     - ResNet
-  README: configs/hand/2d_kpt_sview_rgb_img/deeppose/rhd2d/resnet_rhd2d.md
+  Name: resnet_rhd2d
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2014/html/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://lmb.informatik.uni-freiburg.de/projects/hand3d/
+  README: configs/hand/2d_kpt_sview_rgb_img/deeppose/rhd2d/resnet_rhd2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--deeppose--rhd2d--res50_rhd2d_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/deeppose/rhd2d/res50_rhd2d_256x256.py
   In Collection: resnet_rhd2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/deeppose/rhd2d/res50_rhd2d_256x256.py
   Metadata:
     Training Data: RHD
+  Name: hand--2d_kpt_sview_rgb_img--deeppose--rhd2d--res50_rhd2d_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: RHD
+  - Dataset: RHD
     Metrics:
-      PCK@0.2: 0.988
       AUC: 0.865
       EPE: 3.29
+      PCK@0.2: 0.988
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/deeppose/deeppose_res50_rhd2d_256x256-37f1c4d3_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/freihand2d/resnet_freihand2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/freihand2d/resnet_freihand2d.yml
@@ -1,38 +1,38 @@
 Collections:
-- Name: resnet_freihand2d
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/freihand2d/resnet_freihand2d.md
+  Name: resnet_freihand2d
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_ICCV_2019/html/Zimmermann_FreiHAND_A_Dataset_for_Markerless_Capture_of_Hand_Pose_and_ICCV_2019_paper.html
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/freihand2d/resnet_freihand2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--freihand2d--res50_freihand_224x224
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/freihand2d/res50_freihand_224x224.py
   In Collection: resnet_freihand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/freihand2d/res50_freihand_224x224.py
   Metadata:
     Training Data: FreiHand
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--freihand2d--res50_freihand_224x224
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: FreiHand
+  - Dataset: FreiHand
     Metrics:
-      PCK@0.2: 0.993
       AUC: 0.868
       EPE: 3.25
+      PCK@0.2: 0.993
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_freihand_224x224-ff0799bc_20200914.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--freihand2d--res50_freihand_224x224
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/freihand2d/res50_freihand_224x224.py
   In Collection: resnet_freihand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/freihand2d/res50_freihand_224x224.py
   Metadata:
     Training Data: FreiHand
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--freihand2d--res50_freihand_224x224
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: FreiHand
+  - Dataset: FreiHand
     Metrics:
-      PCK@0.2: 0.992
       AUC: 0.868
       EPE: 3.27
+      PCK@0.2: 0.992
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_freihand_224x224-ff0799bc_20200914.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/resnet_interhand2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/resnet_interhand2d.yml
@@ -1,168 +1,168 @@
 Collections:
-- Name: resnet_interhand2d
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/resnet_interhand2d.md
+  Name: resnet_interhand2d
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://link.springer.com/content/pdf/10.1007/978-3-030-58565-5_33.pdf
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/resnet_interhand2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_human_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_human_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_human_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_human_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.973
       AUC: 0.828
       EPE: 5.15
+      PCK@0.2: 0.973
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_human-77b27d1a_20201029.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_human_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_human_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_human_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_human_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.973
       AUC: 0.826
       EPE: 5.27
+      PCK@0.2: 0.973
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_human-77b27d1a_20201029.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_human_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_human_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_human_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_human_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.975
       AUC: 0.841
       EPE: 4.9
+      PCK@0.2: 0.975
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_human-77b27d1a_20201029.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_human_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_human_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_human_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_human_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.975
       AUC: 0.839
       EPE: 4.97
+      PCK@0.2: 0.975
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_human-77b27d1a_20201029.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_machine_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_machine_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_machine_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_machine_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.97
       AUC: 0.824
       EPE: 5.39
+      PCK@0.2: 0.97
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_machine-8f3efe9a_20201102.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_machine_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_machine_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_machine_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_machine_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.969
       AUC: 0.821
       EPE: 5.52
+      PCK@0.2: 0.969
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_machine-8f3efe9a_20201102.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_machine_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_machine_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_machine_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_machine_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.972
       AUC: 0.838
       EPE: 5.03
+      PCK@0.2: 0.972
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_machine-8f3efe9a_20201102.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_machine_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_machine_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_machine_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_machine_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.972
       AUC: 0.837
       EPE: 5.11
+      PCK@0.2: 0.972
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_machine-8f3efe9a_20201102.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_all_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_all_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_all_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_all_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.977
       AUC: 0.84
       EPE: 4.66
+      PCK@0.2: 0.977
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_all-78cc95d4_20201102.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_all_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_all_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_all_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_all_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.979
       AUC: 0.839
       EPE: 4.65
+      PCK@0.2: 0.979
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_all-78cc95d4_20201102.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_all_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_all_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_all_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_all_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.979
       AUC: 0.838
       EPE: 4.42
+      PCK@0.2: 0.979
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_all-78cc95d4_20201102.pth
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_all_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_all_256x256.py
   In Collection: resnet_interhand2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/interhand2d/res50_interhand2d_all_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--interhand2d--res50_interhand2d_all_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      PCK@0.2: 0.979
       AUC: 0.851
       EPE: 4.46
+      PCK@0.2: 0.979
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_interhand2d_256x256_all-78cc95d4_20201102.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_dark_onehand10k.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_dark_onehand10k.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: hrnetv2_dark_onehand10k
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
     - DarkPose
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_dark_onehand10k.md
+  Name: hrnetv2_dark_onehand10k
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html
   - https://ieeexplore.ieee.org/abstract/document/8529221/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_dark_onehand10k.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--hrnetv2_w18_onehand10k_256x256_dark
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_w18_onehand10k_256x256_dark.py
   In Collection: hrnetv2_dark_onehand10k
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_w18_onehand10k_256x256_dark.py
   Metadata:
     Training Data: OneHand10K
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--hrnetv2_w18_onehand10k_256x256_dark
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: OneHand10K
+  - Dataset: OneHand10K
     Metrics:
-      PCK@0.2: 0.99
       AUC: 0.573
       EPE: 23.84
+      PCK@0.2: 0.99
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/dark/hrnetv2_w18_onehand10k_256x256_dark-a2f80c64_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_onehand10k.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_onehand10k.yml
@@ -1,23 +1,23 @@
 Collections:
-- Name: hrnetv2_onehand10k
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_onehand10k.md
+  Name: hrnetv2_onehand10k
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - https://ieeexplore.ieee.org/abstract/document/8529221/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_onehand10k.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--hrnetv2_w18_onehand10k_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_w18_onehand10k_256x256.py
   In Collection: hrnetv2_onehand10k
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_w18_onehand10k_256x256.py
   Metadata:
     Training Data: OneHand10K
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--hrnetv2_w18_onehand10k_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: OneHand10K
+  - Dataset: OneHand10K
     Metrics:
-      PCK@0.2: 0.99
       AUC: 0.568
       EPE: 24.16
+      PCK@0.2: 0.99
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/hrnetv2/hrnetv2_w18_onehand10k_256x256-30bc9c6b_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_udp_onehand10k.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_udp_onehand10k.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: hrnetv2_udp_onehand10k
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
     - UDP
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_udp_onehand10k.md
+  Name: hrnetv2_udp_onehand10k
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Huang_The_Devil_Is_in_the_Details_Delving_Into_Unbiased_Data_CVPR_2020_paper.html
   - https://ieeexplore.ieee.org/abstract/document/8529221/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_udp_onehand10k.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--hrnetv2_w18_onehand10k_256x256_udp
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_w18_onehand10k_256x256_udp.py
   In Collection: hrnetv2_udp_onehand10k
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/hrnetv2_w18_onehand10k_256x256_udp.py
   Metadata:
     Training Data: OneHand10K
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--hrnetv2_w18_onehand10k_256x256_udp
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: OneHand10K
+  - Dataset: OneHand10K
     Metrics:
-      PCK@0.2: 0.99
       AUC: 0.572
       EPE: 23.87
+      PCK@0.2: 0.99
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/udp/hrnetv2_w18_onehand10k_256x256_udp-0d1b515d_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/mobilenetv2_onehand10k.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/mobilenetv2_onehand10k.yml
@@ -1,23 +1,23 @@
 Collections:
-- Name: mobilenetv2_onehand10k
-  Metadata:
+- Metadata:
     Architecture:
     - MobilenetV2
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/mobilenetv2_onehand10k.md
+  Name: mobilenetv2_onehand10k
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Sandler_MobileNetV2_Inverted_Residuals_CVPR_2018_paper.html
   - https://ieeexplore.ieee.org/abstract/document/8529221/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/mobilenetv2_onehand10k.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--mobilenetv2_onehand10k_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/mobilenetv2_onehand10k_256x256.py
   In Collection: mobilenetv2_onehand10k
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/mobilenetv2_onehand10k_256x256.py
   Metadata:
     Training Data: OneHand10K
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--mobilenetv2_onehand10k_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: OneHand10K
+  - Dataset: OneHand10K
     Metrics:
-      PCK@0.2: 0.986
       AUC: 0.537
       EPE: 28.6
+      PCK@0.2: 0.986
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/mobilenetv2/mobilenetv2_onehand10k_256x256-f3a3d90e_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/resnet_onehand10k.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/resnet_onehand10k.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: resnet_onehand10k
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/resnet_onehand10k.md
+  Name: resnet_onehand10k
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://ieeexplore.ieee.org/abstract/document/8529221/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/resnet_onehand10k.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--res50_onehand10k_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/res50_onehand10k_256x256.py
   In Collection: resnet_onehand10k
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/onehand10k/res50_onehand10k_256x256.py
   Metadata:
     Training Data: OneHand10K
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--onehand10k--res50_onehand10k_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: OneHand10K
+  - Dataset: OneHand10K
     Metrics:
-      PCK@0.2: 0.989
       AUC: 0.555
       EPE: 25.19
+      PCK@0.2: 0.989
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_onehand10k_256x256-739c8639_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_dark_panoptic2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_dark_panoptic2d.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: hrnetv2_dark_panoptic2d
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
     - DarkPose
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_dark_panoptic2d.md
+  Name: hrnetv2_dark_panoptic2d
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2017/html/Simon_Hand_Keypoint_Detection_CVPR_2017_paper.html
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_dark_panoptic2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--hrnetv2_w18_panoptic_256x256_dark
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_w18_panoptic_256x256_dark.py
   In Collection: hrnetv2_dark_panoptic2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_w18_panoptic_256x256_dark.py
   Metadata:
     Training Data: CMU Panoptic HandDB
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--hrnetv2_w18_panoptic_256x256_dark
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: CMU Panoptic HandDB
+  - Dataset: CMU Panoptic HandDB
     Metrics:
-      PCKh@0.7: 0.999
       AUC: 0.745
       EPE: 7.77
+      PCKh@0.7: 0.999
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/dark/hrnetv2_w18_panoptic_256x256_dark-1f1e4b74_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_panoptic2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_panoptic2d.yml
@@ -1,23 +1,23 @@
 Collections:
-- Name: hrnetv2_panoptic2d
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_panoptic2d.md
+  Name: hrnetv2_panoptic2d
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_cvpr_2017/html/Simon_Hand_Keypoint_Detection_CVPR_2017_paper.html
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_panoptic2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--hrnetv2_w18_panoptic_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_w18_panoptic_256x256.py
   In Collection: hrnetv2_panoptic2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_w18_panoptic_256x256.py
   Metadata:
     Training Data: CMU Panoptic HandDB
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--hrnetv2_w18_panoptic_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: CMU Panoptic HandDB
+  - Dataset: CMU Panoptic HandDB
     Metrics:
-      PCKh@0.7: 0.999
       AUC: 0.744
       EPE: 7.79
+      PCKh@0.7: 0.999
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/hrnetv2/hrnetv2_w18_panoptic_256x256-53b12345_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_udp_panoptic2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_udp_panoptic2d.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: hrnetv2_udp_panoptic2d
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
     - UDP
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_udp_panoptic2d.md
+  Name: hrnetv2_udp_panoptic2d
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Huang_The_Devil_Is_in_the_Details_Delving_Into_Unbiased_Data_CVPR_2020_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2017/html/Simon_Hand_Keypoint_Detection_CVPR_2017_paper.html
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_udp_panoptic2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--hrnetv2_w18_panoptic_256x256_udp
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_w18_panoptic_256x256_udp.py
   In Collection: hrnetv2_udp_panoptic2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_w18_panoptic_256x256_udp.py
   Metadata:
     Training Data: CMU Panoptic HandDB
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--hrnetv2_w18_panoptic_256x256_udp
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: CMU Panoptic HandDB
+  - Dataset: CMU Panoptic HandDB
     Metrics:
-      PCKh@0.7: 0.998
       AUC: 0.742
       EPE: 7.84
+      PCKh@0.7: 0.998
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/udp/hrnetv2_w18_panoptic_256x256_udp-f9e15948_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/mobilenetv2_panoptic2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/mobilenetv2_panoptic2d.yml
@@ -1,23 +1,23 @@
 Collections:
-- Name: mobilenetv2_panoptic2d
-  Metadata:
+- Metadata:
     Architecture:
     - MobilenetV2
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/mobilenetv2_panoptic2d.md
+  Name: mobilenetv2_panoptic2d
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Sandler_MobileNetV2_Inverted_Residuals_CVPR_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2017/html/Simon_Hand_Keypoint_Detection_CVPR_2017_paper.html
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/mobilenetv2_panoptic2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--mobilenetv2_panoptic_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/mobilenetv2_panoptic_256x256.py
   In Collection: mobilenetv2_panoptic2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/mobilenetv2_panoptic_256x256.py
   Metadata:
     Training Data: CMU Panoptic HandDB
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--mobilenetv2_panoptic_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: CMU Panoptic HandDB
+  - Dataset: CMU Panoptic HandDB
     Metrics:
-      PCKh@0.7: 0.998
       AUC: 0.694
       EPE: 9.7
+      PCKh@0.7: 0.998
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/mobilenetv2/mobilenetv2_panoptic_256x256-b733d98c_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/resnet_panoptic2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/resnet_panoptic2d.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: resnet_panoptic2d
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/resnet_panoptic2d.md
+  Name: resnet_panoptic2d
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2017/html/Simon_Hand_Keypoint_Detection_CVPR_2017_paper.html
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/resnet_panoptic2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--res50_panoptic_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/res50_panoptic_256x256.py
   In Collection: resnet_panoptic2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/res50_panoptic_256x256.py
   Metadata:
     Training Data: CMU Panoptic HandDB
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--res50_panoptic_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: CMU Panoptic HandDB
+  - Dataset: CMU Panoptic HandDB
     Metrics:
-      PCKh@0.7: 0.999
       AUC: 0.713
       EPE: 9.0
+      PCKh@0.7: 0.999
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/resnet/res50_panoptic_256x256-4eafc561_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_dark_rhd2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_dark_rhd2d.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: hrnetv2_dark_rhd2d
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
     - DarkPose
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_dark_rhd2d.md
+  Name: hrnetv2_dark_rhd2d
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html
   - https://lmb.informatik.uni-freiburg.de/projects/hand3d/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_dark_rhd2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--rhd2d--hrnetv2_w18_rhd2d_256x256_dark
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_w18_rhd2d_256x256_dark.py
   In Collection: hrnetv2_dark_rhd2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_w18_rhd2d_256x256_dark.py
   Metadata:
     Training Data: RHD
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--rhd2d--hrnetv2_w18_rhd2d_256x256_dark
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: RHD
+  - Dataset: RHD
     Metrics:
-      PCK@0.2: 0.992
       AUC: 0.903
       EPE: 2.17
+      PCK@0.2: 0.992
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/dark/hrnetv2_w18_rhd2d_256x256_dark-4df3a347_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_rhd2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_rhd2d.yml
@@ -1,23 +1,23 @@
 Collections:
-- Name: hrnetv2_rhd2d
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_rhd2d.md
+  Name: hrnetv2_rhd2d
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - https://lmb.informatik.uni-freiburg.de/projects/hand3d/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_rhd2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--rhd2d--hrnetv2_w18_rhd2d_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_w18_rhd2d_256x256.py
   In Collection: hrnetv2_rhd2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_w18_rhd2d_256x256.py
   Metadata:
     Training Data: RHD
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--rhd2d--hrnetv2_w18_rhd2d_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: RHD
+  - Dataset: RHD
     Metrics:
-      PCK@0.2: 0.992
       AUC: 0.902
       EPE: 2.21
+      PCK@0.2: 0.992
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/hrnetv2/hrnetv2_w18_rhd2d_256x256-95b20dd8_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_udp_rhd2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_udp_rhd2d.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: hrnetv2_udp_rhd2d
-  Metadata:
+- Metadata:
     Architecture:
     - HRNetv2
     - UDP
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_udp_rhd2d.md
+  Name: hrnetv2_udp_rhd2d
   Paper:
   - https://ieeexplore.ieee.org/abstract/document/9052469/
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Huang_The_Devil_Is_in_the_Details_Delving_Into_Unbiased_Data_CVPR_2020_paper.html
   - https://lmb.informatik.uni-freiburg.de/projects/hand3d/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_udp_rhd2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--hrnetv2_w18_panoptic_256x256_udp
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_w18_panoptic_256x256_udp.py
   In Collection: hrnetv2_udp_rhd2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/panoptic2d/hrnetv2_w18_panoptic_256x256_udp.py
   Metadata:
     Training Data: RHD
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--panoptic2d--hrnetv2_w18_panoptic_256x256_udp
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: RHD
+  - Dataset: RHD
     Metrics:
-      PCKh@0.7: 0.998
       AUC: 0.742
       EPE: 7.84
+      PCKh@0.7: 0.998
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/udp/hrnetv2_w18_panoptic_256x256_udp-f9e15948_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/mobilenetv2_rhd2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/mobilenetv2_rhd2d.yml
@@ -1,23 +1,23 @@
 Collections:
-- Name: mobilenetv2_rhd2d
-  Metadata:
+- Metadata:
     Architecture:
     - MobilenetV2
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/mobilenetv2_rhd2d.md
+  Name: mobilenetv2_rhd2d
   Paper:
   - http://openaccess.thecvf.com/content_cvpr_2018/html/Sandler_MobileNetV2_Inverted_Residuals_CVPR_2018_paper.html
   - https://lmb.informatik.uni-freiburg.de/projects/hand3d/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/mobilenetv2_rhd2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--rhd2d--mobilenetv2_rhd2d_256x256
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/mobilenetv2_rhd2d_256x256.py
   In Collection: mobilenetv2_rhd2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/mobilenetv2_rhd2d_256x256.py
   Metadata:
     Training Data: RHD
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--rhd2d--mobilenetv2_rhd2d_256x256
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: RHD
+  - Dataset: RHD
     Metrics:
-      PCK@0.2: 0.985
       AUC: 0.883
       EPE: 2.8
+      PCK@0.2: 0.985
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/mobilenetv2/mobilenetv2_rhd2d_256x256-85fa02db_20210330.pth

--- a/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/resnet_rhd2d.yml
+++ b/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/resnet_rhd2d.yml
@@ -1,25 +1,25 @@
 Collections:
-- Name: resnet_rhd2d
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
     - ResNet
-  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/resnet_rhd2d.md
+  Name: resnet_rhd2d
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://lmb.informatik.uni-freiburg.de/projects/hand3d/
+  README: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/resnet_rhd2d.md
 Models:
-- Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--rhd2d--hrnetv2_w18_rhd2d_256x256_udp
+- Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_w18_rhd2d_256x256_udp.py
   In Collection: resnet_rhd2d
-  Config: configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/rhd2d/hrnetv2_w18_rhd2d_256x256_udp.py
   Metadata:
     Training Data: RHD
+  Name: hand--2d_kpt_sview_rgb_img--topdown_heatmap--rhd2d--hrnetv2_w18_rhd2d_256x256_udp
   Results:
-  - Task: 2D Hand Pose Estimation
-    Dataset: RHD
+  - Dataset: RHD
     Metrics:
-      PCK@0.2: 0.992
       AUC: 0.902
       EPE: 2.21
+      PCK@0.2: 0.992
+    Task: 2D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand/udp/hrnetv2_w18_rhd2d_256x256_udp-63ba6007_20210330.pth

--- a/configs/hand/3d_kpt_sview_rgb_img/internet/interhand3d/internet_interhand3d.yml
+++ b/configs/hand/3d_kpt_sview_rgb_img/internet/interhand3d/internet_interhand3d.yml
@@ -1,40 +1,40 @@
 Collections:
-- Name: internet_interhand3d
-  Metadata:
+- Metadata:
     Architecture:
     - InterNet
     - ResNet
-  README: configs/hand/3d_kpt_sview_rgb_img/internet/interhand3d/internet_interhand3d.md
+  Name: internet_interhand3d
   Paper:
   - https://link.springer.com/content/pdf/10.1007/978-3-030-58565-5_33.pdf
   - http://openaccess.thecvf.com/content_cvpr_2016/html/He_Deep_Residual_Learning_CVPR_2016_paper.html
   - https://link.springer.com/content/pdf/10.1007/978-3-030-58565-5_33.pdf
+  README: configs/hand/3d_kpt_sview_rgb_img/internet/interhand3d/internet_interhand3d.md
 Models:
-- Name: hand--3d_kpt_sview_rgb_img--internet--interhand3d--res50_interhand3d_all_256x256
+- Config: configs/hand/3d_kpt_sview_rgb_img/internet/interhand3d/res50_interhand3d_all_256x256.py
   In Collection: internet_interhand3d
-  Config: configs/hand/3d_kpt_sview_rgb_img/internet/interhand3d/res50_interhand3d_all_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--3d_kpt_sview_rgb_img--internet--interhand3d--res50_interhand3d_all_256x256
   Results:
-  - Task: 3D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      MPJPE-single: 9.47
-      MPJPE-interacting: 13.4
-      MPJPE-all: 11.59
       APh: 0.99
+      MPJPE-all: 11.59
+      MPJPE-interacting: 13.4
+      MPJPE-single: 9.47
+    Task: 3D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand3d/internet/res50_intehand3dv1.0_all_256x256-42b7f2ac_20210702.pth
-- Name: hand--3d_kpt_sview_rgb_img--internet--interhand3d--res50_interhand3d_all_256x256
+- Config: configs/hand/3d_kpt_sview_rgb_img/internet/interhand3d/res50_interhand3d_all_256x256.py
   In Collection: internet_interhand3d
-  Config: configs/hand/3d_kpt_sview_rgb_img/internet/interhand3d/res50_interhand3d_all_256x256.py
   Metadata:
     Training Data: InterHand2.6M
+  Name: hand--3d_kpt_sview_rgb_img--internet--interhand3d--res50_interhand3d_all_256x256
   Results:
-  - Task: 3D Hand Pose Estimation
-    Dataset: InterHand2.6M
+  - Dataset: InterHand2.6M
     Metrics:
-      MPJPE-single: 11.22
-      MPJPE-interacting: 15.23
-      MPJPE-all: 13.16
       APh: 0.98
+      MPJPE-all: 13.16
+      MPJPE-interacting: 15.23
+      MPJPE-single: 11.22
+    Task: 3D Hand Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/hand3d/internet/res50_intehand3dv1.0_all_256x256-42b7f2ac_20210702.pth

--- a/configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/higherhrnet_coco-wholebody.yml
+++ b/configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/higherhrnet_coco-wholebody.yml
@@ -1,52 +1,52 @@
 Collections:
-- Name: higherhrnet_coco-wholebody
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HigherHRNet
-  README: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/higherhrnet_coco-wholebody.md
+  Name: higherhrnet_coco-wholebody
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Cheng_HigherHRNet_Scale-Aware_Representation_Learning_for_Bottom-Up_Human_Pose_Estimation_CVPR_2020_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-030-58545-7_12
+  README: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/higherhrnet_coco-wholebody.md
 Models:
-- Name: wholebody--2d_kpt_sview_rgb_img--associative_embedding--coco-wholebody--higherhrnet_w32_coco_wholebody_512x512
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/higherhrnet_w32_coco_wholebody_512x512.py
   In Collection: higherhrnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/higherhrnet_w32_coco_wholebody_512x512.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--associative_embedding--coco-wholebody--higherhrnet_w32_coco_wholebody_512x512
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.59
       Body AR: 0.672
-      Foot AP: 0.185
-      Foot AR: 0.335
       Face AP: 0.676
       Face AR: 0.721
+      Foot AP: 0.185
+      Foot AR: 0.335
       Hand AP: 0.212
       Hand AR: 0.298
       Whole AP: 0.401
       Whole AR: 0.493
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet32_coco_wholebody_512x512_plus-2fa137ab_20210517.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--associative_embedding--coco-wholebody--higherhrnet_w48_coco_wholebody_512x512
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/higherhrnet_w48_coco_wholebody_512x512.py
   In Collection: higherhrnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/higherhrnet_w48_coco_wholebody_512x512.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--associative_embedding--coco-wholebody--higherhrnet_w48_coco_wholebody_512x512
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.63
       Body AR: 0.706
-      Foot AP: 0.44
-      Foot AR: 0.573
       Face AP: 0.73
       Face AR: 0.777
+      Foot AP: 0.44
+      Foot AR: 0.573
       Hand AP: 0.389
       Hand AR: 0.477
       Whole AP: 0.487
       Whole AR: 0.574
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/higher_hrnet48_coco_wholebody_512x512_plus-934f08aa_20210517.pth

--- a/configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/hrnet_coco-wholebody.yml
+++ b/configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/hrnet_coco-wholebody.yml
@@ -1,52 +1,52 @@
 Collections:
-- Name: hrnet_coco-wholebody
-  Metadata:
+- Metadata:
     Architecture:
     - Associative Embedding
     - HRNet
-  README: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/hrnet_coco-wholebody.md
+  Name: hrnet_coco-wholebody
   Paper:
   - https://arxiv.org/abs/1611.05424
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-030-58545-7_12
+  README: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/hrnet_coco-wholebody.md
 Models:
-- Name: wholebody--2d_kpt_sview_rgb_img--associative_embedding--coco-wholebody--hrnet_w32_coco_wholebody_512x512
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/hrnet_w32_coco_wholebody_512x512.py
   In Collection: hrnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/hrnet_w32_coco_wholebody_512x512.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--associative_embedding--coco-wholebody--hrnet_w32_coco_wholebody_512x512
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.551
       Body AR: 0.65
-      Foot AP: 0.271
-      Foot AR: 0.451
       Face AP: 0.564
       Face AR: 0.618
+      Foot AP: 0.271
+      Foot AR: 0.451
       Hand AP: 0.159
       Hand AR: 0.238
       Whole AP: 0.342
       Whole AR: 0.453
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w32_coco_wholebody_512x512_plus-f1f1185c_20210517.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--associative_embedding--coco-wholebody--hrnet_w48_coco_wholebody_512x512
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/hrnet_w48_coco_wholebody_512x512.py
   In Collection: hrnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/associative_embedding/coco-wholebody/hrnet_w48_coco_wholebody_512x512.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--associative_embedding--coco-wholebody--hrnet_w48_coco_wholebody_512x512
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.592
       Body AR: 0.686
-      Foot AP: 0.443
-      Foot AR: 0.595
       Face AP: 0.619
       Face AR: 0.674
+      Foot AP: 0.443
+      Foot AR: 0.595
       Hand AP: 0.347
       Hand AR: 0.438
       Whole AP: 0.422
       Whole AR: 0.532
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/bottom_up/hrnet_w48_coco_wholebody_512x512_plus-4de8a695_20210517.pth

--- a/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_coco-wholebody.yml
+++ b/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_coco-wholebody.yml
@@ -1,90 +1,90 @@
 Collections:
-- Name: hrnet_coco-wholebody
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
-  README: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_coco-wholebody.md
+  Name: hrnet_coco-wholebody
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-030-58545-7_12
+  README: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_coco-wholebody.md
 Models:
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w32_coco_wholebody_256x192
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w32_coco_wholebody_256x192.py
   In Collection: hrnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w32_coco_wholebody_256x192.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w32_coco_wholebody_256x192
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.7
       Body AR: 0.746
-      Foot AP: 0.567
-      Foot AR: 0.645
       Face AP: 0.637
       Face AR: 0.688
+      Foot AP: 0.567
+      Foot AR: 0.645
       Hand AP: 0.473
       Hand AR: 0.546
       Whole AP: 0.553
       Whole AR: 0.626
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_wholebody_256x192-853765cd_20200918.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w32_coco_wholebody_384x288
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w32_coco_wholebody_384x288.py
   In Collection: hrnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w32_coco_wholebody_384x288.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w32_coco_wholebody_384x288
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.701
       Body AR: 0.773
-      Foot AP: 0.586
-      Foot AR: 0.692
       Face AP: 0.727
       Face AR: 0.783
+      Foot AP: 0.586
+      Foot AR: 0.692
       Hand AP: 0.516
       Hand AR: 0.604
       Whole AP: 0.586
       Whole AR: 0.674
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_wholebody_384x288-78cacac3_20200922.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w48_coco_wholebody_256x192
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_256x192.py
   In Collection: hrnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_256x192.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w48_coco_wholebody_256x192
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.7
       Body AR: 0.776
-      Foot AP: 0.672
-      Foot AR: 0.785
       Face AP: 0.656
       Face AR: 0.743
+      Foot AP: 0.672
+      Foot AR: 0.785
       Hand AP: 0.534
       Hand AR: 0.639
       Whole AP: 0.579
       Whole AR: 0.681
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_wholebody_256x192-643e18cb_20200922.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w48_coco_wholebody_384x288
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288.py
   In Collection: hrnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w48_coco_wholebody_384x288
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.722
       Body AR: 0.79
-      Foot AP: 0.694
-      Foot AR: 0.799
       Face AP: 0.777
       Face AR: 0.834
+      Foot AP: 0.694
+      Foot AR: 0.799
       Hand AP: 0.587
       Hand AR: 0.679
       Whole AP: 0.631
       Whole AR: 0.716
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_wholebody_384x288-6e061c6a_20200922.pth

--- a/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_dark_coco-wholebody.yml
+++ b/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_dark_coco-wholebody.yml
@@ -1,52 +1,52 @@
 Collections:
-- Name: hrnet_dark_coco-wholebody
-  Metadata:
+- Metadata:
     Architecture:
     - HRNet
     - DarkPose
-  README: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_dark_coco-wholebody.md
+  Name: hrnet_dark_coco-wholebody
   Paper:
   - http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html
   - http://openaccess.thecvf.com/content_CVPR_2020/html/Zhang_Distribution-Aware_Coordinate_Representation_for_Human_Pose_Estimation_CVPR_2020_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-030-58545-7_12
+  README: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_dark_coco-wholebody.md
 Models:
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w32_coco_wholebody_256x192_dark
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w32_coco_wholebody_256x192_dark.py
   In Collection: hrnet_dark_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w32_coco_wholebody_256x192_dark.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w32_coco_wholebody_256x192_dark
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.694
       Body AR: 0.764
-      Foot AP: 0.565
-      Foot AR: 0.674
       Face AP: 0.736
       Face AR: 0.808
+      Foot AP: 0.565
+      Foot AR: 0.674
       Hand AP: 0.503
       Hand AR: 0.602
       Whole AP: 0.582
       Whole AR: 0.671
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_wholebody_256x192_dark-469327ef_20200922.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w48_coco_wholebody_384x288_dark_plus
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py
   In Collection: hrnet_dark_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--hrnet_w48_coco_wholebody_384x288_dark_plus
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.742
       Body AR: 0.807
-      Foot AP: 0.705
-      Foot AR: 0.804
       Face AP: 0.84
       Face AR: 0.892
+      Foot AP: 0.705
+      Foot AR: 0.804
       Hand AP: 0.602
       Hand AR: 0.694
       Whole AP: 0.661
       Whole AR: 0.743
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_wholebody_384x288_dark-f5726563_20200918.pth

--- a/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/resnet_coco-wholebody.yml
+++ b/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/resnet_coco-wholebody.yml
@@ -1,130 +1,130 @@
 Collections:
-- Name: resnet_coco-wholebody
-  Metadata:
+- Metadata:
     Architecture:
     - SimpleBaseline2D
-  README: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/resnet_coco-wholebody.md
+  Name: resnet_coco-wholebody
   Paper:
   - http://openaccess.thecvf.com/content_ECCV_2018/html/Bin_Xiao_Simple_Baselines_for_ECCV_2018_paper.html
   - https://link.springer.com/chapter/10.1007/978-3-030-58545-7_12
+  README: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/resnet_coco-wholebody.md
 Models:
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res50_coco_wholebody_256x192
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res50_coco_wholebody_256x192.py
   In Collection: resnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res50_coco_wholebody_256x192.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res50_coco_wholebody_256x192
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.652
       Body AR: 0.739
-      Foot AP: 0.614
-      Foot AR: 0.746
       Face AP: 0.608
       Face AR: 0.716
+      Foot AP: 0.614
+      Foot AR: 0.746
       Hand AP: 0.46
       Hand AR: 0.584
       Whole AP: 0.457
       Whole AR: 0.578
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_coco_wholebody_256x192-9e37ed88_20201004.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res50_coco_wholebody_384x288
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res50_coco_wholebody_384x288.py
   In Collection: resnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res50_coco_wholebody_384x288.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res50_coco_wholebody_384x288
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.666
       Body AR: 0.747
-      Foot AP: 0.635
-      Foot AR: 0.763
       Face AP: 0.732
       Face AR: 0.812
+      Foot AP: 0.635
+      Foot AR: 0.763
       Hand AP: 0.537
       Hand AR: 0.647
       Whole AP: 0.573
       Whole AR: 0.671
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res50_coco_wholebody_384x288-ce11e294_20201004.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res101_coco_wholebody_256x192
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res101_coco_wholebody_256x192.py
   In Collection: resnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res101_coco_wholebody_256x192.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res101_coco_wholebody_256x192
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.67
       Body AR: 0.754
-      Foot AP: 0.64
-      Foot AR: 0.767
       Face AP: 0.611
       Face AR: 0.723
+      Foot AP: 0.64
+      Foot AR: 0.767
       Hand AP: 0.463
       Hand AR: 0.589
       Whole AP: 0.533
       Whole AR: 0.647
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_coco_wholebody_256x192-7325f982_20201004.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res101_coco_wholebody_384x288
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res101_coco_wholebody_384x288.py
   In Collection: resnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res101_coco_wholebody_384x288.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res101_coco_wholebody_384x288
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.692
       Body AR: 0.77
-      Foot AP: 0.68
-      Foot AR: 0.798
       Face AP: 0.747
       Face AR: 0.822
+      Foot AP: 0.68
+      Foot AR: 0.798
       Hand AP: 0.549
       Hand AR: 0.658
       Whole AP: 0.597
       Whole AR: 0.692
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res101_coco_wholebody_384x288-6c137b9a_20201004.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res152_coco_wholebody_256x192
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res152_coco_wholebody_256x192.py
   In Collection: resnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res152_coco_wholebody_256x192.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res152_coco_wholebody_256x192
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.682
       Body AR: 0.764
-      Foot AP: 0.662
-      Foot AR: 0.788
       Face AP: 0.624
       Face AR: 0.728
+      Foot AP: 0.662
+      Foot AR: 0.788
       Hand AP: 0.482
       Hand AR: 0.606
       Whole AP: 0.548
       Whole AR: 0.661
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_coco_wholebody_256x192-5de8ae23_20201004.pth
-- Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res152_coco_wholebody_384x288
+- Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res152_coco_wholebody_384x288.py
   In Collection: resnet_coco-wholebody
-  Config: configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/res152_coco_wholebody_384x288.py
   Metadata:
     Training Data: COCO-WholeBody
+  Name: wholebody--2d_kpt_sview_rgb_img--topdown_heatmap--coco-wholebody--res152_coco_wholebody_384x288
   Results:
-  - Task: 2D Human Whole-Body Pose Estimation
-    Dataset: COCO-WholeBody
+  - Dataset: COCO-WholeBody
     Metrics:
       Body AP: 0.703
       Body AR: 0.78
-      Foot AP: 0.693
-      Foot AR: 0.813
       Face AP: 0.751
       Face AR: 0.825
+      Foot AP: 0.693
+      Foot AR: 0.813
       Hand AP: 0.559
       Hand AR: 0.667
       Whole AP: 0.61
       Whole AR: 0.705
+    Task: 2D Human Whole-Body Pose Estimation
   Weights: https://download.openmmlab.com/mmpose/top_down/resnet/res152_coco_wholebody_384x288-eab8caa8_20201004.pth

--- a/tools/misc/update_model_index.py
+++ b/tools/misc/update_model_index.py
@@ -26,19 +26,22 @@ def dump_yaml_and_check_difference(obj, file):
         Bool: If the target YAML file is different from the original.
     """
 
-    original = None
+    str_dump = mmcv.dump(obj, None, file_format='yaml', sort_keys=True)
+
     if osp.isfile(file):
+        file_exists = True
         with open(file, 'r', encoding='utf-8') as f:
-            original = f.read()
+            str_orig = f.read()
+    else:
+        file_exists = False
+        str_orig = None
 
-    with open(file, 'w', encoding='utf-8') as f:
-        mmcv.dump(obj, f, file_format='yaml', sort_keys=False)
-
-    is_different = True
-    if original is not None:
-        with open(file, 'r') as f:
-            new = f.read()
-        is_different = (original != new)
+    if file_exists and str_orig == str_dump:
+        is_different = False
+    else:
+        is_different = True
+        with open(file, 'w', encoding='utf-8') as f:
+            f.write(str_dump)
 
     return is_different
 
@@ -245,7 +248,7 @@ if __name__ == '__main__':
     file_list = [fn for fn in sys.argv[1:] if osp.basename(fn) != 'README.md']
 
     if not file_list:
-        exit(0)
+        sys.exit(0)
 
     file_modified = False
     for fn in file_list:
@@ -253,4 +256,4 @@ if __name__ == '__main__':
 
     file_modified |= update_model_index()
 
-    exit(1 if file_modified else 0)
+    sys.exit(1 if file_modified else 0)


### PR DESCRIPTION
## Motivation

The pre-commit hook update_model_index is observed to exit with code 1 (indicating files modified) randomly without actually modifying the metafiles. We found that this is caused by file I/O conflict when this pre-commit hook is running in a multi-threading manner.

## Modification

* Add `require_serial=true` to prevent multi-threading that causes file I/O conflict
* Modify update_model_index.py to prevent redundant file I/O
* Set sort_keys=True when dumping model metafiles (this only changed the key order in the YAML files)