### PR TITLE
[Fix] Update pose tracking demo to be compatible with latest mmtrakcing

### DIFF
--- a/demo/mmtracking_cfg/deepsort_faster-rcnn_fpn_4e_mot17-private-half.py
+++ b/demo/mmtracking_cfg/deepsort_faster-rcnn_fpn_4e_mot17-private-half.py
@@ -1,0 +1,321 @@
+model = dict(
+    detector=dict(
+        type='FasterRCNN',
+        backbone=dict(
+            type='ResNet',
+            depth=50,
+            num_stages=4,
+            out_indices=(0, 1, 2, 3),
+            frozen_stages=1,
+            norm_cfg=dict(type='BN', requires_grad=True),
+            norm_eval=True,
+            style='pytorch',
+            init_cfg=dict(
+                type='Pretrained', checkpoint='torchvision://resnet50')),
+        neck=dict(
+            type='FPN',
+            in_channels=[256, 512, 1024, 2048],
+            out_channels=256,
+            num_outs=5),
+        rpn_head=dict(
+            type='RPNHead',
+            in_channels=256,
+            feat_channels=256,
+            anchor_generator=dict(
+                type='AnchorGenerator',
+                scales=[8],
+                ratios=[0.5, 1.0, 2.0],
+                strides=[4, 8, 16, 32, 64]),
+            bbox_coder=dict(
+                type='DeltaXYWHBBoxCoder',
+                target_means=[0.0, 0.0, 0.0, 0.0],
+                target_stds=[1.0, 1.0, 1.0, 1.0],
+                clip_border=False),
+            loss_cls=dict(
+                type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
+            loss_bbox=dict(
+                type='SmoothL1Loss', beta=0.1111111111111111,
+                loss_weight=1.0)),
+        roi_head=dict(
+            type='StandardRoIHead',
+            bbox_roi_extractor=dict(
+                type='SingleRoIExtractor',
+                roi_layer=dict(
+                    type='RoIAlign', output_size=7, sampling_ratio=0),
+                out_channels=256,
+                featmap_strides=[4, 8, 16, 32]),
+            bbox_head=dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=1,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0.0, 0.0, 0.0, 0.0],
+                    target_stds=[0.1, 0.1, 0.2, 0.2],
+                    clip_border=False),
+                reg_class_agnostic=False,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', loss_weight=1.0))),
+        train_cfg=dict(
+            rpn=dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.7,
+                    neg_iou_thr=0.3,
+                    min_pos_iou=0.3,
+                    match_low_quality=True,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=256,
+                    pos_fraction=0.5,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=False),
+                allowed_border=-1,
+                pos_weight=-1,
+                debug=False),
+            rpn_proposal=dict(
+                nms_pre=2000,
+                max_per_img=1000,
+                nms=dict(type='nms', iou_threshold=0.7),
+                min_bbox_size=0),
+            rcnn=dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.5,
+                    neg_iou_thr=0.5,
+                    min_pos_iou=0.5,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False)),
+        test_cfg=dict(
+            rpn=dict(
+                nms_pre=1000,
+                max_per_img=1000,
+                nms=dict(type='nms', iou_threshold=0.7),
+                min_bbox_size=0),
+            rcnn=dict(
+                score_thr=0.05,
+                nms=dict(type='nms', iou_threshold=0.5),
+                max_per_img=100)),
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='https://download.openmmlab.com/mmtracking/'
+            'mot/faster_rcnn/faster-rcnn_r50_fpn_4e_mot17-half-64ee2ed4.pth')),
+    type='DeepSORT',
+    motion=dict(type='KalmanFilter', center_only=False),
+    reid=dict(
+        type='BaseReID',
+        backbone=dict(
+            type='ResNet',
+            depth=50,
+            num_stages=4,
+            out_indices=(3, ),
+            style='pytorch'),
+        neck=dict(type='GlobalAveragePooling', kernel_size=(8, 4), stride=1),
+        head=dict(
+            type='LinearReIDHead',
+            num_fcs=1,
+            in_channels=2048,
+            fc_channels=1024,
+            out_channels=128,
+            num_classes=380,
+            loss=dict(type='CrossEntropyLoss', loss_weight=1.0),
+            loss_pairwise=dict(
+                type='TripletLoss', margin=0.3, loss_weight=1.0),
+            norm_cfg=dict(type='BN1d'),
+            act_cfg=dict(type='ReLU')),
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='https://download.openmmlab.com/mmtracking/'
+            'mot/reid/tracktor_reid_r50_iter25245-a452f51f.pth')),
+    tracker=dict(
+        type='SortTracker',
+        obj_score_thr=0.5,
+        reid=dict(
+            num_samples=10,
+            img_scale=(256, 128),
+            img_norm_cfg=None,
+            match_score_thr=2.0),
+        match_iou_thr=0.5,
+        momentums=None,
+        num_tentatives=2,
+        num_frames_retain=100))
+dataset_type = 'MOTChallengeDataset'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+train_pipeline = [
+    dict(type='LoadMultiImagesFromFile', to_float32=True),
+    dict(type='SeqLoadAnnotations', with_bbox=True, with_track=True),
+    dict(
+        type='SeqResize',
+        img_scale=(1088, 1088),
+        share_params=True,
+        ratio_range=(0.8, 1.2),
+        keep_ratio=True,
+        bbox_clip_border=False),
+    dict(type='SeqPhotoMetricDistortion', share_params=True),
+    dict(
+        type='SeqRandomCrop',
+        share_params=False,
+        crop_size=(1088, 1088),
+        bbox_clip_border=False),
+    dict(type='SeqRandomFlip', share_params=True, flip_ratio=0.5),
+    dict(
+        type='SeqNormalize',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        to_rgb=True),
+    dict(type='SeqPad', size_divisor=32),
+    dict(type='MatchInstances', skip_nomatch=True),
+    dict(
+        type='VideoCollect',
+        keys=[
+            'img', 'gt_bboxes', 'gt_labels', 'gt_match_indices',
+            'gt_instance_ids'
+        ]),
+    dict(type='SeqDefaultFormatBundle', ref_prefix='ref')
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(1088, 1088),
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(
+                type='Normalize',
+                mean=[123.675, 116.28, 103.53],
+                std=[58.395, 57.12, 57.375],
+                to_rgb=True),
+            dict(type='Pad', size_divisor=32),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='VideoCollect', keys=['img'])
+        ])
+]
+data_root = 'data/MOT17/'
+data = dict(
+    samples_per_gpu=2,
+    workers_per_gpu=2,
+    train=dict(
+        type='MOTChallengeDataset',
+        visibility_thr=-1,
+        ann_file='data/MOT17/annotations/half-train_cocoformat.json',
+        img_prefix='data/MOT17/train',
+        ref_img_sampler=dict(
+            num_ref_imgs=1,
+            frame_range=10,
+            filter_key_img=True,
+            method='uniform'),
+        pipeline=[
+            dict(type='LoadMultiImagesFromFile', to_float32=True),
+            dict(type='SeqLoadAnnotations', with_bbox=True, with_track=True),
+            dict(
+                type='SeqResize',
+                img_scale=(1088, 1088),
+                share_params=True,
+                ratio_range=(0.8, 1.2),
+                keep_ratio=True,
+                bbox_clip_border=False),
+            dict(type='SeqPhotoMetricDistortion', share_params=True),
+            dict(
+                type='SeqRandomCrop',
+                share_params=False,
+                crop_size=(1088, 1088),
+                bbox_clip_border=False),
+            dict(type='SeqRandomFlip', share_params=True, flip_ratio=0.5),
+            dict(
+                type='SeqNormalize',
+                mean=[123.675, 116.28, 103.53],
+                std=[58.395, 57.12, 57.375],
+                to_rgb=True),
+            dict(type='SeqPad', size_divisor=32),
+            dict(type='MatchInstances', skip_nomatch=True),
+            dict(
+                type='VideoCollect',
+                keys=[
+                    'img', 'gt_bboxes', 'gt_labels', 'gt_match_indices',
+                    'gt_instance_ids'
+                ]),
+            dict(type='SeqDefaultFormatBundle', ref_prefix='ref')
+        ]),
+    val=dict(
+        type='MOTChallengeDataset',
+        ann_file='data/MOT17/annotations/half-val_cocoformat.json',
+        img_prefix='data/MOT17/train',
+        ref_img_sampler=None,
+        pipeline=[
+            dict(type='LoadImageFromFile'),
+            dict(
+                type='MultiScaleFlipAug',
+                img_scale=(1088, 1088),
+                flip=False,
+                transforms=[
+                    dict(type='Resize', keep_ratio=True),
+                    dict(type='RandomFlip'),
+                    dict(
+                        type='Normalize',
+                        mean=[123.675, 116.28, 103.53],
+                        std=[58.395, 57.12, 57.375],
+                        to_rgb=True),
+                    dict(type='Pad', size_divisor=32),
+                    dict(type='ImageToTensor', keys=['img']),
+                    dict(type='VideoCollect', keys=['img'])
+                ])
+        ]),
+    test=dict(
+        type='MOTChallengeDataset',
+        ann_file='data/MOT17/annotations/half-val_cocoformat.json',
+        img_prefix='data/MOT17/train',
+        ref_img_sampler=None,
+        pipeline=[
+            dict(type='LoadImageFromFile'),
+            dict(
+                type='MultiScaleFlipAug',
+                img_scale=(1088, 1088),
+                flip=False,
+                transforms=[
+                    dict(type='Resize', keep_ratio=True),
+                    dict(type='RandomFlip'),
+                    dict(
+                        type='Normalize',
+                        mean=[123.675, 116.28, 103.53],
+                        std=[58.395, 57.12, 57.375],
+                        to_rgb=True),
+                    dict(type='Pad', size_divisor=32),
+                    dict(type='ImageToTensor', keys=['img']),
+                    dict(type='VideoCollect', keys=['img'])
+                ])
+        ]))
+optimizer = dict(type='SGD', lr=0.02, momentum=0.9, weight_decay=0.0001)
+optimizer_config = dict(grad_clip=None)
+checkpoint_config = dict(interval=1)
+log_config = dict(interval=50, hooks=[dict(type='TextLoggerHook')])
+dist_params = dict(backend='nccl')
+log_level = 'INFO'
+load_from = None
+resume_from = None
+workflow = [('train', 1)]
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=100,
+    warmup_ratio=0.01,
+    step=[3])
+total_epochs = 4
+evaluation = dict(metric=['bbox', 'track'], interval=1)
+search_metrics = ['MOTA', 'IDF1', 'FN', 'FP', 'IDs', 'MT', 'ML']

--- a/demo/top_down_pose_tracking_demo_with_mmtracking.py
+++ b/demo/top_down_pose_tracking_demo_with_mmtracking.py
@@ -24,6 +24,8 @@ def process_mmtracking_results(mmtracking_results):
     :return: a list of tracked bounding boxes
     """
     person_results = []
+    # 'track_results' is changed to 'track_bboxes'
+    # in https://github.com/open-mmlab/mmtracking/pull/300
     if 'track_bboxes' in mmtracking_results:
         tracking_results = mmtracking_results['track_bboxes'][0]
     elif 'track_results' in mmtracking_results:

--- a/demo/top_down_pose_tracking_demo_with_mmtracking.py
+++ b/demo/top_down_pose_tracking_demo_with_mmtracking.py
@@ -24,7 +24,12 @@ def process_mmtracking_results(mmtracking_results):
     :return: a list of tracked bounding boxes
     """
     person_results = []
-    for track in mmtracking_results['track_bboxes'][0]:
+    if 'track_bboxes' in mmtracking_results:
+        tracking_results = mmtracking_results['track_bboxes'][0]
+    elif 'track_results' in mmtracking_results:
+        tracking_results = mmtracking_results['track_results'][0]
+
+    for track in tracking_results:
         person = {}
         person['track_id'] = int(track[0])
         person['bbox'] = track[1:]

--- a/demo/top_down_pose_tracking_demo_with_mmtracking.py
+++ b/demo/top_down_pose_tracking_demo_with_mmtracking.py
@@ -24,7 +24,7 @@ def process_mmtracking_results(mmtracking_results):
     :return: a list of tracked bounding boxes
     """
     person_results = []
-    for track in mmtracking_results['track_results'][0]:
+    for track in mmtracking_results['track_bboxes'][0]:
         person = {}
         person['track_id'] = int(track[0])
         person['bbox'] = track[1:]


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->
The result key of mmtracking has changed from `track_results` to `track_bboxes`.
This PR will update it and support demo with the recent mmtracking.

Also the config of another popular mot algorithm (deepsort) is added.

## Modification

<!-- Please briefly describe what modification is made in this PR. -->

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
