### PR TITLE
[Fix] Bug in post dark udp

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,12 +36,12 @@ If the contents here do not cover your issue, please create an issue using the [
 ## Data
 
 - **How to convert my 2d keypoint dataset to coco-type?**
-  
+
   You may refer to this conversion [tool](https://github.com/open-mmlab/mmpose/blob/master/tools/dataset/parse_macaquepose_dataset.py) to prepare your data.
   Here is an [example](https://github.com/open-mmlab/mmpose/blob/master/tests/data/macaque/test_macaque.json) of the coco-type json.
-  In the coco-type json, we need "categories", "annotations" and "images". "categories" contain some basic information of the dataset, e.g. class name and keypoint names. 
-  "images" contain image-level information. We need "id", "file_name", "height", "width". Others are optional. 
-  Note: (1) It is okay that "id"s are not continuous or not sorted (e.g. 1000, 40, 352, 333 ...). 
+  In the coco-type json, we need "categories", "annotations" and "images". "categories" contain some basic information of the dataset, e.g. class name and keypoint names.
+  "images" contain image-level information. We need "id", "file_name", "height", "width". Others are optional.
+  Note: (1) It is okay that "id"s are not continuous or not sorted (e.g. 1000, 40, 352, 333 ...).
 
   "annotations" contain instance-level information. We need "image_id", "id", "keypoints", "num_keypoints", "bbox", "iscrowd", "area", "category_id". Others are optional.
   Note: (1) "num_keypoints" means the number of visible keypoints. (2) By default, please set "iscrowd: 0". (3) "area" can be calculated using the bbox (area = w * h) (4) Simply set "category_id: 1". (5) The "image_id" in "annotations" should match the "id" in "images".

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,6 +35,17 @@ If the contents here do not cover your issue, please create an issue using the [
 
 ## Data
 
+- **How to convert my 2d keypoint dataset to coco-type?**
+  
+  You may refer to this conversion [tool](https://github.com/open-mmlab/mmpose/blob/master/tools/dataset/parse_macaquepose_dataset.py) to prepare your data.
+  Here is an [example](https://github.com/open-mmlab/mmpose/blob/master/tests/data/macaque/test_macaque.json) of the coco-type json.
+  In the coco-type json, we need "categories", "annotations" and "images". "categories" contain some basic information of the dataset, e.g. class name and keypoint names. 
+  "images" contain image-level information. We need "id", "file_name", "height", "width". Others are optional. 
+  Note: (1) It is okay that "id"s are not continuous or not sorted (e.g. 1000, 40, 352, 333 ...). 
+
+  "annotations" contain instance-level information. We need "image_id", "id", "keypoints", "num_keypoints", "bbox", "iscrowd", "area", "category_id". Others are optional.
+  Note: (1) "num_keypoints" means the number of visible keypoints. (2) By default, please set "iscrowd: 0". (3) "area" can be calculated using the bbox (area = w * h) (4) Simply set "category_id: 1". (5) The "image_id" in "annotations" should match the "id" in "images".
+
 - **What if my custom dataset does not have bounding box label?**
 
   We can estimate the bounding box of a person as the minimal box that tightly bounds all the keypoints.
@@ -92,6 +103,9 @@ If the contents here do not cover your issue, please create an issue using the [
 - **How to evaluate on MPII test dataset?**
   Since we do not have the ground-truth for test dataset, we cannot evaluate it 'locally'.
   If you would like to evaluate the performance on test set, you have to upload the pred.mat (which is generated during testing) to the official server via email, according to [the MPII guideline](http://human-pose.mpi-inf.mpg.de/#evaluation).
+
+- **For top-down 2d pose estimation, why predicted joint coordinates can be out of the bounding box (bbox)?**
+  We do not directly use the bbox to crop the image. bbox will be first transformed to center & scale, and the scale will be multiplied by a factor (1.25) to include some context. If the ratio of width/height is different from that of model input (possibly 192/256), we will adjust the bbox.
 
 ## Inference
 

--- a/mmpose/core/evaluation/top_down_eval.py
+++ b/mmpose/core/evaluation/top_down_eval.py
@@ -3,6 +3,7 @@ import warnings
 
 import cv2
 import numpy as np
+import math
 
 from mmpose.core.post_processing import transform_preds
 

--- a/mmpose/core/evaluation/top_down_eval.py
+++ b/mmpose/core/evaluation/top_down_eval.py
@@ -366,8 +366,22 @@ def post_dark_udp(coords, batch_heatmaps, kernel=3):
     np.log(batch_heatmaps, batch_heatmaps)
     batch_heatmaps = np.transpose(batch_heatmaps,
                                   (2, 3, 0, 1)).reshape(H, W, -1)
-    batch_heatmaps_pad = cv2.copyMakeBorder(
-        batch_heatmaps, 1, 1, 1, 1, borderType=cv2.BORDER_REFLECT)
+
+    # cv2.copyMakeBorder will report an error when input channel is greater than 512
+    batch_heatmaps_channel = batch_heatmaps.shape[2]
+    if batch_heatmaps_channel > 512:
+        total_group_number = math.ceil(batch_heatmaps_channel / 512)
+        splited_batch_heatmaps = []
+        for group_idx in range(total_group_number):
+            splited_batch_heatmap = batch_heatmaps[...,
+                                    group_idx * 512:min(batch_heatmaps_channel, (group_idx + 1) * 512)]
+            batch_heatmap_pad = cv2.copyMakeBorder(splited_batch_heatmap, 1, 1, 1, 1, borderType=cv2.BORDER_REFLECT)
+            splited_batch_heatmaps.append(batch_heatmap_pad)
+        batch_heatmaps_pad = np.concatenate(splited_batch_heatmaps, axis=2)
+    else:
+        batch_heatmaps_pad = cv2.copyMakeBorder(
+            batch_heatmaps, 1, 1, 1, 1, borderType=cv2.BORDER_REFLECT)
+
     batch_heatmaps_pad = np.transpose(
         batch_heatmaps_pad.reshape(H + 2, W + 2, B, K),
         (2, 3, 0, 1)).flatten()

--- a/mmpose/core/evaluation/top_down_eval.py
+++ b/mmpose/core/evaluation/top_down_eval.py
@@ -3,7 +3,6 @@ import warnings
 
 import cv2
 import numpy as np
-import math
 
 from mmpose.core.post_processing import transform_preds
 
@@ -371,12 +370,13 @@ def post_dark_udp(coords, batch_heatmaps, kernel=3):
     # cv2.copyMakeBorder will report an error when input dimension exceeds 512
     batch_heatmaps_channel = batch_heatmaps.shape[2]
     if batch_heatmaps_channel > 512:
-        total_group_number = math.ceil(batch_heatmaps_channel / 512)
+        total_group_number = int(np.ceil(batch_heatmaps_channel / 512))
         splited_batch_heatmaps = []
         for group_idx in range(total_group_number):
             splited_batch_heatmap = batch_heatmaps[...,
                                     group_idx * 512:min(batch_heatmaps_channel, (group_idx + 1) * 512)]
-            batch_heatmap_pad = cv2.copyMakeBorder(splited_batch_heatmap, 1, 1, 1, 1, borderType=cv2.BORDER_REFLECT)
+            batch_heatmap_pad = cv2.copyMakeBorder(
+                splited_batch_heatmap, 1, 1, 1, 1, borderType=cv2.BORDER_REFLECT)
             splited_batch_heatmaps.append(batch_heatmap_pad)
         batch_heatmaps_pad = np.concatenate(splited_batch_heatmaps, axis=2)
     else:

--- a/mmpose/core/evaluation/top_down_eval.py
+++ b/mmpose/core/evaluation/top_down_eval.py
@@ -368,7 +368,7 @@ def post_dark_udp(coords, batch_heatmaps, kernel=3):
     batch_heatmaps = np.transpose(batch_heatmaps,
                                   (2, 3, 0, 1)).reshape(H, W, -1)
 
-    # cv2.copyMakeBorder will report an error when input channel is greater than 512
+    # cv2.copyMakeBorder will report an error when input dimension exceeds 512
     batch_heatmaps_channel = batch_heatmaps.shape[2]
     if batch_heatmaps_channel > 512:
         total_group_number = math.ceil(batch_heatmaps_channel / 512)

--- a/mmpose/core/evaluation/top_down_eval.py
+++ b/mmpose/core/evaluation/top_down_eval.py
@@ -373,10 +373,16 @@ def post_dark_udp(coords, batch_heatmaps, kernel=3):
         total_group_number = int(np.ceil(batch_heatmaps_channel / 512))
         splited_batch_heatmaps = []
         for group_idx in range(total_group_number):
-            splited_batch_heatmap = batch_heatmaps[...,
-                                    group_idx * 512:min(batch_heatmaps_channel, (group_idx + 1) * 512)]
+            splited_batch_heatmap = batch_heatmaps[
+                ..., group_idx *
+                512:min(batch_heatmaps_channel, (group_idx + 1) * 512)]
             batch_heatmap_pad = cv2.copyMakeBorder(
-                splited_batch_heatmap, 1, 1, 1, 1, borderType=cv2.BORDER_REFLECT)
+                splited_batch_heatmap,
+                1,
+                1,
+                1,
+                1,
+                borderType=cv2.BORDER_REFLECT)
             splited_batch_heatmaps.append(batch_heatmap_pad)
         batch_heatmaps_pad = np.concatenate(splited_batch_heatmaps, axis=2)
     else:

--- a/tests/test_evaluation/test_top_down_eval.py
+++ b/tests/test_evaluation/test_top_down_eval.py
@@ -63,8 +63,7 @@ def test_keypoints_from_heatmaps():
         udp_scale,
         post_process='default',
         target_type='GaussianHeatMap',
-        use_udp=True
-    )
+        use_udp=True)
     assert_array_almost_equal(preds, np.tile([76, 76], (32, 17, 1)), decimal=0)
     assert_array_almost_equal(maxvals, np.tile([2], (32, 17, 1)), decimal=4)
     assert isinstance(preds, np.ndarray)

--- a/tests/test_evaluation/test_top_down_eval.py
+++ b/tests/test_evaluation/test_top_down_eval.py
@@ -32,6 +32,12 @@ def test_keypoints_from_heatmaps():
     center = np.array([[127, 127]])
     scale = np.array([[64 / 200.0, 64 / 200.0]])
 
+    udp_heatmaps = np.ones((32, 17, 64, 64), dtype=np.float32)
+    udp_heatmaps[:, :, 31, 31] = 2
+    udp_center = np.tile([127, 127], (32, 1))
+    udp_scale = np.tile([64 / 200.0, 64 / 200.0], (32, 1))
+
+
     preds, maxvals = keypoints_from_heatmaps(heatmaps, center, scale)
 
     assert_array_almost_equal(preds, np.array([[[126, 126]]]), decimal=4)
@@ -53,8 +59,22 @@ def test_keypoints_from_heatmaps():
 
     preds, maxvals = keypoints_from_heatmaps(
         heatmaps, center, scale, post_process='unbiased')
-    assert_array_almost_equal(preds, np.array([[[126, 126]]]), decimal=4)
-    assert_array_almost_equal(maxvals, np.array([[[2]]]), decimal=4)
+    assert_array_almost_equal(preds, np.tile([126, 126], (32, 17)), decimal=4)
+    assert_array_almost_equal(maxvals, np.tile([2], (32, 17)), decimal=4)
+    assert isinstance(preds, np.ndarray)
+    assert isinstance(maxvals, np.ndarray)
+
+    # test for udp dimension problem
+    preds, maxvals = keypoints_from_heatmaps(
+        udp_heatmaps,
+        udp_center,
+        udp_scale,
+        post_process='default',
+        target_type='GaussianHeatMap',
+        use_udp=True
+    )
+    assert_array_almost_equal(preds, np.array([[126, 126]]), decimal=4)
+    assert_array_almost_equal(maxvals, np.array([[2]]), decimal=4)
     assert isinstance(preds, np.ndarray)
     assert isinstance(maxvals, np.ndarray)
 

--- a/tests/test_evaluation/test_top_down_eval.py
+++ b/tests/test_evaluation/test_top_down_eval.py
@@ -35,8 +35,7 @@ def test_keypoints_from_heatmaps():
     udp_heatmaps = np.ones((32, 17, 64, 64), dtype=np.float32)
     udp_heatmaps[:, :, 31, 31] = 2
     udp_center = np.tile([127, 127], (32, 1))
-    udp_scale = np.tile([64 / 200.0, 64 / 200.0], (32, 1))
-
+    udp_scale = np.tile([32, 32], (32, 1))
 
     preds, maxvals = keypoints_from_heatmaps(heatmaps, center, scale)
 
@@ -57,13 +56,6 @@ def test_keypoints_from_heatmaps():
     assert isinstance(preds, np.ndarray)
     assert isinstance(maxvals, np.ndarray)
 
-    preds, maxvals = keypoints_from_heatmaps(
-        heatmaps, center, scale, post_process='unbiased')
-    assert_array_almost_equal(preds, np.tile([126, 126], (32, 17)), decimal=4)
-    assert_array_almost_equal(maxvals, np.tile([2], (32, 17)), decimal=4)
-    assert isinstance(preds, np.ndarray)
-    assert isinstance(maxvals, np.ndarray)
-
     # test for udp dimension problem
     preds, maxvals = keypoints_from_heatmaps(
         udp_heatmaps,
@@ -73,8 +65,8 @@ def test_keypoints_from_heatmaps():
         target_type='GaussianHeatMap',
         use_udp=True
     )
-    assert_array_almost_equal(preds, np.array([[126, 126]]), decimal=4)
-    assert_array_almost_equal(maxvals, np.array([[2]]), decimal=4)
+    assert_array_almost_equal(preds, np.tile([76, 76], (32, 17, 1)), decimal=0)
+    assert_array_almost_equal(maxvals, np.tile([2], (32, 17, 1)), decimal=4)
     assert isinstance(preds, np.ndarray)
     assert isinstance(maxvals, np.ndarray)
 


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation
Met a bug when training with udp, look like this
```
error: (-215:Assertion failed) top >= 0 && bottom >= 0 && left >= 0 && right >= 0 && _src.dims() <= 2 in function 'cv::copyMakeBorder'
```
Review the code and find that cv2.copMakeBorder will report an error when input dimension exceeds 512

In the raw code, the author directly use cv2.copyMakeBorder to operate batch of heatmaps and it crashed

The tested opencv-python version is 4.5.4.60, 4.4.0.40, 4.1.0.25, all have this problem

Complete environmental information is like this
```
Environment info:
------------------------------------------------------------
sys.platform: linux
Python: 3.7.11 (default, Jul 27 2021, 14:32:16) [GCC 7.5.0]
CUDA available: True
GPU 0,1,2,3: Tesla P40
CUDA_HOME: /usr/local/cuda
NVCC: Cuda compilation tools, release 10.0, V10.0.130
GCC: gcc (GCC) 8.3.0
PyTorch: 1.7.1+cu101
PyTorch compiling details: PyTorch built with:
  - GCC 7.3
  - C++ Version: 201402
  - Intel(R) Math Kernel Library Version 2020.0.0 Product Build 20191122 for Intel(R) 64 architecture applications
  - Intel(R) MKL-DNN v1.6.0 (Git Hash 5ef631a030a6f73131c77892041042805a06064f)
  - OpenMP 201511 (a.k.a. OpenMP 4.5)
  - NNPACK is enabled
  - CPU capability usage: AVX2
  - CUDA Runtime 10.1
  - NVCC architecture flags: -gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_60,code=sm_60;-gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75
  - CuDNN 7.6.3
  - Magma 2.5.2
  - Build settings: BLAS=MKL, BUILD_TYPE=Release, CXX_FLAGS= -Wno-deprecated -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -fopenmp -DNDEBUG -DUSE_FBGEMM -DUSE_QNNPACK -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DUSE_VULKAN_WRAPPER -O2 -fPIC -Wno-narrowing -Wall -Wextra -Werror$
return-type -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -Wno-unused-result -Wno-unused-local-typedefs -Wno-strict-overflow -Wno-strict-aliasing -$
no-error=deprecated-declarations -Wno-stringop-overflow -Wno-psabi -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -fdiagnostics-color=always -faligned-new -Wno-unused-but-set-variable -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -$
error=format -Wno-stringop-overflow, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, PERF_WITH_AVX512=1, USE_CUDA=ON, USE_EXCEPTION_PTR=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=ON, USE_NNPACK=ON, USE_OPENMP=ON,

TorchVision: 0.8.2+cu101
OpenCV: 4.5.4
MMCV: 1.3.13
MMCV Compiler: GCC 7.3
MMCV CUDA Compiler: 11.0
MMPose: 0.21.0+ac48c74
------------------------------------------------------------
```
<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

## Modification
When the input heatmaps' dimension exceeds 512, split it to operation, and then concat the splitted heatmaps
<!-- Please briefly describe what modification is made in this PR. -->

## Use cases (Optional)
Just test this bug with official command line
```
./tools/dist_train.sh configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192_udp.py 4
```
It doesn't work on the original code, and work well on the new code
<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [X] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
