### PR TITLE
Adjust inference tracking min keypoints

### DIFF
--- a/mmpose/apis/inference_tracking.py
+++ b/mmpose/apis/inference_tracking.py
@@ -182,7 +182,7 @@ def get_track_id(results,
             equivalent to an empty result list. Default: None
         next_id (int): The track id for the new person instance.
         min_keypoints (int): Minimum number of keypoints recognized as person.
-            default: 3.
+            0 means no minimum threshold required. Default: 3.
         use_oks (bool): Flag to using oks tracking. default: False.
         tracking_thr (float): The threshold for tracking.
         use_one_euro (bool): Option to use one-euro-filter. default: False.
@@ -218,7 +218,8 @@ def get_track_id(results,
         track_id, results_last, match_result = _track(result, results_last,
                                                       tracking_thr)
         if track_id == -1:
-            if np.count_nonzero(result['keypoints'][:, 1]) > min_keypoints:
+            if min_keypoints <= 0 or np.count_nonzero(
+                    result['keypoints'][:, 1]) >= min_keypoints:
                 result['track_id'] = next_id
                 next_id += 1
             else:

--- a/mmpose/apis/inference_tracking.py
+++ b/mmpose/apis/inference_tracking.py
@@ -218,8 +218,7 @@ def get_track_id(results,
         track_id, results_last, match_result = _track(result, results_last,
                                                       tracking_thr)
         if track_id == -1:
-            if min_keypoints <= 0 or np.count_nonzero(
-                    result['keypoints'][:, 1]) >= min_keypoints:
+            if np.count_nonzero(result['keypoints'][:, 1]) >= min_keypoints:
                 result['track_id'] = next_id
                 next_id += 1
             else:


### PR DESCRIPTION
## Motivation

The `get_track_id()` function in `inference_tracking.py` has a `min_keypoints` parameter that promises:
```
min_keypoints (int): Minimum number of keypoints recognized as person.
```
For the default value of 3, this means that all detected poses with 3 or more keypoints start a new track if it is not matched above a threshold to an existing track. The implementation has an off-by-one error though meaning in this case only detected poses with 4 or more keypoints will start a new track:
```
if np.count_nonzero(result['keypoints'][:, 1]) > min_keypoints:
```
This is unexpected/unclear for the user of the function.

## Modification

The obvious solution is to change `>` to `>=`, but this leads to a problem when `min_keypoints` is zero, so it needs to become:
```
if min_keypoints <= 0 or np.count_nonzero(result['keypoints'][:, 1]) >= min_keypoints:
```

## Use cases

One use case is that tracking by default is only performed by bbox IOU, so you would naturally expect the track ID of the 2D pose to be equivalent to the bounding box track ID, or want it to be (e.g. I do in my application). It is not equivalent however if pose detection returns too few keypoints. Passing `min_keypoints=0` makes it possible to achieve the described matching behaviour, which was not possible at all with the original code.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
