### PR TITLE
[Fix] update albumentations installed way

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,4 @@
-albumentations>=0.3.2 --no-binary imgaug,albumentations
+albumentations>=0.3.2 --no-binary qudida,albumentations
 onnx
 onnxruntime
 poseval@git+https://github.com/svenkreiss/poseval.git


### PR DESCRIPTION
By default, installing `albumentations` by pip has `opencv-python-headless` dependency even if `opencv-python` has already been installed. This could cause different opencv versions installed in the environment and lead to unexpected errors. 

https://github.com/open-mmlab/mmpose/pull/833 has fixed this potential issue, but `albumentations` has updated their installing way, which changes 
`pip install albumentations --no-binary imgaug,albumentations` 
to 
`pip install -U albumentations --no-binary qudida,albumentations`. See its [docs](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies) for details.