### PR TITLE
[FIX] fixing typo in function definition in 3d demo

### DIFF
--- a/demo/body3d_two_stage_video_demo.py
+++ b/demo/body3d_two_stage_video_demo.py
@@ -22,7 +22,7 @@ except (ImportError, ModuleNotFoundError):
     has_mmdet = False
 
 
-def covert_keypoint_definition(keypoints, pose_det_dataset, pose_lift_dataset):
+def convert_keypoint_definition(keypoints, pose_det_dataset, pose_lift_dataset):
     """Convert pose det dataset keypoints definition to pose lifter dataset
     keypoints definition.
 
@@ -234,7 +234,7 @@ def main():
     for pose_det_results in pose_det_results_list:
         for res in pose_det_results:
             keypoints = res['keypoints']
-            res['keypoints'] = covert_keypoint_definition(
+            res['keypoints'] = convert_keypoint_definition(
                 keypoints, pose_det_dataset, pose_lift_dataset)
 
     # load temporal padding config from model.data_cfg


### PR DESCRIPTION

## Motivation

Fixing a typo in function definiton

## Modification

Changed ```covert_keypoint_definition``` to ```convert_keypoint_definition```

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
