### PR TITLE
Fix bbox area calculation in inference tracking (#1194)

### DIFF
--- a/mmpose/apis/inference_tracking.py
+++ b/mmpose/apis/inference_tracking.py
@@ -128,8 +128,8 @@ def _get_area(results):
     """
     for result in results:
         if 'bbox' in result:
-            result['area'] = np.abs((result['bbox'][1] - result['bbox'][0]) *
-                                    (result['bbox'][2] - result['bbox'][3]))
+            result['area'] = ((result['bbox'][2] - result['bbox'][0]) *
+                              (result['bbox'][3] - result['bbox'][1]))
         else:
             xmin = np.min(
                 result['keypoints'][:, 0][result['keypoints'][:, 0] > 0],


### PR DESCRIPTION
## Motivation

Fix the calculation of bounding box area (#1194).

## Modification

- Corrected the way `result['area']` is calculated

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
