### PR TITLE
[Fix] Add warning message in coco evaluation when gt annotations are absent

### DIFF
--- a/mmpose/datasets/datasets/animal/animal_ap10k_dataset.py
+++ b/mmpose/datasets/datasets/animal/animal_ap10k_dataset.py
@@ -282,11 +282,19 @@ class AnimalAP10KDataset(Kpt2dSviewRgbImgTopDownDataset):
 
         self._write_coco_keypoint_results(valid_kpts, res_file)
 
-        info_str = self._do_python_keypoint_eval(res_file)
-        name_value = OrderedDict(info_str)
+        # do evaluation only if the ground truth keypoint annotations exist
+        if 'annotations' in self.coco.dataset:
+            info_str = self._do_python_keypoint_eval(res_file)
+            name_value = OrderedDict(info_str)
 
-        if tmp_folder is not None:
-            tmp_folder.cleanup()
+            if tmp_folder is not None:
+                tmp_folder.cleanup()
+        else:
+            warnings.warn(f'Due to the absence of ground truth keypoint'
+                          f'annotations, the quantitative evaluation can not'
+                          f'be conducted. The prediction results have been'
+                          f'saved at: {osp.abspath(res_file)}')
+            name_value = {}
 
         return name_value
 

--- a/mmpose/datasets/datasets/animal/animal_atrw_dataset.py
+++ b/mmpose/datasets/datasets/animal/animal_atrw_dataset.py
@@ -267,11 +267,19 @@ class AnimalATRWDataset(Kpt2dSviewRgbImgTopDownDataset):
 
         self._write_coco_keypoint_results(valid_kpts, res_file)
 
-        info_str = self._do_python_keypoint_eval(res_file)
-        name_value = OrderedDict(info_str)
+        # do evaluation only if the ground truth keypoint annotations exist
+        if 'annotations' in self.coco.dataset:
+            info_str = self._do_python_keypoint_eval(res_file)
+            name_value = OrderedDict(info_str)
 
-        if tmp_folder is not None:
-            tmp_folder.cleanup()
+            if tmp_folder is not None:
+                tmp_folder.cleanup()
+        else:
+            warnings.warn(f'Due to the absence of ground truth keypoint'
+                          f'annotations, the quantitative evaluation can not'
+                          f'be conducted. The prediction results have been'
+                          f'saved at: {osp.abspath(res_file)}')
+            name_value = {}
 
         return name_value
 

--- a/mmpose/datasets/datasets/animal/animal_macaque_dataset.py
+++ b/mmpose/datasets/datasets/animal/animal_macaque_dataset.py
@@ -269,11 +269,19 @@ class AnimalMacaqueDataset(Kpt2dSviewRgbImgTopDownDataset):
 
         self._write_coco_keypoint_results(valid_kpts, res_file)
 
-        info_str = self._do_python_keypoint_eval(res_file)
-        name_value = OrderedDict(info_str)
+        # do evaluation only if the ground truth keypoint annotations exist
+        if 'annotations' in self.coco.dataset:
+            info_str = self._do_python_keypoint_eval(res_file)
+            name_value = OrderedDict(info_str)
 
-        if tmp_folder is not None:
-            tmp_folder.cleanup()
+            if tmp_folder is not None:
+                tmp_folder.cleanup()
+        else:
+            warnings.warn(f'Due to the absence of ground truth keypoint'
+                          f'annotations, the quantitative evaluation can not'
+                          f'be conducted. The prediction results have been'
+                          f'saved at: {osp.abspath(res_file)}')
+            name_value = {}
 
         return name_value
 

--- a/mmpose/datasets/datasets/animal/animal_pose_dataset.py
+++ b/mmpose/datasets/datasets/animal/animal_pose_dataset.py
@@ -273,11 +273,19 @@ class AnimalPoseDataset(Kpt2dSviewRgbImgTopDownDataset):
 
         self._write_coco_keypoint_results(valid_kpts, res_file)
 
-        info_str = self._do_python_keypoint_eval(res_file)
-        name_value = OrderedDict(info_str)
+        # do evaluation only if the ground truth keypoint annotations exist
+        if 'annotations' in self.coco.dataset:
+            info_str = self._do_python_keypoint_eval(res_file)
+            name_value = OrderedDict(info_str)
 
-        if tmp_folder is not None:
-            tmp_folder.cleanup()
+            if tmp_folder is not None:
+                tmp_folder.cleanup()
+        else:
+            warnings.warn(f'Due to the absence of ground truth keypoint'
+                          f'annotations, the quantitative evaluation can not'
+                          f'be conducted. The prediction results have been'
+                          f'saved at: {osp.abspath(res_file)}')
+            name_value = {}
 
         return name_value
 

--- a/mmpose/datasets/datasets/bottom_up/bottom_up_coco.py
+++ b/mmpose/datasets/datasets/bottom_up/bottom_up_coco.py
@@ -220,11 +220,19 @@ class BottomUpCocoDataset(Kpt2dSviewRgbImgBottomUpDataset):
 
         self._write_coco_keypoint_results(valid_kpts, res_file)
 
-        info_str = self._do_python_keypoint_eval(res_file)
-        name_value = OrderedDict(info_str)
+        # do evaluation only if the ground truth keypoint annotations exist
+        if 'annotations' in self.coco.dataset:
+            info_str = self._do_python_keypoint_eval(res_file)
+            name_value = OrderedDict(info_str)
 
-        if tmp_folder is not None:
-            tmp_folder.cleanup()
+            if tmp_folder is not None:
+                tmp_folder.cleanup()
+        else:
+            warnings.warn(f'Due to the absence of ground truth keypoint'
+                          f'annotations, the quantitative evaluation can not'
+                          f'be conducted. The prediction results have been'
+                          f'saved at: {osp.abspath(res_file)}')
+            name_value = {}
 
         return name_value
 

--- a/mmpose/datasets/datasets/top_down/topdown_coco_dataset.py
+++ b/mmpose/datasets/datasets/top_down/topdown_coco_dataset.py
@@ -316,11 +316,19 @@ class TopDownCocoDataset(Kpt2dSviewRgbImgTopDownDataset):
 
         self._write_coco_keypoint_results(valid_kpts, res_file)
 
-        info_str = self._do_python_keypoint_eval(res_file)
-        name_value = OrderedDict(info_str)
+        # do evaluation only if the ground truth keypoint annotations exist
+        if 'annotations' in self.coco.dataset:
+            info_str = self._do_python_keypoint_eval(res_file)
+            name_value = OrderedDict(info_str)
 
-        if tmp_folder is not None:
-            tmp_folder.cleanup()
+            if tmp_folder is not None:
+                tmp_folder.cleanup()
+        else:
+            warnings.warn(f'Due to the absence of ground truth keypoint'
+                          f'annotations, the quantitative evaluation can not'
+                          f'be conducted. The prediction results have been'
+                          f'saved at: {osp.abspath(res_file)}')
+            name_value = {}
 
         return name_value
 

--- a/tests/test_datasets/test_animal_dataset.py
+++ b/tests/test_datasets/test_animal_dataset.py
@@ -301,6 +301,11 @@ def test_animal_ATRW_dataset():
     with pytest.raises(KeyError):
         infos = custom_dataset.evaluate(results, metric=['PCK'])
 
+    # Test when gt annotations are absent
+    del custom_dataset.coco.dataset['annotations']
+    with pytest.warns(UserWarning):
+        _ = custom_dataset.evaluate(results, metric='mAP')
+
 
 def test_animal_Macaque_dataset():
     dataset = 'AnimalMacaqueDataset'
@@ -363,6 +368,11 @@ def test_animal_Macaque_dataset():
 
     with pytest.raises(KeyError):
         infos = custom_dataset.evaluate(results, metric=['PCK'])
+
+    # Test when gt annotations are absent
+    del custom_dataset.coco.dataset['annotations']
+    with pytest.warns(UserWarning):
+        _ = custom_dataset.evaluate(results, metric='mAP')
 
 
 def test_animalpose_dataset():
@@ -431,6 +441,11 @@ def test_animalpose_dataset():
     with pytest.raises(KeyError):
         infos = custom_dataset.evaluate(results, metric=['PCK'])
 
+    # Test when gt annotations are absent
+    del custom_dataset.coco.dataset['annotations']
+    with pytest.warns(UserWarning):
+        _ = custom_dataset.evaluate(results, metric='mAP')
+
 
 def test_ap10k_dataset():
     dataset = 'AnimalAP10KDataset'
@@ -498,3 +513,8 @@ def test_ap10k_dataset():
 
     with pytest.raises(KeyError):
         infos = custom_dataset.evaluate(results, metric=['PCK'])
+
+    # Test when gt annotations are absent
+    del custom_dataset.coco.dataset['annotations']
+    with pytest.warns(UserWarning):
+        _ = custom_dataset.evaluate(results, metric='mAP')

--- a/tests/test_datasets/test_bottom_up_dataset.py
+++ b/tests/test_datasets/test_bottom_up_dataset.py
@@ -100,6 +100,11 @@ def test_bottom_up_COCO_dataset():
     with pytest.raises(KeyError):
         _ = custom_dataset.evaluate(results, metric='PCK')
 
+    # Test when gt annotations are absent
+    del custom_dataset.coco.dataset['annotations']
+    with pytest.warns(UserWarning):
+        _ = custom_dataset.evaluate(results, metric='mAP')
+
 
 def test_bottom_up_CrowdPose_dataset():
     dataset = 'BottomUpCrowdPoseDataset'

--- a/tests/test_datasets/test_top_down_dataset.py
+++ b/tests/test_datasets/test_top_down_dataset.py
@@ -87,6 +87,11 @@ def test_top_down_COCO_dataset():
     with pytest.raises(KeyError):
         _ = custom_dataset.evaluate(results, metric='PCK')
 
+    # Test when gt annotations are absent
+    del custom_dataset.coco.dataset['annotations']
+    with pytest.warns(UserWarning):
+        _ = custom_dataset.evaluate(results, metric='mAP')
+
 
 def test_top_down_MHP_dataset():
     dataset = 'TopDownMhpDataset'


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

When the ground truth keypoint annotations are absent, the evaluation will end with a confusing error message like: 
`AttributeError: 'COCOeval' object has no attribute 'score_key' `.

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

## Modification

<!-- Please briefly describe what modification is made in this PR. -->
1. Add warning message in coco evaluation function. 
2. Skip 
```python
tmp_folder.cleanup()
```
to save the results json file if it is saved under `tmp_folder`.

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
