### PR TITLE
[Fix] ignore _base_ in collections

### DIFF
--- a/docs/collect.py
+++ b/docs/collect.py
@@ -10,7 +10,9 @@ os.makedirs('topics', exist_ok=True)
 os.makedirs('papers', exist_ok=True)
 
 # Step 1: get subtopics: a mix of topic and task
-minisections = [x.split('/')[-2:] for x in glob('../configs/*/*')]
+minisections = [
+    x.split('/')[-2:] for x in glob('../configs/*/*') if '_base_' not in x
+]
 alltopics = sorted(list(set(x[0] for x in minisections)))
 subtopics = []
 for t in alltopics:

--- a/docs_zh-CN/collect.py
+++ b/docs_zh-CN/collect.py
@@ -10,7 +10,9 @@ os.makedirs('topics', exist_ok=True)
 os.makedirs('papers', exist_ok=True)
 
 # Step 1: get subtopics: a mix of topic and task
-minisections = [x.split('/')[-2:] for x in glob('../configs/*/*')]
+minisections = [
+    x.split('/')[-2:] for x in glob('../configs/*/*') if '_base_' not in x
+]
 alltopics = sorted(list(set(x[0] for x in minisections)))
 subtopics = []
 for t in alltopics:


### PR DESCRIPTION
## Motivation

Ignore _base_ configs when counting ckpt/cfg.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
