### PR TITLE
[Fix] Changed channel size from -1 to an operable number "channel_shuffle"

### DIFF
--- a/mmpose/models/backbones/utils/channel_shuffle.py
+++ b/mmpose/models/backbones/utils/channel_shuffle.py
@@ -24,6 +24,6 @@ def channel_shuffle(x, groups):
 
     x = x.view(batch_size, groups, channels_per_group, height, width)
     x = torch.transpose(x, 1, 2).contiguous()
-    x = x.view(batch_size, -1, height, width)
+    x = x.view(batch_size, groups * channels_per_group, height, width)
 
     return x


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation
If we use **`pytorch2onnx.py`** to generate ONNX with the batch size set to a variable size of **`-1`**, it will generate a model that cannot be inferred by onnxruntime because the **`Reshape`** operation on ONNX will include two **`-1`** in the modified shape. **`(1)`** in the figure below. The ONNX model shown below will cause an error in onnxruntime if the batch size is changed to **`-1`**. Because onnxruntime does not allow more than two dimensions of variable size.

- Sample ONNX file just before initializing batch size
![image](https://user-images.githubusercontent.com/33194443/158396736-4a80b0cd-94dd-4119-b9d5-8e4358c780cb.png)
[litehrnet_18_coco_Nx256x192_reshape_channel=-1.onnx.zip](https://github.com/open-mmlab/mmpose/files/8254335/litehrnet_18_coco_Nx256x192_reshape_channel.-1.onnx.zip)

The ONNX model output after applying this modification is shown below. The batch size is initialized to **`(1) -1`**, but the channel locations are replaced with fixed values **`(2) 32`** computed, so that onnxruntime will not generate errors and can be inferred correctly.
- Sample ONNX file output immediately after initializing batch size
![image](https://user-images.githubusercontent.com/33194443/158398409-c6018aad-8c65-418d-9d9f-daa41106bd7d.png)
[litehrnet_18_coco_Nx256x192.onnx.zip](https://github.com/open-mmlab/mmpose/files/8254343/litehrnet_18_coco_Nx256x192.onnx.zip)

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

## Modification
Replace the channels part with the value calculated by **`groups * channels_per_group`** instead of **`-1`** so that onnxruntime can infer correctly when the batch size is changed to variable.

From:
```python
assert (num_channels % groups == 0), ('num_channels should be '
                                      'divisible by groups')
channels_per_group = num_channels // groups

x = x.view(batch_size, groups, channels_per_group, height, width)
x = torch.transpose(x, 1, 2).contiguous()
x = x.view(batch_size, -1, height, width)
```

To:
```python
assert (num_channels % groups == 0), ('num_channels should be '
                                      'divisible by groups')
channels_per_group = num_channels // groups

x = x.view(batch_size, groups, channels_per_group, height, width)
x = torch.transpose(x, 1, 2).contiguous()
x = x.view(batch_size, groups * channels_per_group, height, width)
```

<!-- Please briefly describe what modification is made in this PR. -->

## BC-breaking (Optional)
None in particular.

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)
None in particular.

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
