### PR TITLE
[Feature] Add a `SpriteNode` for Webcam API

### DIFF
--- a/tools/webcam/webcam_apis/utils/misc.py
+++ b/tools/webcam/webcam_apis/utils/misc.py
@@ -60,7 +60,7 @@ def load_image_from_disk_or_url(filename, readFlag=cv2.IMREAD_COLOR):
         image = cv2.imdecode(image, readFlag)
         return image
     else:
-        image = cv2.imread(filename)
+        image = cv2.imread(filename, readFlag)
         return image
 
 


### PR DESCRIPTION
## Motivation

The node can draw a sprite chasing your eyes. (At first, I want it to chase hands, but I don't know how to get hand keypoints :joy: )

## Modification

As the title

## Use cases (Optional)

```python
dict(
    type='SpriteNode',
    name='sprite',
    enable_key='s',
    frame_buffer='vis',
    output_buffer='sprite'),
```

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
