### PR TITLE
[Enhance] Speedup the Video Inference by Accelerating data-loading Stage in Top_Down_Full_Frame_without_Det

### DIFF
--- a/demo/docs/2d_animal_demo.md
+++ b/demo/docs/2d_animal_demo.md
@@ -71,32 +71,6 @@ python demo/top_down_video_demo_full_frame_without_det.py \
 
 <img src="https://user-images.githubusercontent.com/11788150/114023530-944c8280-98a5-11eb-86b0-5f6d3e232af0.gif" height="140px" alt><br>
 
-#### Using the full image as input with GPU acceleration
-
-The following script performs inference on a video with GPU acceleration. Assume that you have already installed [ffmpegcv](https://github.com/chenxinfeng4/ffmpegcv).
-
-If the `--nvdecode` option is turned on, the video reader can support NVIDIA-VIDEO-DECODING if possible, to save more CPU workload.
-
-```shell
-python demo/top_down_video_demo_full_frame_without_det_gpuaccel.py \
-    ${MMPOSE_CONFIG_FILE} ${MMPOSE_CHECKPOINT_FILE} \
-    --video-path ${VIDEO_PATH} \
-    --out-video-root ${OUTPUT_VIDEO_ROOT} \
-    [--show --device ${GPU_ID or CPU}] \
-    [--kpt-thr ${KPT_SCORE_THR}] \
-    [--nvdecode]
-```
-
-Examples:
-
-```shell
-python demo/top_down_video_demo_full_frame_without_det_gpuaccel.py \
-    configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/res152_fly_192x192.py \
-    https://download.openmmlab.com/mmpose/animal/resnet/res152_fly_192x192-fcafbd5a_20210407.pth \
-    --video-path https://user-images.githubusercontent.com/87690686/165095600-f68e0d42-830d-4c22-8940-c90c9f3bb817.mp4 \
-    --out-video-root vis_results
-```
-
 #### Using MMDetection to detect animals
 
 Assume that you have already installed [mmdet](https://github.com/open-mmlab/mmdetection).

--- a/demo/docs/2d_animal_demo.md
+++ b/demo/docs/2d_animal_demo.md
@@ -71,6 +71,32 @@ python demo/top_down_video_demo_full_frame_without_det.py \
 
 <img src="https://user-images.githubusercontent.com/11788150/114023530-944c8280-98a5-11eb-86b0-5f6d3e232af0.gif" height="140px" alt><br>
 
+#### Using the full image as input with GPU acceleration
+
+The following script performs inference on a video with GPU acceleration. Assume that you have already installed [ffmpegcv](https://github.com/chenxinfeng4/ffmpegcv).
+
+If the `--nvdecode` option is turned on, the video reader can support NVIDIA-VIDEO-DECODING if possible, to save more CPU workload.
+
+```shell
+python demo/top_down_video_demo_full_frame_without_det_gpuaccel.py \
+    ${MMPOSE_CONFIG_FILE} ${MMPOSE_CHECKPOINT_FILE} \
+    --video-path ${VIDEO_PATH} \
+    --out-video-root ${OUTPUT_VIDEO_ROOT} \
+    [--show --device ${GPU_ID or CPU}] \
+    [--kpt-thr ${KPT_SCORE_THR}] \
+    [--nvdecode]
+```
+
+Examples:
+
+```shell
+python demo/top_down_video_demo_full_frame_without_det_gpuaccel.py \
+    configs/animal/2d_kpt_sview_rgb_img/topdown_heatmap/fly/res152_fly_192x192.py \
+    https://download.openmmlab.com/mmpose/animal/resnet/res152_fly_192x192-fcafbd5a_20210407.pth \
+    --video-path https://user-images.githubusercontent.com/87690686/165095600-f68e0d42-830d-4c22-8940-c90c9f3bb817.mp4 \
+    --out-video-root vis_results
+```
+
 #### Using MMDetection to detect animals
 
 Assume that you have already installed [mmdet](https://github.com/open-mmlab/mmdetection).

--- a/demo/docs/2d_human_pose_demo.md
+++ b/demo/docs/2d_human_pose_demo.md
@@ -119,6 +119,53 @@ python demo/top_down_video_demo_with_mmdet.py \
     --use-multi-frames --online
 ```
 
+#### Using the full image as input
+
+We also provide a video demo which does not require human bounding box detection. If the video is cropped with the human centered in the screen, we can simply use the full image as the model input.
+
+```shell
+python demo/top_down_video_demo_full_frame_without_det.py \
+    ${MMPOSE_CONFIG_FILE} ${MMPOSE_CHECKPOINT_FILE} \
+    --video-path ${VIDEO_PATH} \
+    --out-video-root ${OUTPUT_VIDEO_ROOT} \
+    [--show --device ${GPU_ID or CPU}] \
+    [--kpt-thr ${KPT_SCORE_THR}]
+```
+
+Note that `${VIDEO_PATH}` can be the local path or **URL** link to video file.
+
+Examples:
+
+```shell
+python demo/top_down_video_demo_full_frame_without_det.py \
+    configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_res50_coco_256x192.py \
+     https://download.openmmlab.com/mmpose/top_down/vipnas/vipnas_res50_coco_256x192-cc43b466_20210624.pth \
+    --video-path https://user-images.githubusercontent.com/87690686/169808764-29e5678c-6762-4f43-8666-c3e60f94338f.mp4 \
+    --show
+```
+
+We also provide a GPU version which can accelerate inference and save CPU workload. Assume that you have already installed [ffmpegcv](https://github.com/chenxinfeng4/ffmpegcv). If the `--nvdecode` option is turned on, the video reader can support NVIDIA-VIDEO-DECODING for some qualified Nvidia GPUs, which can further accelerate the inference.
+
+```shell
+python demo/top_down_video_demo_full_frame_without_det_gpuaccel.py \
+    ${MMPOSE_CONFIG_FILE} ${MMPOSE_CHECKPOINT_FILE} \
+    --video-path ${VIDEO_PATH} \
+    --out-video-root ${OUTPUT_VIDEO_ROOT} \
+    [--show --device ${GPU_ID or CPU}] \
+    [--kpt-thr ${KPT_SCORE_THR}] \
+    [--nvdecode]
+```
+
+Examples:
+
+```shell
+python demo/top_down_video_demo_full_frame_without_det_gpuaccel.py \
+    configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/vipnas_res50_coco_256x192.py \
+     https://download.openmmlab.com/mmpose/top_down/vipnas/vipnas_res50_coco_256x192-cc43b466_20210624.pth \
+    --video-path https://user-images.githubusercontent.com/87690686/169808764-29e5678c-6762-4f43-8666-c3e60f94338f.mp4 \
+    --out-video-root vis_results
+```
+
 ### 2D Human Pose Bottom-Up Image Demo
 
 We provide a demo script to test a single image.

--- a/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
+++ b/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
@@ -113,7 +113,7 @@ def process_img(frame_resize, img_metas, device):
 def main():
     """Visualize the demo video with GPU acceleration.
 
-    Using mmdet to detect the human.
+    Using full frame to estimate the keypoints.
     """
     parser = ArgumentParser()
     parser.add_argument('pose_config', help='Config file for pose')

--- a/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
+++ b/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
@@ -21,6 +21,11 @@ except ImportError:
 
 
 def prefetch_img_metas(cfg, ori_wh):
+    """Pre-fetch the img_metas from config and original image size.
+
+    Return:
+        dict: img_metas.
+    """
     w, h = ori_wh
     bbox = np.array([0, 0, w, h])
     center, scale = _box2cs(cfg, bbox)
@@ -70,6 +75,10 @@ def prefetch_img_metas(cfg, ori_wh):
 
 
 def process_img(frame_resize, img_metas, device):
+    """Process the image.
+
+    Cast the image to device and do normalization.
+    """
     assert frame_resize.shape[1::-1] == tuple(
         img_metas['ann_info']['image_size'])
     frame_cuda = torch.from_numpy(frame_resize).to(device).float()

--- a/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
+++ b/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
@@ -187,11 +187,12 @@ def main():
         save_out_video = True
 
     if save_out_video:
-        videoWriter = ffmpegcv.VideoWriter(
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+        size = (video_origin.width, video_origin.height)
+        videoWriter = cv2.VideoWriter(
             os.path.join(args.out_video_root,
-                         f'vis_{os.path.basename(args.video_path)}'),
-            codec='mpeg4',
-            fps=video_origin.fps)
+                         f'vis_{os.path.basename(args.video_path)}'), fourcc,
+            video_origin.fps, size)
 
     with torch.no_grad():
         for frame_resize, frame_origin in zip(

--- a/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
+++ b/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
@@ -16,7 +16,8 @@ try:
     import ffmpegcv
 except ImportError:
     raise ImportError(
-        'Please install ffmpegcv with:\n\n    pip install ffmpegcv')
+        'Please install the ffmpeg: \n\n    apt install ffmpeg \n\n'
+        'And please install ffmpegcv with:\n\n    pip install ffmpegcv')
 
 
 def box2cs(box, image_size):
@@ -188,6 +189,7 @@ def main():
         videoWriter = ffmpegcv.VideoWriter(
             os.path.join(args.out_video_root,
                          f'vis_{os.path.basename(args.video_path)}'),
+            codec='mpeg4',
             fps=video_origin.fps)
 
     with torch.no_grad():

--- a/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
+++ b/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
@@ -1,0 +1,207 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import os
+import warnings
+from argparse import ArgumentParser
+
+import cv2
+import mmcv
+import numpy as np
+import torch
+from torchvision.transforms import functional as F
+
+from mmpose.apis import init_pose_model, vis_pose_result
+from mmpose.apis.inference import _box2cs
+from mmpose.datasets import DatasetInfo
+
+try:
+    import ffmpegcv
+except ImportError:
+    raise ImportError(
+        'Please install ffmpegcv with:\n\n    pip install ffmpegcv')
+
+
+def prefetch_img_metas(cfg, ori_wh):
+    w, h = ori_wh
+    bbox = np.array([0, 0, w, h])
+    center, scale = _box2cs(cfg, bbox)
+    scale /= 1.25  # never expand bbox area
+    dataset_info = cfg.data['test'].get('dataset_info', None)
+    assert dataset_info, 'Please set `dataset_info` in the config.'
+    img_metas = {
+        'img_or_path':
+        None,
+        'img':
+        None,
+        'image_file':
+        '',
+        'center':
+        center,
+        'scale':
+        scale,
+        'bbox_score':
+        1,
+        'bbox_id':
+        0,
+        'dataset':
+        dataset_info.dataset_name,
+        'joints_3d':
+        np.zeros((cfg.data_cfg.num_joints, 3), dtype=np.float32),
+        'joints_3d_visible':
+        np.zeros((cfg.data_cfg.num_joints, 3), dtype=np.float32),
+        'rotation':
+        0,
+        'ann_info': {
+            'image_size': np.array(cfg.data_cfg['image_size']),
+            'num_joints': cfg.data_cfg['num_joints'],
+            'flip_pairs': dataset_info.flip_pairs
+        }
+    }
+    for pipeline in cfg.test_pipeline[1:]:
+        if pipeline['type'] == 'NormalizeTensor':
+            img_metas['img_norm_cfg'] = {
+                'mean': np.array(pipeline['mean']) * 255.0,
+                'std': np.array(pipeline['std']) * 255.0
+            }
+            break
+    else:
+        raise Exception('NormalizeTensor is not found.')
+
+    return img_metas
+
+
+def process_img(frame_resize, img_metas, device):
+    assert frame_resize.shape[1::-1] == tuple(
+        img_metas['ann_info']['image_size'])
+    frame_cuda = torch.from_numpy(frame_resize).to(device).float()
+    frame_cuda = frame_cuda.permute(2, 0, 1)  # HWC to CHW
+    mean = torch.from_numpy(img_metas['img_norm_cfg']['mean']).to(device)
+    std = torch.from_numpy(img_metas['img_norm_cfg']['std']).to(device)
+    frame_cuda = F.normalize(frame_cuda, mean=mean, std=std, inplace=True)
+    frame_cuda = frame_cuda[None, :, :, :]  # NCHW
+    data = {'img': frame_cuda, 'img_metas': [img_metas]}
+    return data
+
+
+def main():
+    """Visualize the demo video with GPU acceleration.
+
+    Using mmdet to detect the human.
+    """
+    parser = ArgumentParser()
+    parser.add_argument('pose_config', help='Config file for pose')
+    parser.add_argument('pose_checkpoint', help='Checkpoint file for pose')
+    parser.add_argument('--video-path', type=str, help='Video path')
+    parser.add_argument(
+        '--show',
+        action='store_true',
+        default=False,
+        help='whether to show visualizations.')
+    parser.add_argument(
+        '--out-video-root',
+        default='',
+        help='Root of the output video file. '
+        'Default not saving the visualization video.')
+    parser.add_argument(
+        '--device', default='cuda:0', help='Device used for inference')
+    parser.add_argument(
+        '--nvdecode', action='store_true', help='Use NVIDIA decoder')
+    parser.add_argument(
+        '--kpt-thr', type=float, default=0.3, help='Keypoint score threshold')
+    parser.add_argument(
+        '--radius',
+        type=int,
+        default=4,
+        help='Keypoint radius for visualization')
+    parser.add_argument(
+        '--thickness',
+        type=int,
+        default=1,
+        help='Link thickness for visualization')
+
+    args = parser.parse_args()
+
+    assert args.show or (args.out_video_root != '')
+    # build the pose model from a config file and a checkpoint file
+    pose_model = init_pose_model(
+        args.pose_config, args.pose_checkpoint, device=args.device.lower())
+
+    dataset = pose_model.cfg.data['test']['type']
+    dataset_info = pose_model.cfg.data['test'].get('dataset_info', None)
+    if dataset_info is None:
+        warnings.warn(
+            'Please set `dataset_info` in the config.'
+            'Check https://github.com/open-mmlab/mmpose/pull/663 for details.',
+            DeprecationWarning)
+    else:
+        dataset_info = DatasetInfo(dataset_info)
+
+    pose_model.cfg.data['test']['dataset_info'] = dataset_info
+    if args.nvdecode:
+        VideoCapture = ffmpegcv.VideoCaptureNV
+    else:
+        VideoCapture = ffmpegcv.VideoCapture
+    video_origin = VideoCapture(args.video_path)
+    img_metas = prefetch_img_metas(pose_model.cfg,
+                                   (video_origin.width, video_origin.height))
+    resize_wh = pose_model.cfg.data_cfg['image_size']
+    video_resize = VideoCapture(
+        args.video_path,
+        resize=resize_wh,
+        resize_keepratio=True,
+        pix_fmt='rgb24')
+
+    if args.out_video_root == '':
+        save_out_video = False
+    else:
+        os.makedirs(args.out_video_root, exist_ok=True)
+        save_out_video = True
+
+    if save_out_video:
+        videoWriter = ffmpegcv.VideoWriter(
+            os.path.join(args.out_video_root,
+                         f'vis_{os.path.basename(args.video_path)}'),
+            fps=video_origin.fps)
+
+    with torch.no_grad():
+        for frame_resize, frame_origin in zip(
+                mmcv.track_iter_progress(video_resize), video_origin):
+
+            # test a single image
+            data = process_img(frame_resize, img_metas, args.device)
+            pose_results = pose_model(
+                return_loss=False, return_heatmap=False, **data)
+            pose_results['keypoints'] = pose_results['preds'][0]
+            del pose_results['preds']
+            pose_results = [pose_results]
+
+            # show the results
+            vis_img = vis_pose_result(
+                pose_model,
+                frame_origin,
+                pose_results,
+                radius=args.radius,
+                thickness=args.thickness,
+                dataset=dataset,
+                dataset_info=dataset_info,
+                kpt_score_thr=args.kpt_thr,
+                show=False)
+
+            if args.show:
+                cv2.imshow('Image', vis_img)
+
+            if save_out_video:
+                videoWriter.write(vis_img)
+
+            if args.show and cv2.waitKey(1) & 0xFF == ord('q'):
+                break
+
+    frame_origin.release()
+    frame_resize.release()
+    if save_out_video:
+        videoWriter.release()
+    if args.show:
+        cv2.destroyAllWindows()
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
+++ b/demo/top_down_video_demo_full_frame_without_det_gpuaccel.py
@@ -78,8 +78,9 @@ def prefetch_img_metas(cfg, ori_wh):
         'ann_info': {
             'image_size': np.array(cfg.data_cfg['image_size']),
             'num_joints': cfg.data_cfg['num_joints'],
-            'flip_pairs': dataset_info.flip_pairs
-        }
+        },
+        'flip_pairs':
+        dataset_info.flip_pairs
     }
     for pipeline in cfg.test_pipeline[1:]:
         if pipeline['type'] == 'NormalizeTensor':
@@ -225,8 +226,8 @@ def main():
             if args.show and cv2.waitKey(1) & 0xFF == ord('q'):
                 break
 
-    frame_origin.release()
-    frame_resize.release()
+    video_origin.release()
+    video_resize.release()
     if save_out_video:
         videoWriter.release()
     if args.show:


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->
It's a parallel to my ![mmdetection PR](https://github.com/open-mmlab/mmdetection/pull/7832).
## Motivation

The video inference was not efficient, because there are many "resize", "padding", "to rgb" and "normalize" operations in CPU workload. Besides, the 'img_metas' is calculated for every frame, which is nonefficient. The CPU workload is really high, but the speed is slow.

## Modification

I transformed the video "crop", "resize", "padding", "to rgb" in ffmpeg-based video reader, which is lite and CPU friendly. The video reader can support NVIDIA-VIDEO-DECODING if possible, to save more CPU workload. And the "normalize" is done in GPU. In all, I reduced the data-loading time and CPU workload.


## Result

For the pure data loading, it can reach 400 Fps (possible the ceiling of NVIDIA-DECODER). The CPU work load is acceptable (450%).
```python
    for frame_resize, frame_origin in zip(
            mmcv.track_iter_progress(video_resize), video_origin):

        # test a single frame without model inference
        data = process_img(frame_resize, img_metas, args.device)
        continue
        pose_results = pose_model(
                return_loss=False, return_heatmap=False, **data)
```
> The video size is 1280x800, converting to image size 512x512. 

<img width="552" alt="图片" src="https://user-images.githubusercontent.com/17546446/165798368-debdf15f-8163-4264-bf55-b3193bc67020.png">

<img width="590" alt="图片" src="https://user-images.githubusercontent.com/17546446/165798927-9a6e6d8b-1e13-4009-ade4-0c6694e30a38.png">

## Limitation
1. Only works for `top_down_video_demo_full_frame_without_det.py`. May be adaptive to `bottom_up_video_demo.py`. 
2. Didn't support for flip-pair test.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.


**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.


