### PR TITLE
[Feature] Support file_client_args in LoadImageFromFile

### DIFF
--- a/mmpose/datasets/pipelines/loading.py
+++ b/mmpose/datasets/pipelines/loading.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import mmcv
+import numpy as np
 
 from ..builder import PIPELINES
 
@@ -8,38 +9,69 @@ from ..builder import PIPELINES
 class LoadImageFromFile:
     """Loading image(s) from file.
 
+    Required key is "image_file". Added key is "img".
+
     Args:
+        to_float32 (bool): Whether to convert the loaded image to a float32
+            numpy array. If set to False, the loaded image is an uint8 array.
+            Defaults to False.
         color_type (str): Flags specifying the color type of a loaded image,
           candidates are 'color', 'grayscale' and 'unchanged'.
         channel_order (str): Order of channel, candidates are 'bgr' and 'rgb'.
+        file_client_args (dict): Arguments to instantiate a FileClient.
+            See :class:`mmcv.fileio.FileClient` for details.
+            Defaults to ``dict(backend='disk')``.
     """
 
     def __init__(self,
                  to_float32=False,
                  color_type='color',
-                 channel_order='rgb'):
+                 channel_order='rgb',
+                 file_client_args=dict(backend='disk')):
         self.to_float32 = to_float32
         self.color_type = color_type
         self.channel_order = channel_order
+        self.file_client_args = file_client_args.copy()
+        self.file_client = None
 
     def __call__(self, results):
         """Loading image(s) from file."""
+        if self.file_client is None:
+            self.file_client = mmcv.FileClient(**self.file_client_args)
+
         image_file = results['image_file']
 
         if isinstance(image_file, (list, tuple)):
             imgs = []
             for image in image_file:
-                img = mmcv.imread(image, self.color_type, self.channel_order)
+                img_bytes = self.file_client.get(image)
+                img = mmcv.imfrombytes(
+                    img_bytes,
+                    flag=self.color_type,
+                    channel_order=self.channel_order)
+                if self.to_float32:
+                    img = img.astype(np.float32)
                 if img is None:
                     raise ValueError(f'Fail to read {image}')
                 imgs.append(img)
-
             results['img'] = imgs
         else:
-            img = mmcv.imread(image_file, self.color_type, self.channel_order)
-
+            img_bytes = self.file_client.get(image_file)
+            img = mmcv.imfrombytes(
+                img_bytes,
+                flag=self.color_type,
+                channel_order=self.channel_order)
+            if self.to_float32:
+                img = img.astype(np.float32)
             if img is None:
                 raise ValueError(f'Fail to read {image_file}')
             results['img'] = img
 
         return results
+
+    def __repr__(self):
+        repr_str = (f'{self.__class__.__name__}('
+                    f'to_float32={self.to_float32}, '
+                    f"color_type='{self.color_type}', "
+                    f'file_client_args={self.file_client_args})')
+        return repr_str


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->
Support file_client_args in LoadImageFromFile. Similar to this in mmdet:

https://github.com/open-mmlab/mmdetection/blame/0b94be76b89fcbbfd83ef2a1a67818b5948280d1/mmdet/datasets/pipelines/loading.py#L12

## Modification

<!-- Please briefly describe what modification is made in this PR. -->
LoadImageFromFile in loading.py


## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
