### PR TITLE
[Fix] Use np.pad

### DIFF
--- a/mmpose/core/evaluation/top_down_eval.py
+++ b/mmpose/core/evaluation/top_down_eval.py
@@ -366,34 +366,10 @@ def post_dark_udp(coords, batch_heatmaps, kernel=3):
             cv2.GaussianBlur(heatmap, (kernel, kernel), 0, heatmap)
     np.clip(batch_heatmaps, 0.001, 50, batch_heatmaps)
     np.log(batch_heatmaps, batch_heatmaps)
-    batch_heatmaps = np.transpose(batch_heatmaps,
-                                  (2, 3, 0, 1)).reshape(H, W, -1)
 
-    # cv2.copyMakeBorder will report an error when input dimension exceeds 512
-    batch_heatmaps_channel = batch_heatmaps.shape[2]
-    if batch_heatmaps_channel > 512:
-        total_group_number = int(np.ceil(batch_heatmaps_channel / 512))
-        splited_batch_heatmaps = []
-        for group_idx in range(total_group_number):
-            splited_batch_heatmap = batch_heatmaps[
-                ..., group_idx *
-                512:min(batch_heatmaps_channel, (group_idx + 1) * 512)]
-            batch_heatmap_pad = cv2.copyMakeBorder(
-                splited_batch_heatmap,
-                1,
-                1,
-                1,
-                1,
-                borderType=cv2.BORDER_REFLECT)
-            splited_batch_heatmaps.append(batch_heatmap_pad)
-        batch_heatmaps_pad = np.concatenate(splited_batch_heatmaps, axis=2)
-    else:
-        batch_heatmaps_pad = cv2.copyMakeBorder(
-            batch_heatmaps, 1, 1, 1, 1, borderType=cv2.BORDER_REFLECT)
-
-    batch_heatmaps_pad = np.transpose(
-        batch_heatmaps_pad.reshape(H + 2, W + 2, B, K),
-        (2, 3, 0, 1)).flatten()
+    batch_heatmaps_pad = np.pad(
+        batch_heatmaps, ((0, 0), (0, 0), (1, 1), (1, 1)),
+        mode='edge').flatten()
 
     index = coords[..., 0] + 1 + (coords[..., 1] + 1) * (W + 2)
     index += (W + 2) * (H + 2) * np.arange(0, B * K).reshape(-1, K)


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

Fix #1100 
Using `np.pad` will make the codes much cleaner. 
But it is a little bit slower. In my tests, the old vs the new  is 0.004 ms vs 0.04 ms. 

## Modification

<!-- Please briefly describe what modification is made in this PR. -->


```
batch_heatmaps = np.transpose(batch_heatmaps,
                                  (2, 3, 0, 1)).reshape(H, W, -1)
# cv2.copyMakeBorder will report an error when input dimension exceeds 512
batch_heatmaps_channel = batch_heatmaps.shape[2]
if batch_heatmaps_channel > 512:
    total_group_number = int(np.ceil(batch_heatmaps_channel / 512))
    splited_batch_heatmaps = []
    for group_idx in range(total_group_number):
        splited_batch_heatmap = batch_heatmaps[
            ..., group_idx *
            512:min(batch_heatmaps_channel, (group_idx + 1) * 512)]
        batch_heatmap_pad = cv2.copyMakeBorder(
            splited_batch_heatmap,
            1,
            1,
            1,
            1,
            borderType=cv2.BORDER_REFLECT)
        splited_batch_heatmaps.append(batch_heatmap_pad)
    batch_heatmaps_pad = np.concatenate(splited_batch_heatmaps, axis=2)
else:
    batch_heatmaps_pad = cv2.copyMakeBorder(
        batch_heatmaps, 1, 1, 1, 1, borderType=cv2.BORDER_REFLECT)

batch_heatmaps_pad = np.transpose(
    batch_heatmaps_pad.reshape(H + 2, W + 2, B, K),
    (2, 3, 0, 1)).flatten()
```
to

```
batch_heatmaps_pad = np.pad(
      batch_heatmaps, ((0, 0), (0, 0), (1, 1), (1, 1)),
      mode='edge').flatten()
```


## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
