### PR TITLE
[Feature] Add algebraic triangulation (multi-view 3D pose)

### DIFF
--- a/mmpose/models/detectors/multiview_pose.py
+++ b/mmpose/models/detectors/multiview_pose.py
@@ -964,3 +964,16 @@ class VoxelCenterDetector(BasePose):
         initial_cubes = feature_maps[0].new_zeros(batch_size, num_channels,
                                                   *self.cube_size)
         _ = self.center_net(initial_cubes)
+
+
+@POSENETS.register_module()
+class AlgebraicTriangulation(BasePose):
+    """Estimate 3D human pose using learnable weighted triangulation.
+
+    Please refer to the
+    `paper <https://arxiv.org/abs/1905.05754>` for details.
+    Args:
+    """
+
+    def __init__(self):
+        pass


### PR DESCRIPTION
## Motivation

Based on a current roadmap (#9), we want to add "Learnable Triangulation of Human Pose" ([link to paper](https://arxiv.org/abs/1905.05754)).

## Modification

For now, I created a new class in `models->detectors->multiview_pose.py`.

## Use cases (Optional)

The _algebraic triangulation_ is one of the two proposed models (the other is volumetric triangulation). The volumetric triangulation was the state-of-the-art of 3D human pose estimation task for a relatively long time. The algebraic triangulation is simpler, but still powerful model. Moreover, the volumetric triangulation depends on the algebraic triangulation (needs algebraic model to locate the root joint). Therefore, it is reasonable to first add the algebraic triangulation.

## Checklist

**Before PR**:

- [X] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [X] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
