### PR TITLE
nonsquare input shape for bottom_up

### DIFF
--- a/mmpose/apis/inference.py
+++ b/mmpose/apis/inference.py
@@ -526,7 +526,7 @@ def inference_bottom_up_pose_model(model,
         'img_or_path': img_or_path,
         'dataset': dataset_name,
         'ann_info': {
-            'image_size': cfg.data_cfg['image_size'],
+            'image_size': np.array(cfg.data_cfg['image_size']),
             'num_joints': cfg.data_cfg['num_joints'],
             'flip_index': flip_index,
         }

--- a/mmpose/datasets/pipelines/bottom_up_transform.py
+++ b/mmpose/datasets/pipelines/bottom_up_transform.py
@@ -22,7 +22,7 @@ def _get_multi_scale_size(image,
 
     Args:
         image: Input image.
-        input_size (np.ndarray[2): Size of the image input.
+        input_size (np.ndarray[2]): Size (w, h) of the image input.
         current_scale (float): Scale factor.
         min_scale (float): Minimal scale.
         use_udp (bool): To use unbiased data processing.
@@ -76,14 +76,14 @@ def _resize_align_multi_scale(image, input_size, current_scale, min_scale):
 
     Args:
         image: Input image
-        input_size (np.ndarray[2]): Size of the image input
+        input_size (np.ndarray[2]): Size (w, h) of the image input
         current_scale (float): Current scale
         min_scale (float): Minimal scale
 
     Returns:
         tuple: A tuple containing image info.
 
-        - image_resized (tuple): size of resize image
+        - image_resized (np.ndarray): resized image
         - center (np.ndarray): center of image
         - scale (np.ndarray): scale
     """
@@ -102,14 +102,14 @@ def _resize_align_multi_scale_udp(image, input_size, current_scale, min_scale):
 
     Args:
         image: Input image
-        input_size (np.ndarray[2]): Size of the image input
+        input_size (np.ndarray[2]): Size (w, h) of the image input
         current_scale (float): Current scale
         min_scale (float): Minimal scale
 
     Returns:
         tuple: A tuple containing image info.
 
-        - image_resized (tuple): size of resize image
+        - image_resized (np.ndarray): resized image
         - center (np.ndarray): center of image
         - scale (np.ndarray): scale
     """
@@ -136,7 +136,7 @@ class HeatmapGenerator:
 
     Args:
         num_joints (int): Number of keypoints
-        output_size (np.ndarray): Size of feature map
+        output_size (np.ndarray): Size (w, h) of feature map
         sigma (int): Sigma of the heatmaps.
         use_udp (bool): To use unbiased data processing.
             Paper ref: Huang et al. The Devil is in the Details: Delving into
@@ -217,7 +217,7 @@ class JointsEncoder:
     Args:
         max_num_people(int): Max number of people in an image
         num_joints(int): Number of keypoints
-        output_size(np.ndarray): Size of feature map
+        output_size(np.ndarray): Size (w, h) of feature map
         tag_per_joint(bool):  Option to use one tag map per joint.
     """
 
@@ -269,7 +269,7 @@ class PAFGenerator:
     """Generate part affinity fields.
 
     Args:
-        output_size (np.ndarray): Size of feature map.
+        output_size (np.ndarray): Size (w, h) of feature map.
         limb_width (int): Limb width of part affinity fields.
         skeleton (list[list]): connections of joints.
     """

--- a/mmpose/datasets/pipelines/bottom_up_transform.py
+++ b/mmpose/datasets/pipelines/bottom_up_transform.py
@@ -402,7 +402,6 @@ class BottomUpRandomAffine:
         scale_factor (float): Scaling to [1-scale_factor, 1+scale_factor]
         scale_type: wrt ``long`` or ``short`` length of the image.
         trans_factor: Translation factor.
-        scale_aware_sigma: Option to use scale-aware sigma
         use_udp (bool): To use unbiased data processing.
             Paper ref: Huang et al. The Devil is in the Details: Delving into
             Unbiased Data Processing for Human Pose Estimation (CVPR 2020).

--- a/mmpose/datasets/pipelines/bottom_up_transform.py
+++ b/mmpose/datasets/pipelines/bottom_up_transform.py
@@ -22,7 +22,7 @@ def _get_multi_scale_size(image,
 
     Args:
         image: Input image.
-        input_size (np.array[2): Size of the image input.
+        input_size (np.ndarray[2): Size of the image input.
         current_scale (float): Scale factor.
         min_scale (float): Minimal scale.
         use_udp (bool): To use unbiased data processing.
@@ -76,7 +76,7 @@ def _resize_align_multi_scale(image, input_size, current_scale, min_scale):
 
     Args:
         image: Input image
-        input_size (np.array[2]): Size of the image input
+        input_size (np.ndarray[2]): Size of the image input
         current_scale (float): Current scale
         min_scale (float): Minimal scale
 
@@ -102,7 +102,7 @@ def _resize_align_multi_scale_udp(image, input_size, current_scale, min_scale):
 
     Args:
         image: Input image
-        input_size (np.array[2]): Size of the image input
+        input_size (np.ndarray[2]): Size of the image input
         current_scale (float): Current scale
         min_scale (float): Minimal scale
 
@@ -136,7 +136,7 @@ class HeatmapGenerator:
 
     Args:
         num_joints (int): Number of keypoints
-        output_size (np.array): Size of feature map
+        output_size (np.ndarray): Size of feature map
         sigma (int): Sigma of the heatmaps.
         use_udp (bool): To use unbiased data processing.
             Paper ref: Huang et al. The Devil is in the Details: Delving into
@@ -144,7 +144,8 @@ class HeatmapGenerator:
     """
 
     def __init__(self, output_size, num_joints, sigma=-1, use_udp=False):
-        assert isinstance(output_size, np.ndarray)
+        if not isinstance(output_size, np.ndarray):
+            output_size = np.array(output_size)
         if output_size.size > 1:
             assert len(output_size) == 2
             self.output_size = output_size
@@ -216,14 +217,15 @@ class JointsEncoder:
     Args:
         max_num_people(int): Max number of people in an image
         num_joints(int): Number of keypoints
-        output_size(np.array): Size of feature map
+        output_size(np.ndarray): Size of feature map
         tag_per_joint(bool):  Option to use one tag map per joint.
     """
 
     def __init__(self, max_num_people, num_joints, output_size, tag_per_joint):
         self.max_num_people = max_num_people
         self.num_joints = num_joints
-        assert isinstance(output_size, np.ndarray)
+        if not isinstance(output_size, np.ndarray):
+            output_size = np.array(output_size)
         if output_size.size > 1:
             assert len(output_size) == 2
             self.output_size = output_size
@@ -267,13 +269,14 @@ class PAFGenerator:
     """Generate part affinity fields.
 
     Args:
-        output_size (np.array): Size of feature map.
+        output_size (np.ndarray): Size of feature map.
         limb_width (int): Limb width of part affinity fields.
         skeleton (list[list]): connections of joints.
     """
 
     def __init__(self, output_size, limb_width, skeleton):
-        assert isinstance(output_size, np.ndarray)
+        if not isinstance(output_size, np.ndarray):
+            output_size = np.array(output_size)
         if output_size.size > 1:
             assert len(output_size) == 2
             self.output_size = output_size
@@ -379,7 +382,8 @@ class BottomUpRandomFlip:
         if np.random.random() < self.flip_prob:
             image = image[:, ::-1].copy() - np.zeros_like(image)
             for i, _output_size in enumerate(self.output_size):
-                assert isinstance(_output_size, np.ndarray)
+                if not isinstance(_output_size, np.ndarray):
+                    _output_size = np.array(_output_size)
                 if _output_size.size > 1:
                     assert len(_output_size) == 2
                 else:
@@ -448,7 +452,8 @@ class BottomUpRandomAffine:
             'joints']
 
         self.input_size = results['ann_info']['image_size']
-        assert isinstance(self.input_size, np.ndarray)
+        if not isinstance(self.input_size, np.ndarray):
+            self.input_size = np.array(self.input_size)
         if self.input_size.size > 1:
             assert len(self.input_size) == 2
         else:
@@ -484,7 +489,8 @@ class BottomUpRandomAffine:
             center[1] += dy
         if self.use_udp:
             for i, _output_size in enumerate(self.output_size):
-                assert isinstance(_output_size, np.ndarray)
+                if not isinstance(_output_size, np.ndarray):
+                    _output_size = np.array(_output_size)
                 if _output_size.size > 1:
                     assert len(_output_size) == 2
                 else:
@@ -521,7 +527,8 @@ class BottomUpRandomAffine:
                 flags=cv2.INTER_LINEAR)
         else:
             for i, _output_size in enumerate(self.output_size):
-                assert isinstance(_output_size, np.ndarray)
+                if not isinstance(_output_size, np.ndarray):
+                    _output_size = np.array(_output_size)
                 if _output_size.size > 1:
                     assert len(_output_size) == 2
                 else:
@@ -534,7 +541,7 @@ class BottomUpRandomAffine:
                     output_size=_output_size)
                 mask[i] = cv2.warpAffine(
                     (mask[i] * 255).astype(np.uint8), mat_output,
-                    (_output_size[0], _output_size[1])) / 255
+                    (int(_output_size[0]), int(_output_size[1]))) / 255
                 mask[i] = (mask[i] > 0.5).astype(np.float32)
 
                 joints[i][:, :, 0:2] = \
@@ -718,7 +725,8 @@ class BottomUpGetImgSize:
     def __call__(self, results):
         """Get multi-scale image sizes for bottom-up."""
         input_size = results['ann_info']['image_size']
-        assert isinstance(input_size, np.ndarray)
+        if not isinstance(input_size, np.ndarray):
+            input_size = np.array(input_size)
         if input_size.size > 1:
             assert len(input_size) == 2
         else:
@@ -785,7 +793,8 @@ class BottomUpResizeAlign:
     def __call__(self, results):
         """Resize multi-scale size and align transform for bottom-up."""
         input_size = results['ann_info']['image_size']
-        assert isinstance(input_size, np.ndarray)
+        if not isinstance(input_size, np.ndarray):
+            input_size = np.array(input_size)
         if input_size.size > 1:
             assert len(input_size) == 2
         else:

--- a/mmpose/datasets/pipelines/bottom_up_transform.py
+++ b/mmpose/datasets/pipelines/bottom_up_transform.py
@@ -431,16 +431,20 @@ class BottomUpRandomAffine:
             if self.scale_type == 'long':
                 w_pad = h / h_resized * w_resized
                 h_pad = h
-            else:
+            elif self.scale_type == 'short':
                 w_pad = w
                 h_pad = w / w_resized * h_resized
+            else:
+                raise ValueError(f'Unknown scale type: {self.scale_type}')
         else:
             if self.scale_type == 'long':
                 w_pad = w
                 h_pad = w / w_resized * h_resized
-            else:
+            elif self.scale_type == 'short':
                 w_pad = h / h_resized * w_resized
                 h_pad = h
+            else:
+                raise ValueError(f'Unknown scale type: {self.scale_type}')
 
         scale = np.array([w_pad, h_pad], dtype=np.float32)
 

--- a/mmpose/datasets/pipelines/bottom_up_transform.py
+++ b/mmpose/datasets/pipelines/bottom_up_transform.py
@@ -22,7 +22,7 @@ def _get_multi_scale_size(image,
 
     Args:
         image: Input image.
-        input_size (int): Size of the image input.
+        input_size (np.array[2): Size of the image input.
         current_scale (float): Scale factor.
         min_scale (float): Minimal scale.
         use_udp (bool): To use unbiased data processing.
@@ -36,14 +36,16 @@ def _get_multi_scale_size(image,
         - center (np.ndarray)image center
         - scale (np.ndarray): scales wrt width/height
     """
+    assert len(input_size) == 2
     h, w, _ = image.shape
 
     # calculate the size for min_scale
-    min_input_size = _ceil_to_multiples_of(min_scale * input_size, 64)
+    min_input_w = _ceil_to_multiples_of(min_scale * input_size[0], 64)
+    min_input_h = _ceil_to_multiples_of(min_scale * input_size[1], 64)
     if w < h:
-        w_resized = int(min_input_size * current_scale / min_scale)
+        w_resized = int(min_input_w * current_scale / min_scale)
         h_resized = int(
-            _ceil_to_multiples_of(min_input_size / w * h, 64) * current_scale /
+            _ceil_to_multiples_of(min_input_w / w * h, 64) * current_scale /
             min_scale)
         if use_udp:
             scale_w = w - 1.0
@@ -52,9 +54,9 @@ def _get_multi_scale_size(image,
             scale_w = w / 200.0
             scale_h = h_resized / w_resized * w / 200.0
     else:
-        h_resized = int(min_input_size * current_scale / min_scale)
+        h_resized = int(min_input_h * current_scale / min_scale)
         w_resized = int(
-            _ceil_to_multiples_of(min_input_size / h * w, 64) * current_scale /
+            _ceil_to_multiples_of(min_input_h / h * w, 64) * current_scale /
             min_scale)
         if use_udp:
             scale_h = h - 1.0
@@ -74,7 +76,7 @@ def _resize_align_multi_scale(image, input_size, current_scale, min_scale):
 
     Args:
         image: Input image
-        input_size (int): Size of the image input
+        input_size (np.array[2]): Size of the image input
         current_scale (float): Current scale
         min_scale (float): Minimal scale
 
@@ -85,6 +87,7 @@ def _resize_align_multi_scale(image, input_size, current_scale, min_scale):
         - center (np.ndarray): center of image
         - scale (np.ndarray): scale
     """
+    assert len(input_size) == 2
     size_resized, center, scale = _get_multi_scale_size(
         image, input_size, current_scale, min_scale)
 
@@ -99,7 +102,7 @@ def _resize_align_multi_scale_udp(image, input_size, current_scale, min_scale):
 
     Args:
         image: Input image
-        input_size (int): Size of the image input
+        input_size (np.array[2]): Size of the image input
         current_scale (float): Current scale
         min_scale (float): Minimal scale
 
@@ -110,6 +113,7 @@ def _resize_align_multi_scale_udp(image, input_size, current_scale, min_scale):
         - center (np.ndarray): center of image
         - scale (np.ndarray): scale
     """
+    assert len(input_size) == 2
     size_resized, _, _ = _get_multi_scale_size(image, input_size,
                                                current_scale, min_scale, True)
 
@@ -132,7 +136,7 @@ class HeatmapGenerator:
 
     Args:
         num_joints (int): Number of keypoints
-        output_size (int): Size of feature map
+        output_size (np.array): Size of feature map
         sigma (int): Sigma of the heatmaps.
         use_udp (bool): To use unbiased data processing.
             Paper ref: Huang et al. The Devil is in the Details: Delving into
@@ -140,10 +144,16 @@ class HeatmapGenerator:
     """
 
     def __init__(self, output_size, num_joints, sigma=-1, use_udp=False):
-        self.output_size = output_size
+        assert isinstance(output_size, np.ndarray)
+        if output_size.size > 1:
+            assert len(output_size) == 2
+            self.output_size = output_size
+        else:
+            self.output_size = np.array([output_size, output_size],
+                                        dtype=np.int)
         self.num_joints = num_joints
         if sigma < 0:
-            sigma = self.output_size / 64
+            sigma = self.output_size.prod()**0.5 / 64
         self.sigma = sigma
         size = 6 * sigma + 3
         self.use_udp = use_udp
@@ -158,8 +168,9 @@ class HeatmapGenerator:
 
     def __call__(self, joints):
         """Generate heatmaps."""
-        hms = np.zeros((self.num_joints, self.output_size, self.output_size),
-                       dtype=np.float32)
+        hms = np.zeros(
+            (self.num_joints, self.output_size[1], self.output_size[0]),
+            dtype=np.float32)
 
         sigma = self.sigma
         for p in joints:
@@ -167,7 +178,7 @@ class HeatmapGenerator:
                 if pt[2] > 0:
                     x, y = int(pt[0]), int(pt[1])
                     if x < 0 or y < 0 or \
-                       x >= self.output_size or y >= self.output_size:
+                       x >= self.output_size[0] or y >= self.output_size[1]:
                         continue
 
                     if self.use_udp:
@@ -183,11 +194,13 @@ class HeatmapGenerator:
                     br = int(np.round(x + 3 * sigma +
                                       2)), int(np.round(y + 3 * sigma + 2))
 
-                    c, d = max(0, -ul[0]), min(br[0], self.output_size) - ul[0]
-                    a, b = max(0, -ul[1]), min(br[1], self.output_size) - ul[1]
+                    c, d = max(0,
+                               -ul[0]), min(br[0], self.output_size[0]) - ul[0]
+                    a, b = max(0,
+                               -ul[1]), min(br[1], self.output_size[1]) - ul[1]
 
-                    cc, dd = max(0, ul[0]), min(br[0], self.output_size)
-                    aa, bb = max(0, ul[1]), min(br[1], self.output_size)
+                    cc, dd = max(0, ul[0]), min(br[0], self.output_size[0])
+                    aa, bb = max(0, ul[1]), min(br[1], self.output_size[1])
                     hms[idx, aa:bb,
                         cc:dd] = np.maximum(hms[idx, aa:bb, cc:dd], g[a:b,
                                                                       c:d])
@@ -203,14 +216,20 @@ class JointsEncoder:
     Args:
         max_num_people(int): Max number of people in an image
         num_joints(int): Number of keypoints
-        output_size(int): Size of feature map
+        output_size(np.array): Size of feature map
         tag_per_joint(bool):  Option to use one tag map per joint.
     """
 
     def __init__(self, max_num_people, num_joints, output_size, tag_per_joint):
         self.max_num_people = max_num_people
         self.num_joints = num_joints
-        self.output_size = output_size
+        assert isinstance(output_size, np.ndarray)
+        if output_size.size > 1:
+            assert len(output_size) == 2
+            self.output_size = output_size
+        else:
+            self.output_size = np.array([output_size, output_size],
+                                        dtype=np.int)
         self.tag_per_joint = tag_per_joint
 
     def __call__(self, joints):
@@ -228,18 +247,18 @@ class JointsEncoder:
         """
         visible_kpts = np.zeros((self.max_num_people, self.num_joints, 2),
                                 dtype=np.float32)
-        output_size = self.output_size
         for i in range(len(joints)):
             tot = 0
             for idx, pt in enumerate(joints[i]):
                 x, y = int(pt[0]), int(pt[1])
-                if (pt[2] > 0 and 0 <= y < self.output_size
-                        and 0 <= x < self.output_size):
+                if (pt[2] > 0 and 0 <= y < self.output_size[1]
+                        and 0 <= x < self.output_size[0]):
                     if self.tag_per_joint:
                         visible_kpts[i][tot] = \
-                            (idx * output_size**2 + y * output_size + x, 1)
+                            (idx * self.output_size.prod()
+                             + y * self.output_size[0] + x, 1)
                     else:
-                        visible_kpts[i][tot] = (y * output_size + x, 1)
+                        visible_kpts[i][tot] = (y * self.output_size[0] + x, 1)
                     tot += 1
         return visible_kpts
 
@@ -248,13 +267,19 @@ class PAFGenerator:
     """Generate part affinity fields.
 
     Args:
-        output_size (int): Size of feature map.
+        output_size (np.array): Size of feature map.
         limb_width (int): Limb width of part affinity fields.
         skeleton (list[list]): connections of joints.
     """
 
     def __init__(self, output_size, limb_width, skeleton):
-        self.output_size = output_size
+        assert isinstance(output_size, np.ndarray)
+        if output_size.size > 1:
+            assert len(output_size) == 2
+            self.output_size = output_size
+        else:
+            self.output_size = np.array([output_size, output_size],
+                                        dtype=np.int)
         self.limb_width = limb_width
         self.skeleton = skeleton
 
@@ -281,11 +306,11 @@ class PAFGenerator:
         min_x = max(np.floor(min(src[0], dst[0]) - self.limb_width), 0)
         max_x = min(
             np.ceil(max(src[0], dst[0]) + self.limb_width),
-            self.output_size - 1)
+            self.output_size[0] - 1)
         min_y = max(np.floor(min(src[1], dst[1]) - self.limb_width), 0)
         max_y = min(
             np.ceil(max(src[1], dst[1]) + self.limb_width),
-            self.output_size - 1)
+            self.output_size[1] - 1)
 
         range_x = list(range(int(min_x), int(max_x + 1), 1))
         range_y = list(range(int(min_y), int(max_y + 1), 1))
@@ -309,11 +334,11 @@ class PAFGenerator:
     def __call__(self, joints):
         """Generate the target part affinity fields."""
         pafs = np.zeros(
-            (len(self.skeleton) * 2, self.output_size, self.output_size),
+            (len(self.skeleton) * 2, self.output_size[1], self.output_size[0]),
             dtype=np.float32)
 
         for idx, sk in enumerate(self.skeleton):
-            count = np.zeros((self.output_size, self.output_size),
+            count = np.zeros((self.output_size[1], self.output_size[0]),
                              dtype=np.float32)
 
             for p in joints:
@@ -354,9 +379,15 @@ class BottomUpRandomFlip:
         if np.random.random() < self.flip_prob:
             image = image[:, ::-1].copy() - np.zeros_like(image)
             for i, _output_size in enumerate(self.output_size):
+                assert isinstance(_output_size, np.ndarray)
+                if _output_size.size > 1:
+                    assert len(_output_size) == 2
+                else:
+                    _output_size = np.array([_output_size, _output_size],
+                                            dtype=np.int)
                 mask[i] = mask[i][:, ::-1].copy()
                 joints[i] = joints[i][:, self.flip_index]
-                joints[i][:, :, 0] = _output_size - joints[i][:, :, 0] - 1
+                joints[i][:, :, 0] = _output_size[0] - joints[i][:, :, 0] - 1
         results['img'], results['mask'], results[
             'joints'] = image, mask, joints
         return results
@@ -390,32 +421,27 @@ class BottomUpRandomAffine:
         self.trans_factor = trans_factor
         self.use_udp = use_udp
 
-    @staticmethod
-    def _get_affine_matrix(center, scale, res, rot=0):
-        """Generate transformation matrix."""
-        h = scale
-        t = np.zeros((3, 3), dtype=np.float32)
-        t[0, 0] = float(res[1]) / h
-        t[1, 1] = float(res[0]) / h
-        t[0, 2] = res[1] * (-float(center[0]) / h + .5)
-        t[1, 2] = res[0] * (-float(center[1]) / h + .5)
-        t[2, 2] = 1
-        if rot != 0:
-            rot = -rot  # To match direction of rotation from cropping
-            rot_mat = np.zeros((3, 3), dtype=np.float32)
-            rot_rad = rot * np.pi / 180
-            sn, cs = np.sin(rot_rad), np.cos(rot_rad)
-            rot_mat[0, :2] = [cs, -sn]
-            rot_mat[1, :2] = [sn, cs]
-            rot_mat[2, 2] = 1
-            # Need to rotate around center
-            t_mat = np.eye(3)
-            t_mat[0, 2] = -res[1] / 2
-            t_mat[1, 2] = -res[0] / 2
-            t_inv = t_mat.copy()
-            t_inv[:2, 2] *= -1
-            t = np.dot(t_inv, np.dot(rot_mat, np.dot(t_mat, t)))
-        return t
+    def _get_scale(self, image_size, resized_size):
+        w, h = image_size
+        w_resized, h_resized = resized_size
+        if w / w_resized < h / h_resized:
+            if self.scale_type == 'long':
+                w_pad = h / h_resized * w_resized
+                h_pad = h
+            else:
+                w_pad = w
+                h_pad = w / w_resized * h_resized
+        else:
+            if self.scale_type == 'long':
+                w_pad = w
+                h_pad = w / w_resized * h_resized
+            else:
+                w_pad = h / h_resized * w_resized
+                h_pad = h
+
+        scale = np.array([w_pad, h_pad], dtype=np.float32)
+
+        return scale
 
     def __call__(self, results):
         """Perform data augmentation with random scaling & rotating."""
@@ -423,6 +449,11 @@ class BottomUpRandomAffine:
             'joints']
 
         self.input_size = results['ann_info']['image_size']
+        assert isinstance(self.input_size, np.ndarray)
+        if self.input_size.size > 1:
+            assert len(self.input_size) == 2
+        else:
+            self.input_size = [self.input_size, self.input_size]
         self.output_size = results['ann_info']['heatmap_size']
 
         assert isinstance(mask, list)
@@ -437,76 +468,94 @@ class BottomUpRandomAffine:
             center = np.array(((width - 1.0) / 2, (height - 1.0) / 2))
         else:
             center = np.array((width / 2, height / 2))
-        if self.scale_type == 'long':
-            scale = max(height, width) / 1.0
-        elif self.scale_type == 'short':
-            scale = min(height, width) / 1.0
-        else:
-            raise ValueError(f'Unknown scale type: {self.scale_type}')
+
+        img_scale = np.array([width, height], dtype=np.float32)
         aug_scale = np.random.random() * (self.max_scale - self.min_scale) \
             + self.min_scale
-        scale *= aug_scale
+        img_scale *= aug_scale
         aug_rot = (np.random.random() * 2 - 1) * self.max_rotation
 
         if self.trans_factor > 0:
-            dx = np.random.randint(-self.trans_factor * scale / 200.0,
-                                   self.trans_factor * scale / 200.0)
-            dy = np.random.randint(-self.trans_factor * scale / 200.0,
-                                   self.trans_factor * scale / 200.0)
+            dx = np.random.randint(-self.trans_factor * img_scale[0] / 200.0,
+                                   self.trans_factor * img_scale[0] / 200.0)
+            dy = np.random.randint(-self.trans_factor * img_scale[1] / 200.0,
+                                   self.trans_factor * img_scale[1] / 200.0)
 
             center[0] += dx
             center[1] += dy
         if self.use_udp:
             for i, _output_size in enumerate(self.output_size):
+                assert isinstance(_output_size, np.ndarray)
+                if _output_size.size > 1:
+                    assert len(_output_size) == 2
+                else:
+                    _output_size = [_output_size, _output_size]
+
+                scale = self._get_scale(img_scale, _output_size)
+
                 trans = get_warp_matrix(
                     theta=aug_rot,
                     size_input=center * 2.0,
                     size_dst=np.array(
-                        (_output_size, _output_size), dtype=np.float32) - 1.0,
-                    size_target=np.array((scale, scale), dtype=np.float32))
+                        (_output_size[0], _output_size[1]), dtype=np.float32) -
+                    1.0,
+                    size_target=scale)
                 mask[i] = cv2.warpAffine(
                     (mask[i] * 255).astype(np.uint8),
-                    trans, (int(_output_size), int(_output_size)),
+                    trans, (int(_output_size[0]), int(_output_size[1])),
                     flags=cv2.INTER_LINEAR) / 255
                 mask[i] = (mask[i] > 0.5).astype(np.float32)
                 joints[i][:, :, 0:2] = \
                     warp_affine_joints(joints[i][:, :, 0:2].copy(), trans)
                 if results['ann_info']['scale_aware_sigma']:
                     joints[i][:, :, 3] = joints[i][:, :, 3] / aug_scale
+            scale = self._get_scale(img_scale, self.input_size)
             mat_input = get_warp_matrix(
                 theta=aug_rot,
                 size_input=center * 2.0,
-                size_dst=np.array(
-                    (self.input_size, self.input_size), dtype=np.float32) -
-                1.0,
-                size_target=np.array((scale, scale), dtype=np.float32))
+                size_dst=np.array((self.input_size[0], self.input_size[1]),
+                                  dtype=np.float32) - 1.0,
+                size_target=scale)
             image = cv2.warpAffine(
                 image,
-                mat_input, (int(self.input_size), int(self.input_size)),
+                mat_input, (int(self.input_size[0]), int(self.input_size[1])),
                 flags=cv2.INTER_LINEAR)
         else:
             for i, _output_size in enumerate(self.output_size):
-                mat_output = self._get_affine_matrix(center, scale,
-                                                     (_output_size,
-                                                      _output_size),
-                                                     aug_rot)[:2]
+                assert isinstance(_output_size, np.ndarray)
+                if _output_size.size > 1:
+                    assert len(_output_size) == 2
+                else:
+                    _output_size = [_output_size, _output_size]
+                scale = self._get_scale(img_scale, _output_size)
+                mat_output = get_affine_transform(
+                    center=center,
+                    scale=scale / 200.0,
+                    rot=aug_rot,
+                    output_size=_output_size)
                 mask[i] = cv2.warpAffine(
                     (mask[i] * 255).astype(np.uint8), mat_output,
-                    (_output_size, _output_size)) / 255
+                    (_output_size[0], _output_size[1])) / 255
                 mask[i] = (mask[i] > 0.5).astype(np.float32)
 
                 joints[i][:, :, 0:2] = \
                     warp_affine_joints(joints[i][:, :, 0:2], mat_output)
                 if results['ann_info']['scale_aware_sigma']:
                     joints[i][:, :, 3] = joints[i][:, :, 3] / aug_scale
-            mat_input = self._get_affine_matrix(center, scale,
-                                                (self.input_size,
-                                                 self.input_size), aug_rot)[:2]
-            image = cv2.warpAffine(image, mat_input, (self.input_size.item(),
-                                                      self.input_size.item()))
+
+            scale = self._get_scale(img_scale, self.input_size)
+            mat_input = get_affine_transform(
+                center=center,
+                scale=scale / 200.0,
+                rot=aug_rot,
+                output_size=self.input_size)
+            image = cv2.warpAffine(image, mat_input, (int(
+                self.input_size[0]), int(self.input_size[1])))
 
         results['img'], results['mask'], results[
             'joints'] = image, mask, joints
+
+        results['center'], results['scale'] = center, scale
 
         return results
 
@@ -670,17 +719,22 @@ class BottomUpGetImgSize:
     def __call__(self, results):
         """Get multi-scale image sizes for bottom-up."""
         input_size = results['ann_info']['image_size']
+        assert isinstance(input_size, np.ndarray)
+        if input_size.size > 1:
+            assert len(input_size) == 2
+        else:
+            input_size = np.array([input_size, input_size], dtype=np.int)
         img = results['img']
 
         h, w, _ = img.shape
 
         # calculate the size for min_scale
-        min_input_size = _ceil_to_multiples_of(self.min_scale * input_size, 64)
+        min_input_w = _ceil_to_multiples_of(self.min_scale * input_size[0], 64)
+        min_input_h = _ceil_to_multiples_of(self.min_scale * input_size[1], 64)
         if w < h:
-            w_resized = int(min_input_size * self.current_scale /
-                            self.min_scale)
+            w_resized = int(min_input_w * self.current_scale / self.min_scale)
             h_resized = int(
-                _ceil_to_multiples_of(min_input_size / w * h, 64) *
+                _ceil_to_multiples_of(min_input_w / w * h, 64) *
                 self.current_scale / self.min_scale)
             if self.use_udp:
                 scale_w = w - 1.0
@@ -689,10 +743,9 @@ class BottomUpGetImgSize:
                 scale_w = w / 200.0
                 scale_h = h_resized / w_resized * w / 200.0
         else:
-            h_resized = int(min_input_size * self.current_scale /
-                            self.min_scale)
+            h_resized = int(min_input_h * self.current_scale / self.min_scale)
             w_resized = int(
-                _ceil_to_multiples_of(min_input_size / h * w, 64) *
+                _ceil_to_multiples_of(min_input_h / h * w, 64) *
                 self.current_scale / self.min_scale)
             if self.use_udp:
                 scale_h = h - 1.0
@@ -733,6 +786,11 @@ class BottomUpResizeAlign:
     def __call__(self, results):
         """Resize multi-scale size and align transform for bottom-up."""
         input_size = results['ann_info']['image_size']
+        assert isinstance(input_size, np.ndarray)
+        if input_size.size > 1:
+            assert len(input_size) == 2
+        else:
+            input_size = np.array([input_size, input_size], dtype=np.int)
         test_scale_factor = results['ann_info']['test_scale_factor']
         aug_data = []
 

--- a/tests/test_pipelines/test_bottom_up_pipelines.py
+++ b/tests/test_pipelines/test_bottom_up_pipelines.py
@@ -93,8 +93,8 @@ def test_bottomup_pipeline():
         1.5
     ],
                                          dtype=np.float32).reshape((17, 1))
-    ann_info['image_size'] = np.array(512)
-    ann_info['heatmap_size'] = np.array([128, 256])
+    ann_info['image_size'] = np.array([384, 512])
+    ann_info['heatmap_size'] = np.array([[96, 128], [192, 256]])
     ann_info['num_joints'] = 17
     ann_info['num_scales'] = 2
     ann_info['scale_aware_sigma'] = False
@@ -158,12 +158,12 @@ def test_bottomup_pipeline():
     # test TopDownAffine
     random_affine_transform = BottomUpRandomAffine(30, [0.75, 1.5], 'short', 0)
     results_affine_transform = random_affine_transform(copy.deepcopy(results))
-    assert results_affine_transform['img'].shape == (512, 512, 3)
+    assert results_affine_transform['img'].shape == (512, 384, 3)
 
     random_affine_transform = BottomUpRandomAffine(30, [0.75, 1.5], 'short',
                                                    40)
     results_affine_transform = random_affine_transform(copy.deepcopy(results))
-    assert results_affine_transform['img'].shape == (512, 512, 3)
+    assert results_affine_transform['img'].shape == (512, 384, 3)
 
     results_copy = copy.deepcopy(results)
     results_copy['ann_info']['scale_aware_sigma'] = True
@@ -171,7 +171,7 @@ def test_bottomup_pipeline():
     results_copy['joints'] = \
         [joints.copy() for _ in range(results_copy['ann_info']['num_scales'])]
     results_affine_transform = random_affine_transform(results_copy)
-    assert results_affine_transform['img'].shape == (512, 512, 3)
+    assert results_affine_transform['img'].shape == (512, 384, 3)
 
     results_copy = copy.deepcopy(results)
     results_copy['mask'] = mask_list[0]
@@ -199,7 +199,7 @@ def test_bottomup_pipeline():
 
     random_affine_transform = BottomUpRandomAffine(30, [0.75, 1.5], 'long', 40)
     results_affine_transform = random_affine_transform(copy.deepcopy(results))
-    assert results_affine_transform['img'].shape == (512, 512, 3)
+    assert results_affine_transform['img'].shape == (512, 384, 3)
 
     with pytest.raises(ValueError):
         random_affine_transform = BottomUpRandomAffine(30, [0.75, 1.5],
@@ -241,7 +241,7 @@ def test_bottomup_pipeline():
     results_copy = copy.deepcopy(results)
     results_copy['img'] = np.random.rand(640, 425, 3)
     results_get_multi_scale_size = get_multi_scale_size(results_copy)
-    assert results_get_multi_scale_size['ann_info']['base_size'][0] == 512
+    assert results_get_multi_scale_size['ann_info']['base_size'][0] == 384
 
 
 def test_BottomUpGenerateHeatmapTarget():

--- a/tests/test_pipelines/test_bottom_up_pipelines.py
+++ b/tests/test_pipelines/test_bottom_up_pipelines.py
@@ -237,11 +237,118 @@ def test_bottomup_pipeline():
     results_resize_align_multi_scale = resize_align_multi_scale(results_copy)
     assert 'aug_data' in results_resize_align_multi_scale['ann_info']
 
-    # test BottomUpGetImgSize when W < H
+    # test when W < H
+    ann_info['image_size'] = np.array([512, 384])
+    ann_info['heatmap_size'] = np.array([[128, 96], [256, 192]])
+    results = {}
+    results['dataset'] = 'coco'
+    results['image_file'] = osp.join(data_prefix, '000000000785.jpg')
+    results['mask'] = mask_list
+    results['joints'] = joints_list
+    results['ann_info'] = ann_info
+    results['img'] = np.random.rand(640, 425, 3)
+
+    # test HorizontalFlip
+    random_horizontal_flip = BottomUpRandomFlip(flip_prob=1.)
+    results_horizontal_flip = random_horizontal_flip(copy.deepcopy(results))
+    assert _check_flip(results['img'], results_horizontal_flip['img'])
+
+    random_horizontal_flip = BottomUpRandomFlip(flip_prob=0.)
+    results_horizontal_flip = random_horizontal_flip(copy.deepcopy(results))
+    assert (results['img'] == results_horizontal_flip['img']).all()
+
     results_copy = copy.deepcopy(results)
-    results_copy['img'] = np.random.rand(640, 425, 3)
-    results_get_multi_scale_size = get_multi_scale_size(results_copy)
-    assert results_get_multi_scale_size['ann_info']['base_size'][0] == 384
+    results_copy['mask'] = mask_list[0]
+    with pytest.raises(AssertionError):
+        results_horizontal_flip = random_horizontal_flip(
+            copy.deepcopy(results_copy))
+
+    results_copy = copy.deepcopy(results)
+    results_copy['joints'] = joints_list[0]
+    with pytest.raises(AssertionError):
+        results_horizontal_flip = random_horizontal_flip(
+            copy.deepcopy(results_copy))
+
+    results_copy = copy.deepcopy(results)
+    results_copy['joints'] = joints_list[:1]
+    with pytest.raises(AssertionError):
+        results_horizontal_flip = random_horizontal_flip(
+            copy.deepcopy(results_copy))
+
+    results_copy = copy.deepcopy(results)
+    results_copy['mask'] = mask_list[:1]
+    with pytest.raises(AssertionError):
+        results_horizontal_flip = random_horizontal_flip(
+            copy.deepcopy(results_copy))
+
+    # test TopDownAffine
+    random_affine_transform = BottomUpRandomAffine(30, [0.75, 1.5], 'short', 0)
+    results_affine_transform = random_affine_transform(copy.deepcopy(results))
+    assert results_affine_transform['img'].shape == (384, 512, 3)
+
+    random_affine_transform = BottomUpRandomAffine(30, [0.75, 1.5], 'short',
+                                                   40)
+    results_affine_transform = random_affine_transform(copy.deepcopy(results))
+    assert results_affine_transform['img'].shape == (384, 512, 3)
+
+    results_copy = copy.deepcopy(results)
+    results_copy['ann_info']['scale_aware_sigma'] = True
+    joints = _get_joints(anno, results_copy['ann_info'], False)
+    results_copy['joints'] = \
+        [joints.copy() for _ in range(results_copy['ann_info']['num_scales'])]
+    results_affine_transform = random_affine_transform(results_copy)
+    assert results_affine_transform['img'].shape == (384, 512, 3)
+
+    results_copy = copy.deepcopy(results)
+    results_copy['mask'] = mask_list[0]
+    with pytest.raises(AssertionError):
+        results_horizontal_flip = random_affine_transform(
+            copy.deepcopy(results_copy))
+
+    results_copy = copy.deepcopy(results)
+    results_copy['joints'] = joints_list[0]
+    with pytest.raises(AssertionError):
+        results_horizontal_flip = random_affine_transform(
+            copy.deepcopy(results_copy))
+
+    results_copy = copy.deepcopy(results)
+    results_copy['joints'] = joints_list[:1]
+    with pytest.raises(AssertionError):
+        results_horizontal_flip = random_affine_transform(
+            copy.deepcopy(results_copy))
+
+    results_copy = copy.deepcopy(results)
+    results_copy['mask'] = mask_list[:1]
+    with pytest.raises(AssertionError):
+        results_horizontal_flip = random_affine_transform(
+            copy.deepcopy(results_copy))
+
+    random_affine_transform = BottomUpRandomAffine(30, [0.75, 1.5], 'long', 40)
+    results_affine_transform = random_affine_transform(copy.deepcopy(results))
+    assert results_affine_transform['img'].shape == (384, 512, 3)
+
+    with pytest.raises(ValueError):
+        random_affine_transform = BottomUpRandomAffine(30, [0.75, 1.5],
+                                                       'short-long', 40)
+        results_affine_transform = random_affine_transform(
+            copy.deepcopy(results))
+
+    # test BottomUpGenerateTarget
+    generate_multi_target = BottomUpGenerateTarget(2, 30)
+    results_generate_multi_target = generate_multi_target(
+        copy.deepcopy(results))
+    assert 'targets' in results_generate_multi_target
+    assert len(results_generate_multi_target['targets']
+               ) == results['ann_info']['num_scales']
+
+    # test BottomUpGetImgSize when W < H
+    get_multi_scale_size = BottomUpGetImgSize([1])
+    results_get_multi_scale_size = get_multi_scale_size(copy.deepcopy(results))
+    assert 'test_scale_factor' in results_get_multi_scale_size['ann_info']
+    assert 'base_size' in results_get_multi_scale_size['ann_info']
+    assert 'center' in results_get_multi_scale_size['ann_info']
+    assert 'scale' in results_get_multi_scale_size['ann_info']
+    assert results_get_multi_scale_size['ann_info']['base_size'][0] == 512
 
 
 def test_BottomUpGenerateHeatmapTarget():


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

The current version requires the input of a bottom-up model to have a square shape (w=h). This pr is to enable the pipeline of bottom-up approaches to take inputs with any w-h ratio.

## Modification

mmpose/datasets/pipelines/bottom_up_transform.py

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
