### PR TITLE
[Fix] move the key `use_different_joint_weights` to Kpt2dSviewRgbImgTopDownDataset

### DIFF
--- a/mmpose/datasets/datasets/base/kpt_2d_sview_rgb_img_top_down_dataset.py
+++ b/mmpose/datasets/datasets/base/kpt_2d_sview_rgb_img_top_down_dataset.py
@@ -60,7 +60,8 @@ class Kpt2dSviewRgbImgTopDownDataset(Dataset, metaclass=ABCMeta):
         self.ann_info['num_output_channels'] = data_cfg['num_output_channels']
         self.ann_info['dataset_channel'] = data_cfg['dataset_channel']
 
-        self.ann_info['use_different_joint_weights'] = False
+        self.ann_info['use_different_joint_weights'] = data_cfg.get(
+            'use_different_joint_weights', False)
 
         if dataset_info is None:
             raise ValueError(

--- a/mmpose/datasets/datasets/base/kpt_2d_sview_rgb_img_top_down_dataset.py
+++ b/mmpose/datasets/datasets/base/kpt_2d_sview_rgb_img_top_down_dataset.py
@@ -60,6 +60,8 @@ class Kpt2dSviewRgbImgTopDownDataset(Dataset, metaclass=ABCMeta):
         self.ann_info['num_output_channels'] = data_cfg['num_output_channels']
         self.ann_info['dataset_channel'] = data_cfg['dataset_channel']
 
+        self.ann_info['use_different_joint_weights'] = False
+
         if dataset_info is None:
             raise ValueError(
                 'Check https://github.com/open-mmlab/mmpose/pull/663 '

--- a/mmpose/datasets/datasets/top_down/topdown_aic_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_aic_dataset.py
@@ -78,7 +78,6 @@ class TopDownAicDataset(TopDownCocoDataset):
         self.oks_thr = data_cfg['oks_thr']
         self.vis_thr = data_cfg['vis_thr']
 
-        self.ann_info['use_different_joint_weights'] = False
         self.db = self._get_db()
 
         print(f'=> num_images: {self.num_images}')

--- a/mmpose/datasets/datasets/top_down/topdown_coco_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_coco_dataset.py
@@ -88,7 +88,6 @@ class TopDownCocoDataset(Kpt2dSviewRgbImgTopDownDataset):
         self.oks_thr = data_cfg['oks_thr']
         self.vis_thr = data_cfg['vis_thr']
 
-        self.ann_info['use_different_joint_weights'] = False
         self.db = self._get_db()
 
         print(f'=> num_images: {self.num_images}')

--- a/mmpose/datasets/datasets/top_down/topdown_coco_wholebody_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_coco_wholebody_dataset.py
@@ -73,8 +73,6 @@ class TopDownCocoWholeBodyDataset(TopDownCocoDataset):
         self.oks_thr = data_cfg['oks_thr']
         self.vis_thr = data_cfg['vis_thr']
 
-        self.ann_info['use_different_joint_weights'] = False
-
         self.body_num = 17
         self.foot_num = 6
         self.face_num = 68

--- a/mmpose/datasets/datasets/top_down/topdown_crowdpose_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_crowdpose_dataset.py
@@ -76,7 +76,6 @@ class TopDownCrowdPoseDataset(TopDownCocoDataset):
         self.oks_thr = data_cfg['oks_thr']
         self.vis_thr = data_cfg['vis_thr']
 
-        self.ann_info['use_different_joint_weights'] = False
         self.db = self._get_db()
 
         print(f'=> num_images: {self.num_images}')

--- a/mmpose/datasets/datasets/top_down/topdown_h36m_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_h36m_dataset.py
@@ -74,7 +74,6 @@ class TopDownH36MDataset(Kpt2dSviewRgbImgTopDownDataset):
             dataset_info=dataset_info,
             test_mode=test_mode)
 
-        self.ann_info['use_different_joint_weights'] = False
         self.db = self._get_db()
 
         print(f'=> num_images: {self.num_images}')

--- a/mmpose/datasets/datasets/top_down/topdown_jhmdb_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_jhmdb_dataset.py
@@ -83,7 +83,6 @@ class TopDownJhmdbDataset(TopDownCocoDataset):
         self.oks_thr = data_cfg['oks_thr']
         self.vis_thr = data_cfg['vis_thr']
 
-        self.ann_info['use_different_joint_weights'] = False
         self.db = self._get_db()
 
         print(f'=> num_images: {self.num_images}')

--- a/mmpose/datasets/datasets/top_down/topdown_mhp_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_mhp_dataset.py
@@ -94,7 +94,6 @@ class TopDownMhpDataset(TopDownCocoDataset):
         self.oks_thr = data_cfg['oks_thr']
         self.vis_thr = data_cfg['vis_thr']
 
-        self.ann_info['use_different_joint_weights'] = False
         self.db = self._get_db()
 
         print(f'=> num_images: {self.num_images}')

--- a/mmpose/datasets/datasets/top_down/topdown_mpii_trb_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_mpii_trb_dataset.py
@@ -103,7 +103,6 @@ class TopDownMpiiTrbDataset(Kpt2dSviewRgbImgTopDownDataset):
             dataset_info=dataset_info,
             test_mode=test_mode)
 
-        self.ann_info['use_different_joint_weights'] = False
         self.db = self._get_db(ann_file)
         self.image_set = set(x['image_file'] for x in self.db)
         self.num_images = len(self.image_set)

--- a/mmpose/datasets/datasets/top_down/topdown_ochuman_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_ochuman_dataset.py
@@ -85,7 +85,6 @@ class TopDownOCHumanDataset(TopDownCocoDataset):
         self.oks_thr = data_cfg['oks_thr']
         self.vis_thr = data_cfg['vis_thr']
 
-        self.ann_info['use_different_joint_weights'] = False
         self.db = self._get_db()
 
         print(f'=> num_images: {self.num_images}')

--- a/mmpose/datasets/datasets/top_down/topdown_posetrack18_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_posetrack18_dataset.py
@@ -89,7 +89,6 @@ class TopDownPoseTrack18Dataset(TopDownCocoDataset):
         self.oks_thr = data_cfg['oks_thr']
         self.vis_thr = data_cfg['vis_thr']
 
-        self.ann_info['use_different_joint_weights'] = False
         self.db = self._get_db()
 
         print(f'=> num_images: {self.num_images}')


### PR DESCRIPTION
## Motivation
Fix #915.

In case that we forget to assign the key `ann_info['use_different_joint_weights']`, we move it from all topdown dataset classes to the very base class, `Kpt2dSviewRgbImgTopDownDataset`. 

## Modification
Add the following code  `self.ann_info['use_different_joint_weights'] = False` in `mmpose/mmpose/datasets/datasets/base/kpt_2d_sview_rgb_img_top_down_dataset.py`.

And also remove this code from all related classes:

```
mmpose/mmpose/datasets/datasets/top_down/topdown_aic_dataset.py
mmpose/mmpose/datasets/datasets/top_down/topdown_coco_dataset.pyy
mmpose/mmpose/datasets/datasets/top_down/topdown_coco_wholebody_dataset.py
mmpose/mmpose/datasets/datasets/top_down/topdown_crowdpose_dataset.p
mmpose/mmpose/datasets/datasets/top_down/topdown_h36m_dataset.py
mmpose/mmpose/datasets/datasets/top_down/topdown_jhmdb_dataset.py
mmpose/mmpose/datasets/datasets/top_down/topdown_mhp_dataset.py
mmpose/mmpose/datasets/datasets/top_down/topdown_mpii_trb_dataset.py
mmpose/mmpose/datasets/datasets/top_down/topdown_ochuman_dataset.py
mmpose/mmpose/datasets/datasets/top_down/topdown_posetrack18_dataset.py

```