### PR TITLE
[Fix] skip joints that should be hidden in visualization

### DIFF
--- a/mmpose/core/visualization/image.py
+++ b/mmpose/core/visualization/image.py
@@ -170,45 +170,39 @@ def imshow_keypoints(img,
             assert len(pose_link_color) == len(skeleton)
 
             for sk_id, sk in enumerate(skeleton):
-                if pose_link_color[sk_id] is not None:
-                    pos1 = (int(kpts[sk[0], 0]), int(kpts[sk[0], 1]))
-                    pos2 = (int(kpts[sk[1], 0]), int(kpts[sk[1], 1]))
-                    if (pos1[0] > 0 and pos1[0] < img_w and pos1[1] > 0
-                            and pos1[1] < img_h and pos2[0] > 0
-                            and pos2[0] < img_w and pos2[1] > 0
-                            and pos2[1] < img_h
-                            and kpts[sk[0], 2] > kpt_score_thr
-                            and kpts[sk[1], 2] > kpt_score_thr):
-                        color = tuple(int(c) for c in pose_link_color[sk_id])
-                        if show_keypoint_weight:
-                            img_copy = img.copy()
-                            X = (pos1[0], pos2[0])
-                            Y = (pos1[1], pos2[1])
-                            mX = np.mean(X)
-                            mY = np.mean(Y)
-                            length = ((Y[0] - Y[1])**2 + (X[0] - X[1])**2)**0.5
-                            angle = math.degrees(
-                                math.atan2(Y[0] - Y[1], X[0] - X[1]))
-                            stickwidth = 2
-                            polygon = cv2.ellipse2Poly(
-                                (int(mX), int(mY)),
-                                (int(length / 2), int(stickwidth)), int(angle),
-                                0, 360, 1)
-                            cv2.fillConvexPoly(img_copy, polygon, color)
-                            transparency = max(
-                                0,
-                                min(1,
-                                    0.5 * (kpts[sk[0], 2] + kpts[sk[1], 2])))
-                            cv2.addWeighted(
-                                img_copy,
-                                transparency,
-                                img,
-                                1 - transparency,
-                                0,
-                                dst=img)
-                        else:
-                            cv2.line(
-                                img, pos1, pos2, color, thickness=thickness)
+                if (pos1[0] < 0 or pos1[0] >= img_w or pos1[1] < 0
+                        or pos1[1] >= img_h or pos2[0] < 0 or pos2[0] >= img_w
+                        or pos2[1] < 0 or pos2[1] >= img_h
+                        or kpts[sk[0], 2] < kpt_score_thr
+                        or kpts[sk[1], 2] < kpt_score_thr
+                        or pose_link_color[sk_id] is None):
+                    # skip the link that should not be drawn
+                    continue
+                color = tuple(int(c) for c in pose_link_color[sk_id])
+                if show_keypoint_weight:
+                    img_copy = img.copy()
+                    X = (pos1[0], pos2[0])
+                    Y = (pos1[1], pos2[1])
+                    mX = np.mean(X)
+                    mY = np.mean(Y)
+                    length = ((Y[0] - Y[1])**2 + (X[0] - X[1])**2)**0.5
+                    angle = math.degrees(math.atan2(Y[0] - Y[1], X[0] - X[1]))
+                    stickwidth = 2
+                    polygon = cv2.ellipse2Poly(
+                        (int(mX), int(mY)), (int(length / 2), int(stickwidth)),
+                        int(angle), 0, 360, 1)
+                    cv2.fillConvexPoly(img_copy, polygon, color)
+                    transparency = max(
+                        0, min(1, 0.5 * (kpts[sk[0], 2] + kpts[sk[1], 2])))
+                    cv2.addWeighted(
+                        img_copy,
+                        transparency,
+                        img,
+                        1 - transparency,
+                        0,
+                        dst=img)
+                else:
+                    cv2.line(img, pos1, pos2, color, thickness=thickness)
 
     return img
 

--- a/mmpose/core/visualization/image.py
+++ b/mmpose/core/visualization/image.py
@@ -140,64 +140,68 @@ def imshow_keypoints(img,
         # draw each point on image
         if pose_kpt_color is not None:
             assert len(pose_kpt_color) == len(kpts)
+
             for kid, kpt in enumerate(kpts):
-                x_coord, y_coord, kpt_score = int(kpt[0]), int(kpt[1]), kpt[2]
-                if kpt_score > kpt_score_thr:
-                    color = tuple(int(c) for c in pose_kpt_color[kid])
-                    if show_keypoint_weight:
-                        img_copy = img.copy()
-                        cv2.circle(img_copy, (int(x_coord), int(y_coord)),
-                                   radius, color, -1)
-                        transparency = max(0, min(1, kpt_score))
-                        cv2.addWeighted(
-                            img_copy,
-                            transparency,
-                            img,
-                            1 - transparency,
-                            0,
-                            dst=img)
-                    else:
-                        cv2.circle(img, (int(x_coord), int(y_coord)), radius,
-                                   color, -1)
+                if pose_kpt_color[kid] is not None:
+                    x_coord, y_coord, kpt_score = int(kpt[0]), int(kpt[1]), kpt[2]
+                    if kpt_score > kpt_score_thr:
+                        color = tuple(int(c) for c in pose_kpt_color[kid])
+                        if show_keypoint_weight:
+                            img_copy = img.copy()
+                            cv2.circle(img_copy, (int(x_coord), int(y_coord)),
+                                       radius, color, -1)
+                            transparency = max(0, min(1, kpt_score))
+                            cv2.addWeighted(
+                                img_copy,
+                                transparency,
+                                img,
+                                1 - transparency,
+                                0,
+                                dst=img)
+                        else:
+                            cv2.circle(img, (int(x_coord), int(y_coord)), radius,
+                                       color, -1)
 
         # draw links
         if skeleton is not None and pose_link_color is not None:
             assert len(pose_link_color) == len(skeleton)
+
             for sk_id, sk in enumerate(skeleton):
-                pos1 = (int(kpts[sk[0], 0]), int(kpts[sk[0], 1]))
-                pos2 = (int(kpts[sk[1], 0]), int(kpts[sk[1], 1]))
-                if (pos1[0] > 0 and pos1[0] < img_w and pos1[1] > 0
-                        and pos1[1] < img_h and pos2[0] > 0 and pos2[0] < img_w
-                        and pos2[1] > 0 and pos2[1] < img_h
-                        and kpts[sk[0], 2] > kpt_score_thr
-                        and kpts[sk[1], 2] > kpt_score_thr):
-                    color = tuple(int(c) for c in pose_link_color[sk_id])
-                    if show_keypoint_weight:
-                        img_copy = img.copy()
-                        X = (pos1[0], pos2[0])
-                        Y = (pos1[1], pos2[1])
-                        mX = np.mean(X)
-                        mY = np.mean(Y)
-                        length = ((Y[0] - Y[1])**2 + (X[0] - X[1])**2)**0.5
-                        angle = math.degrees(
-                            math.atan2(Y[0] - Y[1], X[0] - X[1]))
-                        stickwidth = 2
-                        polygon = cv2.ellipse2Poly(
-                            (int(mX), int(mY)),
-                            (int(length / 2), int(stickwidth)), int(angle), 0,
-                            360, 1)
-                        cv2.fillConvexPoly(img_copy, polygon, color)
-                        transparency = max(
-                            0, min(1, 0.5 * (kpts[sk[0], 2] + kpts[sk[1], 2])))
-                        cv2.addWeighted(
-                            img_copy,
-                            transparency,
-                            img,
-                            1 - transparency,
-                            0,
-                            dst=img)
-                    else:
-                        cv2.line(img, pos1, pos2, color, thickness=thickness)
+                if pose_link_color[sk_id] is not None:
+                    pos1 = (int(kpts[sk[0], 0]), int(kpts[sk[0], 1]))
+                    pos2 = (int(kpts[sk[1], 0]), int(kpts[sk[1], 1]))
+                    if (pos1[0] > 0 and pos1[0] < img_w and pos1[1] > 0
+                            and pos1[1] < img_h and pos2[0] > 0 and pos2[0] < img_w
+                            and pos2[1] > 0 and pos2[1] < img_h
+                            and kpts[sk[0], 2] > kpt_score_thr
+                            and kpts[sk[1], 2] > kpt_score_thr):
+                        color = tuple(int(c) for c in pose_link_color[sk_id])
+                        if show_keypoint_weight:
+                            img_copy = img.copy()
+                            X = (pos1[0], pos2[0])
+                            Y = (pos1[1], pos2[1])
+                            mX = np.mean(X)
+                            mY = np.mean(Y)
+                            length = ((Y[0] - Y[1])**2 + (X[0] - X[1])**2)**0.5
+                            angle = math.degrees(
+                                math.atan2(Y[0] - Y[1], X[0] - X[1]))
+                            stickwidth = 2
+                            polygon = cv2.ellipse2Poly(
+                                (int(mX), int(mY)),
+                                (int(length / 2), int(stickwidth)), int(angle), 0,
+                                360, 1)
+                            cv2.fillConvexPoly(img_copy, polygon, color)
+                            transparency = max(
+                                0, min(1, 0.5 * (kpts[sk[0], 2] + kpts[sk[1], 2])))
+                            cv2.addWeighted(
+                                img_copy,
+                                transparency,
+                                img,
+                                1 - transparency,
+                                0,
+                                dst=img)
+                        else:
+                            cv2.line(img, pos1, pos2, color, thickness=thickness)
 
     return img
 

--- a/mmpose/core/visualization/image.py
+++ b/mmpose/core/visualization/image.py
@@ -143,16 +143,16 @@ def imshow_keypoints(img,
 
             for kid, kpt in enumerate(kpts):
                 x_coord, y_coord, kpt_score = int(kpt[0]), int(kpt[1]), kpt[2]
-                
+
                 if kpt_score < kpt_score_thr or pose_kpt_color[kid] is None:
                     # skip the point that should not be drawn
                     continue
-                    
+
                 color = tuple(int(c) for c in pose_kpt_color[kid])
                 if show_keypoint_weight:
                     img_copy = img.copy()
-                    cv2.circle(img_copy, (int(x_coord), int(y_coord)),
-                                radius, color, -1)
+                    cv2.circle(img_copy, (int(x_coord), int(y_coord)), radius,
+                               color, -1)
                     transparency = max(0, min(1, kpt_score))
                     cv2.addWeighted(
                         img_copy,
@@ -163,16 +163,19 @@ def imshow_keypoints(img,
                         dst=img)
                 else:
                     cv2.circle(img, (int(x_coord), int(y_coord)), radius,
-                                color, -1)
+                               color, -1)
 
         # draw links
         if skeleton is not None and pose_link_color is not None:
             assert len(pose_link_color) == len(skeleton)
 
             for sk_id, sk in enumerate(skeleton):
-                if (pos1[0] < 0 or pos1[0] >= img_w or pos1[1] < 0
-                        or pos1[1] >= img_h or pos2[0] < 0 or pos2[0] >= img_w
-                        or pos2[1] < 0 or pos2[1] >= img_h
+                pos1 = (int(kpts[sk[0], 0]), int(kpts[sk[0], 1]))
+                pos2 = (int(kpts[sk[1], 0]), int(kpts[sk[1], 1]))
+
+                if (pos1[0] <= 0 or pos1[0] >= img_w or pos1[1] <= 0
+                        or pos1[1] >= img_h or pos2[0] <= 0 or pos2[0] >= img_w
+                        or pos2[1] <= 0 or pos2[1] >= img_h
                         or kpts[sk[0], 2] < kpt_score_thr
                         or kpts[sk[1], 2] < kpt_score_thr
                         or pose_link_color[sk_id] is None):

--- a/mmpose/core/visualization/image.py
+++ b/mmpose/core/visualization/image.py
@@ -143,7 +143,8 @@ def imshow_keypoints(img,
 
             for kid, kpt in enumerate(kpts):
                 if pose_kpt_color[kid] is not None:
-                    x_coord, y_coord, kpt_score = int(kpt[0]), int(kpt[1]), kpt[2]
+                    x_coord, y_coord, kpt_score = int(kpt[0]), int(
+                        kpt[1]), kpt[2]
                     if kpt_score > kpt_score_thr:
                         color = tuple(int(c) for c in pose_kpt_color[kid])
                         if show_keypoint_weight:
@@ -159,8 +160,8 @@ def imshow_keypoints(img,
                                 0,
                                 dst=img)
                         else:
-                            cv2.circle(img, (int(x_coord), int(y_coord)), radius,
-                                       color, -1)
+                            cv2.circle(img, (int(x_coord), int(y_coord)),
+                                       radius, color, -1)
 
         # draw links
         if skeleton is not None and pose_link_color is not None:
@@ -171,8 +172,9 @@ def imshow_keypoints(img,
                     pos1 = (int(kpts[sk[0], 0]), int(kpts[sk[0], 1]))
                     pos2 = (int(kpts[sk[1], 0]), int(kpts[sk[1], 1]))
                     if (pos1[0] > 0 and pos1[0] < img_w and pos1[1] > 0
-                            and pos1[1] < img_h and pos2[0] > 0 and pos2[0] < img_w
-                            and pos2[1] > 0 and pos2[1] < img_h
+                            and pos1[1] < img_h and pos2[0] > 0
+                            and pos2[0] < img_w and pos2[1] > 0
+                            and pos2[1] < img_h
                             and kpts[sk[0], 2] > kpt_score_thr
                             and kpts[sk[1], 2] > kpt_score_thr):
                         color = tuple(int(c) for c in pose_link_color[sk_id])
@@ -188,11 +190,13 @@ def imshow_keypoints(img,
                             stickwidth = 2
                             polygon = cv2.ellipse2Poly(
                                 (int(mX), int(mY)),
-                                (int(length / 2), int(stickwidth)), int(angle), 0,
-                                360, 1)
+                                (int(length / 2), int(stickwidth)), int(angle),
+                                0, 360, 1)
                             cv2.fillConvexPoly(img_copy, polygon, color)
                             transparency = max(
-                                0, min(1, 0.5 * (kpts[sk[0], 2] + kpts[sk[1], 2])))
+                                0,
+                                min(1,
+                                    0.5 * (kpts[sk[0], 2] + kpts[sk[1], 2])))
                             cv2.addWeighted(
                                 img_copy,
                                 transparency,
@@ -201,7 +205,8 @@ def imshow_keypoints(img,
                                 0,
                                 dst=img)
                         else:
-                            cv2.line(img, pos1, pos2, color, thickness=thickness)
+                            cv2.line(
+                                img, pos1, pos2, color, thickness=thickness)
 
     return img
 

--- a/mmpose/core/visualization/image.py
+++ b/mmpose/core/visualization/image.py
@@ -142,26 +142,28 @@ def imshow_keypoints(img,
             assert len(pose_kpt_color) == len(kpts)
 
             for kid, kpt in enumerate(kpts):
-                if pose_kpt_color[kid] is not None:
-                    x_coord, y_coord, kpt_score = int(kpt[0]), int(
-                        kpt[1]), kpt[2]
-                    if kpt_score > kpt_score_thr:
-                        color = tuple(int(c) for c in pose_kpt_color[kid])
-                        if show_keypoint_weight:
-                            img_copy = img.copy()
-                            cv2.circle(img_copy, (int(x_coord), int(y_coord)),
-                                       radius, color, -1)
-                            transparency = max(0, min(1, kpt_score))
-                            cv2.addWeighted(
-                                img_copy,
-                                transparency,
-                                img,
-                                1 - transparency,
-                                0,
-                                dst=img)
-                        else:
-                            cv2.circle(img, (int(x_coord), int(y_coord)),
-                                       radius, color, -1)
+                x_coord, y_coord, kpt_score = int(kpt[0]), int(kpt[1]), kpt[2]
+                
+                if kpt_score < kpt_score_thr or pose_kpt_color[kid] is None:
+                    # skip the point that should not be drawn
+                    continue
+                    
+                color = tuple(int(c) for c in pose_kpt_color[kid])
+                if show_keypoint_weight:
+                    img_copy = img.copy()
+                    cv2.circle(img_copy, (int(x_coord), int(y_coord)),
+                                radius, color, -1)
+                    transparency = max(0, min(1, kpt_score))
+                    cv2.addWeighted(
+                        img_copy,
+                        transparency,
+                        img,
+                        1 - transparency,
+                        0,
+                        dst=img)
+                else:
+                    cv2.circle(img, (int(x_coord), int(y_coord)), radius,
+                                color, -1)
 
         # draw links
         if skeleton is not None and pose_link_color is not None:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -9,16 +9,16 @@ from mmpose.core import (apply_bugeye_effect, apply_sunglasses_effect,
                          imshow_bboxes, imshow_keypoints, imshow_keypoints_3d)
 
 
-def test_imshow_keypoints():
-    # 2D keypoint
+def test_imshow_keypoints_2d():
     img = np.zeros((100, 100, 3), dtype=np.uint8)
-    kpts = np.array([[1, 1, 1], [10, 10, 1]], dtype=np.float32)
+    kpts = np.array([[1, 1, 1], [2, 2, 1], [4, 4, 1], [8, 8, 1]],
+                    dtype=np.float32)
     pose_result = [kpts]
-    skeleton = [[0, 1]]
+    skeleton = [[0, 1], [1, 2], [2, 3]]
     # None: kpt or link is hidden
-    pose_kpt_color = [(127, 127, 127)] * (len(kpts) - 1) + [None]
+    pose_kpt_color = [None] + [(127, 127, 127)] * (len(kpts) - 1)
     pose_link_color = [(127, 127, 127)] * (len(skeleton) - 1) + [None]
-    img_vis_2d = imshow_keypoints(
+    _ = imshow_keypoints(
         img,
         pose_result,
         skeleton=skeleton,
@@ -26,12 +26,17 @@ def test_imshow_keypoints():
         pose_link_color=pose_link_color,
         show_keypoint_weight=True)
 
-    # 3D keypoint
+
+def test_imshow_keypoints_3d():
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
     kpts_3d = np.array([[0, 0, 0, 1], [1, 1, 1, 1]], dtype=np.float32)
     pose_result_3d = [{'keypoints_3d': kpts_3d, 'title': 'test'}]
+    skeleton = [[0, 1]]
+    pose_kpt_color = [(127, 127, 127)] * len(kpts_3d)
+    pose_link_color = [(127, 127, 127)] * len(skeleton)
     _ = imshow_keypoints_3d(
         pose_result_3d,
-        img=img_vis_2d,
+        img=img,
         skeleton=skeleton,
         pose_kpt_color=pose_kpt_color,
         pose_link_color=pose_link_color,

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -15,8 +15,9 @@ def test_imshow_keypoints():
     kpts = np.array([[1, 1, 1], [10, 10, 1]], dtype=np.float32)
     pose_result = [kpts]
     skeleton = [[0, 1]]
-    pose_kpt_color = [(127, 127, 127)] * len(kpts)
-    pose_link_color = [(127, 127, 127)] * len(skeleton)
+    # None: kpt or link is hidden
+    pose_kpt_color = [(127, 127, 127)] * (len(kpts) - 1) + [None]
+    pose_link_color = [(127, 127, 127)] * (len(skeleton) - 1) + [None]
     img_vis_2d = imshow_keypoints(
         img,
         pose_result,


### PR DESCRIPTION
fix for issue https://github.com/open-mmlab/mmpose/issues/1227

joints with color=None should be skipped according to the documentation:
https://github.com/open-mmlab/mmpose/blob/c09a6930a2e699722ec3bd6142c6ad334d32b469/mmpose/core/visualization/image.py#L126


- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.

