### PR TITLE
[Fix] sync random seed in DistributedSamplers

### DIFF
--- a/mmpose/core/utils/__init__.py
+++ b/mmpose/core/utils/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .dist_utils import allreduce_grads
+from .dist_utils import allreduce_grads, sync_random_seed
 from .regularizations import WeightNormClipHook
 
-__all__ = ['allreduce_grads', 'WeightNormClipHook']
+__all__ = ['allreduce_grads', 'WeightNormClipHook', 'sync_random_seed']


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

This PR fixes a potential bug introduced in #1229 
- #1229 allows using different random seeds for different ranks, which may cause trouble for DistributedSampler because data shuffle results will be different across ranks.
- This PR syncs random seed (only) in DistributedSampler to fix the problem.

Refer to https://github.com/open-mmlab/mmdetection/pull/7432/ and https://github.com/open-mmlab/mmdetection/pull/7440

## Modification

<!-- Please briefly describe what modification is made in this PR. -->

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
