### PR TITLE
[Fix] Compatible with mme in model loading pretrained.

### DIFF
--- a/mmpose/models/detectors/associative_embedding.py
+++ b/mmpose/models/detectors/associative_embedding.py
@@ -65,7 +65,8 @@ class AssociativeEmbedding(BasePose):
         self.test_cfg = test_cfg
         self.use_udp = test_cfg.get('use_udp', False)
         self.parser = HeatmapParser(self.test_cfg)
-        self.init_weights(pretrained=pretrained)
+        self.pretrained = pretrained
+        self.init_weights()
 
     @property
     def with_keypoint(self):
@@ -74,7 +75,9 @@ class AssociativeEmbedding(BasePose):
 
     def init_weights(self, pretrained=None):
         """Weight initialization for model."""
-        self.backbone.init_weights(pretrained)
+        if pretrained is not None:
+            self.pretrained = pretrained
+        self.backbone.init_weights(self.pretrained)
         if self.with_keypoint:
             self.keypoint_head.init_weights()
 

--- a/mmpose/models/detectors/mesh.py
+++ b/mmpose/models/detectors/mesh.py
@@ -72,11 +72,14 @@ class ParametricMesh(BasePose):
         self.test_cfg = test_cfg
 
         self.loss_mesh = builder.build_loss(loss_mesh)
-        self.init_weights(pretrained=pretrained)
+        self.pretrained = pretrained
+        self.init_weights()
 
     def init_weights(self, pretrained=None):
         """Weight initialization for model."""
-        self.backbone.init_weights(pretrained)
+        if pretrained is not None:
+            self.pretrained = pretrained
+        self.backbone.init_weights(self.pretrained)
         self.mesh_head.init_weights()
         if self.with_gan:
             self.discriminator.init_weights()

--- a/mmpose/models/detectors/multi_task.py
+++ b/mmpose/models/detectors/multi_task.py
@@ -46,8 +46,8 @@ class MultiTask(nn.Module):
         for head in heads:
             assert head is not None
             self.heads.append(builder.build_head(head))
-
-        self.init_weights(pretrained=pretrained)
+        self.pretrained = pretrained
+        self.init_weights()
 
     @property
     def with_necks(self):
@@ -56,7 +56,9 @@ class MultiTask(nn.Module):
 
     def init_weights(self, pretrained=None):
         """Weight initialization for model."""
-        self.backbone.init_weights(pretrained)
+        if pretrained is not None:
+            self.pretrained = pretrained
+        self.backbone.init_weights(self.pretrained)
         if self.with_necks:
             for neck in self.necks:
                 if hasattr(neck, 'init_weights'):

--- a/mmpose/models/detectors/pose_lifter.py
+++ b/mmpose/models/detectors/pose_lifter.py
@@ -86,8 +86,8 @@ class PoseLifter(BasePose):
         if self.semi:
             assert keypoint_head is not None and traj_head is not None
             self.loss_semi = builder.build_loss(loss_semi)
-
-        self.init_weights(pretrained=pretrained)
+        self.pretrained = pretrained
+        self.init_weights()
 
     @property
     def with_neck(self):
@@ -125,13 +125,15 @@ class PoseLifter(BasePose):
 
     def init_weights(self, pretrained=None):
         """Weight initialization for model."""
-        self.backbone.init_weights(pretrained)
+        if pretrained is not None:
+            self.pretrained = pretrained
+        self.backbone.init_weights(self.pretrained)
         if self.with_neck:
             self.neck.init_weights()
         if self.with_keypoint:
             self.keypoint_head.init_weights()
         if self.with_traj_backbone:
-            self.traj_backbone.init_weights(pretrained)
+            self.traj_backbone.init_weights(self.pretrained)
         if self.with_traj_neck:
             self.traj_neck.init_weights()
         if self.with_traj:

--- a/mmpose/models/detectors/top_down.py
+++ b/mmpose/models/detectors/top_down.py
@@ -66,8 +66,8 @@ class TopDown(BasePose):
                 keypoint_head['loss_keypoint'] = loss_pose
 
             self.keypoint_head = builder.build_head(keypoint_head)
-
-        self.init_weights(pretrained=pretrained)
+        self.pretrained = pretrained
+        self.init_weights()
 
     @property
     def with_neck(self):
@@ -81,7 +81,9 @@ class TopDown(BasePose):
 
     def init_weights(self, pretrained=None):
         """Weight initialization for model."""
-        self.backbone.init_weights(pretrained)
+        if pretrained is not None:
+            self.pretrained = pretrained
+        self.backbone.init_weights(self.pretrained)
         if self.with_neck:
             self.neck.init_weights()
         if self.with_keypoint:

--- a/tests/test_models/test_bottom_up_forward.py
+++ b/tests/test_models/test_bottom_up_forward.py
@@ -63,7 +63,7 @@ def test_ae_forward():
 
     with pytest.raises(TypeError):
         detector.init_weights(pretrained=dict())
-
+    detector.pretrained = model_cfg['pretrained']
     detector.init_weights()
 
     input_shape = (1, 3, 256, 256)

--- a/tests/test_models/test_bottom_up_forward.py
+++ b/tests/test_models/test_bottom_up_forward.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import numpy as np
+import pytest
 import torch
 
 from mmpose.models.detectors import AssociativeEmbedding
@@ -59,6 +60,9 @@ def test_ae_forward():
                                     model_cfg['train_cfg'],
                                     model_cfg['test_cfg'],
                                     model_cfg['pretrained'])
+
+    with pytest.raises(TypeError):
+        detector.init_weights(pretrained=dict())
 
     detector.init_weights()
 

--- a/tests/test_models/test_mesh_forward.py
+++ b/tests/test_models/test_mesh_forward.py
@@ -3,6 +3,7 @@ import os.path as osp
 import tempfile
 
 import numpy as np
+import pytest
 import torch
 
 from mmpose.core.optimizer import build_optimizers
@@ -49,6 +50,10 @@ def test_parametric_mesh_forward():
         loss_gan=None)
 
     detector = ParametricMesh(**model_cfg)
+
+    with pytest.raises(TypeError):
+        detector.init_weights(pretrained=dict())
+
     detector.init_weights()
 
     optimizers_config = dict(generator=dict(type='Adam', lr=0.0001))

--- a/tests/test_models/test_mesh_forward.py
+++ b/tests/test_models/test_mesh_forward.py
@@ -53,7 +53,7 @@ def test_parametric_mesh_forward():
 
     with pytest.raises(TypeError):
         detector.init_weights(pretrained=dict())
-
+    detector.pretrained = model_cfg['pretrained']
     detector.init_weights()
 
     optimizers_config = dict(generator=dict(type='Adam', lr=0.0001))

--- a/tests/test_models/test_multitask_forward.py
+++ b/tests/test_models/test_multitask_forward.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import numpy as np
+import pytest
 import torch
 
 from mmpose.models.detectors import MultiTask
@@ -24,6 +25,8 @@ def test_multitask_forward():
         pretrained=None,
     )
     model = MultiTask(**model_cfg)
+    with pytest.raises(TypeError):
+        model.init_weights(pretrained=dict())
 
     # build inputs and target
     mm_inputs = _demo_mm_inputs()

--- a/tests/test_models/test_multitask_forward.py
+++ b/tests/test_models/test_multitask_forward.py
@@ -27,7 +27,7 @@ def test_multitask_forward():
     model = MultiTask(**model_cfg)
     with pytest.raises(TypeError):
         model.init_weights(pretrained=dict())
-
+    model.pretrained = model_cfg['pretrained']
     # build inputs and target
     mm_inputs = _demo_mm_inputs()
     inputs = mm_inputs['img']

--- a/tests/test_models/test_pose_lifter_forward.py
+++ b/tests/test_models/test_pose_lifter_forward.py
@@ -74,7 +74,7 @@ def test_pose_lifter_forward():
 
     with pytest.raises(TypeError):
         detector.init_weights(pretrained=dict())
-
+    detector.pretrained = model_cfg['pretrained']
     detector.init_weights()
 
     inputs = _create_inputs(

--- a/tests/test_models/test_pose_lifter_forward.py
+++ b/tests/test_models/test_pose_lifter_forward.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import mmcv
 import numpy as np
+import pytest
 import torch
 
 from mmpose.models import build_posenet
@@ -70,6 +71,9 @@ def test_pose_lifter_forward():
 
     cfg = mmcv.Config({'model': model_cfg})
     detector = build_posenet(cfg.model)
+
+    with pytest.raises(TypeError):
+        detector.init_weights(pretrained=dict())
 
     detector.init_weights()
 

--- a/tests/test_models/test_top_down_forward.py
+++ b/tests/test_models/test_top_down_forward.py
@@ -82,7 +82,7 @@ def test_topdown_forward():
 
     with pytest.raises(TypeError):
         detector.init_weights(pretrained=dict())
-
+    detector.pretrained = model_cfg['pretrained']
     detector.init_weights()
 
     input_shape = (1, 3, 256, 256)

--- a/tests/test_models/test_top_down_forward.py
+++ b/tests/test_models/test_top_down_forward.py
@@ -2,6 +2,7 @@
 import copy
 
 import numpy as np
+import pytest
 import torch
 
 from mmpose.models.detectors import PoseWarper, TopDown
@@ -78,6 +79,9 @@ def test_topdown_forward():
     detector = TopDown(model_cfg['backbone'], None, model_cfg['keypoint_head'],
                        model_cfg['train_cfg'], model_cfg['test_cfg'],
                        model_cfg['pretrained'])
+
+    with pytest.raises(TypeError):
+        detector.init_weights(pretrained=dict())
 
     detector.init_weights()
 


### PR DESCRIPTION
## Motivation

The motivation of this PR is to compatible with mme in model loading pretrained. MME will call `init_weights` function without input parameter in the training script, which will overwrite the loaded pretrained model parameters. 

## Modification

- detector  
Modify the `pretrained` parameter to an attribute of the detector model. And `init_weights` function preferentially uses the incoming `pretrained`. If there are no input parameters, the attribute `self.pretrained` is used.

## BC-breaking (Optional)

No

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
