### PR TITLE
[Feature] Add layer decay optimizer constructor and learning rate decay optimizer constructor

### DIFF
--- a/docs/en/tutorials/6_customize_runtime.md
+++ b/docs/en/tutorials/6_customize_runtime.md
@@ -86,7 +86,7 @@ from .my_optimizer import MyOptimizer
 - Use `custom_imports` in the config to manually import it
 
 ```python
-custom_imports = dict(imports=['mmpose.core.optimizer.my_optimizer'], allow_failed_imports=False)
+custom_imports = dict(imports=['mmpose.core.optimizers.my_optimizer'], allow_failed_imports=False)
 ```
 
 The module `mmpose.core.optimizer.my_optimizer` will be imported at the beginning of the program and the class `MyOptimizer` is then automatically registered.

--- a/docs/zh_cn/tutorials/6_customize_runtime.md
+++ b/docs/zh_cn/tutorials/6_customize_runtime.md
@@ -81,7 +81,7 @@ from .my_optimizer import MyOptimizer
 - 在配置文件中使用 `custom_imports` 手动导入
 
 ```python
-custom_imports = dict(imports=['mmpose.core.optimizer.my_optimizer'], allow_failed_imports=False)
+custom_imports = dict(imports=['mmpose.core.optimizers.my_optimizer'], allow_failed_imports=False)
 ```
 
 在程序运行之初，库 `mmpose.core.optimizer.my_optimizer` 将会被导入。此时类 `MyOptimizer` 会自动注册。

--- a/mmpose/core/__init__.py
+++ b/mmpose/core/__init__.py
@@ -3,7 +3,7 @@ from .bbox import *  # noqa: F401, F403
 from .camera import *  # noqa: F401, F403
 from .evaluation import *  # noqa: F401, F403
 from .fp16 import *  # noqa: F401, F403
-from .optimizer import *  # noqa: F401, F403
+from .optimizers import *  # noqa: F401, F403
 from .post_processing import *  # noqa: F401, F403
 from .utils import *  # noqa: F401, F403
 from .visualization import *  # noqa: F401, F403

--- a/mmpose/core/optimizer/__init__.py
+++ b/mmpose/core/optimizer/__init__.py
@@ -1,4 +1,0 @@
-# Copyright (c) OpenMMLab. All rights reserved.
-from .builder import OPTIMIZERS, build_optimizers
-
-__all__ = ['build_optimizers', 'OPTIMIZERS']

--- a/mmpose/core/optimizers/__init__.py
+++ b/mmpose/core/optimizers/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .builder import (OPTIMIZER_BUILDERS, OPTIMIZERS,
+                      build_optimizer_constructor, build_optimizers)
+
+__all__ = [
+    'build_optimizers', 'build_optimizer_constructor', 'OPTIMIZERS',
+    'OPTIMIZER_BUILDERS'
+]

--- a/mmpose/core/optimizers/builder.py
+++ b/mmpose/core/optimizers/builder.py
@@ -1,8 +1,22 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from mmcv.runner import build_optimizer
-from mmcv.utils import Registry
+from mmcv.runner.optimizer import OPTIMIZER_BUILDERS as MMCV_OPTIMIZER_BUILDERS
+from mmcv.utils import Registry, build_from_cfg
 
 OPTIMIZERS = Registry('optimizers')
+OPTIMIZER_BUILDERS = Registry(
+    'optimizer builder', parent=MMCV_OPTIMIZER_BUILDERS)
+
+
+def build_optimizer_constructor(cfg):
+    constructor_type = cfg.get('type')
+    if constructor_type in OPTIMIZER_BUILDERS:
+        return build_from_cfg(cfg, OPTIMIZER_BUILDERS)
+    elif constructor_type in MMCV_OPTIMIZER_BUILDERS:
+        return build_from_cfg(cfg, MMCV_OPTIMIZER_BUILDERS)
+    else:
+        raise KeyError(f'{constructor_type} is not registered '
+                       'in the optimizer builder registry.')
 
 
 def build_optimizers(model, cfgs):

--- a/mmpose/core/optimizers/layer_decay_optimizer_constructor.py
+++ b/mmpose/core/optimizers/layer_decay_optimizer_constructor.py
@@ -3,8 +3,8 @@ import json
 import warnings
 
 from mmcv.runner import DefaultOptimizerConstructor, get_dist_info
-from mmdet.utils import get_root_logger
 
+from mmpose.utils import get_root_logger
 from .builder import OPTIMIZER_BUILDERS
 
 

--- a/mmpose/core/optimizers/layer_decay_optimizer_constructor.py
+++ b/mmpose/core/optimizers/layer_decay_optimizer_constructor.py
@@ -1,0 +1,208 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import json
+import warnings
+
+from mmcv.runner import DefaultOptimizerConstructor, get_dist_info
+from mmdet.utils import get_root_logger
+
+from .builder import OPTIMIZER_BUILDERS
+
+
+def get_layer_id_for_convnext(var_name, max_layer_id):
+    """Get the layer id to set the different learning rates in ``layer_wise``
+    decay_type.
+
+    Args:
+        var_name (str): The key of the model.
+        max_layer_id (int): Maximum number of backbone layers.
+
+    Returns:
+        int: The id number corresponding to different learning rate in
+        ``LearningRateDecayOptimizerConstructor``.
+    """
+
+    if var_name in ('backbone.cls_token', 'backbone.mask_token',
+                    'backbone.pos_embed'):
+        return 0
+    elif var_name.startswith('backbone.downsample_layers'):
+        stage_id = int(var_name.split('.')[2])
+        if stage_id == 0:
+            layer_id = 0
+        elif stage_id == 1:
+            layer_id = 2
+        elif stage_id == 2:
+            layer_id = 3
+        elif stage_id == 3:
+            layer_id = max_layer_id
+        return layer_id
+    elif var_name.startswith('backbone.stages'):
+        stage_id = int(var_name.split('.')[2])
+        block_id = int(var_name.split('.')[3])
+        if stage_id == 0:
+            layer_id = 1
+        elif stage_id == 1:
+            layer_id = 2
+        elif stage_id == 2:
+            layer_id = 3 + block_id // 3
+        elif stage_id == 3:
+            layer_id = max_layer_id
+        return layer_id
+    else:
+        return max_layer_id + 1
+
+
+def get_stage_id_for_convnext(var_name, max_stage_id):
+    """Get the stage id to set the different learning rates in ``stage_wise``
+    decay_type.
+
+    Args:
+        var_name (str): The key of the model.
+        max_stage_id (int): Maximum number of backbone layers.
+
+    Returns:
+        int: The id number corresponding to different learning rate in
+        ``LearningRateDecayOptimizerConstructor``.
+    """
+
+    if var_name in ('backbone.cls_token', 'backbone.mask_token',
+                    'backbone.pos_embed'):
+        return 0
+    elif var_name.startswith('backbone.downsample_layers'):
+        return 0
+    elif var_name.startswith('backbone.stages'):
+        stage_id = int(var_name.split('.')[2])
+        return stage_id + 1
+    else:
+        return max_stage_id - 1
+
+
+def get_layer_id_for_vit(var_name, max_layer_id):
+    """Get the layer id to set the different learning rates.
+
+    Args:
+        var_name (str): The key of the model.
+        num_max_layer (int): Maximum number of backbone layers.
+
+    Returns:
+        int: Returns the layer id of the key.
+    """
+
+    if var_name in ('backbone.cls_token', 'backbone.mask_token',
+                    'backbone.pos_embed'):
+        return 0
+    elif var_name.startswith('backbone.patch_embed'):
+        return 0
+    elif var_name.startswith('backbone.layers'):
+        layer_id = int(var_name.split('.')[2])
+        return layer_id + 1
+    else:
+        return max_layer_id - 1
+
+
+@OPTIMIZER_BUILDERS.register_module()
+class LearningRateDecayOptimizerConstructor(DefaultOptimizerConstructor):
+    """Different learning rates are set for different layers of backbone.
+
+    Note: Currently, this optimizer constructor is built for ConvNeXt,
+    BEiT and MAE.
+    """
+
+    def add_params(self, params, module, **kwargs):
+        """Add all parameters of module to the params list.
+
+        The parameters of the given module will be added to the list of param
+        groups, with specific rules defined by paramwise_cfg.
+
+        Args:
+            params (list[dict]): A list of param groups, it will be modified
+                in place.
+            module (nn.Module): The module to be added.
+        """
+        logger = get_root_logger()
+
+        parameter_groups = {}
+        logger.info(f'self.paramwise_cfg is {self.paramwise_cfg}')
+        num_layers = self.paramwise_cfg.get('num_layers') + 2
+        decay_rate = self.paramwise_cfg.get('decay_rate')
+        decay_type = self.paramwise_cfg.get('decay_type', 'layer_wise')
+        logger.info('Build LearningRateDecayOptimizerConstructor  '
+                    f'{decay_type} {decay_rate} - {num_layers}')
+        weight_decay = self.base_wd
+        for name, param in module.named_parameters():
+            if not param.requires_grad:
+                continue  # frozen weights
+            if len(param.shape) == 1 or name.endswith('.bias') or name in (
+                    'pos_embed', 'cls_token'):
+                group_name = 'no_decay'
+                this_weight_decay = 0.
+            else:
+                group_name = 'decay'
+                this_weight_decay = weight_decay
+            if 'layer_wise' in decay_type:
+                if 'ConvNeXt' in module.backbone.__class__.__name__:
+                    layer_id = get_layer_id_for_convnext(
+                        name, self.paramwise_cfg.get('num_layers'))
+                    logger.info(f'set param {name} as id {layer_id}')
+                elif 'BEiT' in module.backbone.__class__.__name__ or \
+                     'MAE' in module.backbone.__class__.__name__:
+                    layer_id = get_layer_id_for_vit(name, num_layers)
+                    logger.info(f'set param {name} as id {layer_id}')
+                else:
+                    raise NotImplementedError()
+            elif decay_type == 'stage_wise':
+                if 'ConvNeXt' in module.backbone.__class__.__name__:
+                    layer_id = get_stage_id_for_convnext(name, num_layers)
+                    logger.info(f'set param {name} as id {layer_id}')
+                else:
+                    raise NotImplementedError()
+            group_name = f'layer_{layer_id}_{group_name}'
+
+            if group_name not in parameter_groups:
+                scale = decay_rate**(num_layers - layer_id - 1)
+
+                parameter_groups[group_name] = {
+                    'weight_decay': this_weight_decay,
+                    'params': [],
+                    'param_names': [],
+                    'lr_scale': scale,
+                    'group_name': group_name,
+                    'lr': scale * self.base_lr,
+                }
+
+            parameter_groups[group_name]['params'].append(param)
+            parameter_groups[group_name]['param_names'].append(name)
+        rank, _ = get_dist_info()
+        if rank == 0:
+            to_display = {}
+            for key in parameter_groups:
+                to_display[key] = {
+                    'param_names': parameter_groups[key]['param_names'],
+                    'lr_scale': parameter_groups[key]['lr_scale'],
+                    'lr': parameter_groups[key]['lr'],
+                    'weight_decay': parameter_groups[key]['weight_decay'],
+                }
+            logger.info(f'Param groups = {json.dumps(to_display, indent=2)}')
+        params.extend(parameter_groups.values())
+
+
+@OPTIMIZER_BUILDERS.register_module()
+class LayerDecayOptimizerConstructor(LearningRateDecayOptimizerConstructor):
+    """Different learning rates are set for different layers of backbone.
+
+    Note: Currently, this optimizer constructor is built for BEiT,
+    and it will be deprecated.
+    Please use ``LearningRateDecayOptimizerConstructor`` instead.
+    """
+
+    def __init__(self, optimizer_cfg, paramwise_cfg):
+        warnings.warn('DeprecationWarning: Original '
+                      'LayerDecayOptimizerConstructor of BEiT '
+                      'will be deprecated. Please use '
+                      'LearningRateDecayOptimizerConstructor instead, '
+                      'and set decay_type = layer_wise_vit in paramwise_cfg.')
+        paramwise_cfg.update({'decay_type': 'layer_wise_vit'})
+        warnings.warn('DeprecationWarning: Layer_decay_rate will '
+                      'be deleted, please use decay_rate instead.')
+        paramwise_cfg['decay_rate'] = paramwise_cfg.pop('layer_decay_rate')
+        super(LayerDecayOptimizerConstructor,
+              self).__init__(optimizer_cfg, paramwise_cfg)

--- a/tests/test_core/test_layer_decay_optimizer_constructor.py
+++ b/tests/test_core/test_layer_decay_optimizer_constructor.py
@@ -170,7 +170,7 @@ class ToyMAE(nn.Module):
             self.layers.append(layer)
 
 
-class ToySegmentor(nn.Module):
+class ToyPoseDetector(nn.Module):
 
     def __init__(self, backbone):
         super().__init__()
@@ -208,7 +208,7 @@ def test_learning_rate_decay_optimizer_constructor():
 
     # Test lr wd for ConvNeXT
     backbone = ToyConvNeXt()
-    model = PseudoDataParallel(ToySegmentor(backbone))
+    model = PseudoDataParallel(ToyPoseDetector(backbone))
     optimizer_cfg = dict(
         type='AdamW', lr=base_lr, betas=(0.9, 0.999), weight_decay=0.05)
     # stagewise decay
@@ -228,7 +228,7 @@ def test_learning_rate_decay_optimizer_constructor():
 
     # Test lr wd for BEiT
     backbone = ToyBEiT()
-    model = PseudoDataParallel(ToySegmentor(backbone))
+    model = PseudoDataParallel(ToyPoseDetector(backbone))
 
     layerwise_paramwise_cfg = dict(
         decay_rate=decay_rate, decay_type='layer_wise', num_layers=3)
@@ -239,7 +239,7 @@ def test_learning_rate_decay_optimizer_constructor():
 
     # Test invalidation of lr wd for Vit
     backbone = ToyViT()
-    model = PseudoDataParallel(ToySegmentor(backbone))
+    model = PseudoDataParallel(ToyPoseDetector(backbone))
     with pytest.raises(NotImplementedError):
         optim_constructor = LearningRateDecayOptimizerConstructor(
             optimizer_cfg, layerwise_paramwise_cfg)
@@ -251,7 +251,7 @@ def test_learning_rate_decay_optimizer_constructor():
 
     # Test lr wd for MAE
     backbone = ToyMAE()
-    model = PseudoDataParallel(ToySegmentor(backbone))
+    model = PseudoDataParallel(ToyPoseDetector(backbone))
 
     layerwise_paramwise_cfg = dict(
         decay_rate=decay_rate, decay_type='layer_wise', num_layers=3)
@@ -265,7 +265,7 @@ def test_beit_layer_decay_optimizer_constructor():
 
     # paramwise_cfg with BEiTExampleModel
     backbone = ToyBEiT()
-    model = PseudoDataParallel(ToySegmentor(backbone))
+    model = PseudoDataParallel(ToyPoseDetector(backbone))
     optimizer_cfg = dict(
         type='AdamW', lr=1, betas=(0.9, 0.999), weight_decay=0.05)
     paramwise_cfg = dict(layer_decay_rate=2, num_layers=3)

--- a/tests/test_core/test_layer_decay_optimizer_constructor.py
+++ b/tests/test_core/test_layer_decay_optimizer_constructor.py
@@ -1,0 +1,275 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import pytest
+import torch
+import torch.nn as nn
+from mmcv.cnn import ConvModule
+
+from mmpose.core.optimizers.layer_decay_optimizer_constructor import (
+    LayerDecayOptimizerConstructor, LearningRateDecayOptimizerConstructor)
+
+base_lr = 1
+decay_rate = 2
+base_wd = 0.05
+weight_decay = 0.05
+
+expected_stage_wise_lr_wd_convnext = [{
+    'weight_decay': 0.0,
+    'lr_scale': 128
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 1
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 64
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 64
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 32
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 32
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 16
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 16
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 8
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 8
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 128
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 1
+}]
+
+expected_layer_wise_lr_wd_convnext = [{
+    'weight_decay': 0.0,
+    'lr_scale': 128
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 1
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 64
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 64
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 32
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 32
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 16
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 16
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 2
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 2
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 128
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 1
+}]
+
+expected_layer_wise_wd_lr_beit = [{
+    'weight_decay': 0.0,
+    'lr_scale': 16
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 8
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 8
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 4
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 4
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 2
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 2
+}, {
+    'weight_decay': 0.05,
+    'lr_scale': 1
+}, {
+    'weight_decay': 0.0,
+    'lr_scale': 1
+}]
+
+
+class ToyConvNeXt(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.stages = nn.ModuleList()
+        for i in range(4):
+            stage = nn.Sequential(ConvModule(3, 4, kernel_size=1, bias=True))
+            self.stages.append(stage)
+        self.norm0 = nn.BatchNorm2d(2)
+
+        # add some variables to meet unit test coverate rate
+        self.cls_token = nn.Parameter(torch.ones(1))
+        self.mask_token = nn.Parameter(torch.ones(1))
+        self.pos_embed = nn.Parameter(torch.ones(1))
+        self.stem_norm = nn.Parameter(torch.ones(1))
+        self.downsample_norm0 = nn.BatchNorm2d(2)
+        self.downsample_norm1 = nn.BatchNorm2d(2)
+        self.downsample_norm2 = nn.BatchNorm2d(2)
+        self.lin = nn.Parameter(torch.ones(1))
+        self.lin.requires_grad = False
+        self.downsample_layers = nn.ModuleList()
+        for _ in range(4):
+            stage = nn.Sequential(nn.Conv2d(3, 4, kernel_size=1, bias=True))
+            self.downsample_layers.append(stage)
+
+
+class ToyBEiT(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        # add some variables to meet unit test coverate rate
+        self.cls_token = nn.Parameter(torch.ones(1))
+        self.patch_embed = nn.Parameter(torch.ones(1))
+        self.layers = nn.ModuleList()
+        for _ in range(3):
+            layer = nn.Conv2d(3, 3, 1)
+            self.layers.append(layer)
+
+
+class ToyMAE(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        # add some variables to meet unit test coverate rate
+        self.cls_token = nn.Parameter(torch.ones(1))
+        self.patch_embed = nn.Parameter(torch.ones(1))
+        self.layers = nn.ModuleList()
+        for _ in range(3):
+            layer = nn.Conv2d(3, 3, 1)
+            self.layers.append(layer)
+
+
+class ToySegmentor(nn.Module):
+
+    def __init__(self, backbone):
+        super().__init__()
+        self.backbone = backbone
+        self.decode_head = nn.Conv2d(2, 2, kernel_size=1, groups=2)
+
+
+class PseudoDataParallel(nn.Module):
+
+    def __init__(self, model):
+        super().__init__()
+        self.module = model
+
+
+class ToyViT(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+
+def check_optimizer_lr_wd(optimizer, gt_lr_wd):
+    assert isinstance(optimizer, torch.optim.AdamW)
+    assert optimizer.defaults['lr'] == base_lr
+    assert optimizer.defaults['weight_decay'] == base_wd
+    param_groups = optimizer.param_groups
+    print(param_groups)
+    assert len(param_groups) == len(gt_lr_wd)
+    for i, param_dict in enumerate(param_groups):
+        assert param_dict['weight_decay'] == gt_lr_wd[i]['weight_decay']
+        assert param_dict['lr_scale'] == gt_lr_wd[i]['lr_scale']
+        assert param_dict['lr_scale'] == param_dict['lr']
+
+
+def test_learning_rate_decay_optimizer_constructor():
+
+    # Test lr wd for ConvNeXT
+    backbone = ToyConvNeXt()
+    model = PseudoDataParallel(ToySegmentor(backbone))
+    optimizer_cfg = dict(
+        type='AdamW', lr=base_lr, betas=(0.9, 0.999), weight_decay=0.05)
+    # stagewise decay
+    stagewise_paramwise_cfg = dict(
+        decay_rate=decay_rate, decay_type='stage_wise', num_layers=6)
+    optim_constructor = LearningRateDecayOptimizerConstructor(
+        optimizer_cfg, stagewise_paramwise_cfg)
+    optimizer = optim_constructor(model)
+    check_optimizer_lr_wd(optimizer, expected_stage_wise_lr_wd_convnext)
+    # layerwise decay
+    layerwise_paramwise_cfg = dict(
+        decay_rate=decay_rate, decay_type='layer_wise', num_layers=6)
+    optim_constructor = LearningRateDecayOptimizerConstructor(
+        optimizer_cfg, layerwise_paramwise_cfg)
+    optimizer = optim_constructor(model)
+    check_optimizer_lr_wd(optimizer, expected_layer_wise_lr_wd_convnext)
+
+    # Test lr wd for BEiT
+    backbone = ToyBEiT()
+    model = PseudoDataParallel(ToySegmentor(backbone))
+
+    layerwise_paramwise_cfg = dict(
+        decay_rate=decay_rate, decay_type='layer_wise', num_layers=3)
+    optim_constructor = LearningRateDecayOptimizerConstructor(
+        optimizer_cfg, layerwise_paramwise_cfg)
+    optimizer = optim_constructor(model)
+    check_optimizer_lr_wd(optimizer, expected_layer_wise_wd_lr_beit)
+
+    # Test invalidation of lr wd for Vit
+    backbone = ToyViT()
+    model = PseudoDataParallel(ToySegmentor(backbone))
+    with pytest.raises(NotImplementedError):
+        optim_constructor = LearningRateDecayOptimizerConstructor(
+            optimizer_cfg, layerwise_paramwise_cfg)
+        optimizer = optim_constructor(model)
+    with pytest.raises(NotImplementedError):
+        optim_constructor = LearningRateDecayOptimizerConstructor(
+            optimizer_cfg, stagewise_paramwise_cfg)
+        optimizer = optim_constructor(model)
+
+    # Test lr wd for MAE
+    backbone = ToyMAE()
+    model = PseudoDataParallel(ToySegmentor(backbone))
+
+    layerwise_paramwise_cfg = dict(
+        decay_rate=decay_rate, decay_type='layer_wise', num_layers=3)
+    optim_constructor = LearningRateDecayOptimizerConstructor(
+        optimizer_cfg, layerwise_paramwise_cfg)
+    optimizer = optim_constructor(model)
+    check_optimizer_lr_wd(optimizer, expected_layer_wise_wd_lr_beit)
+
+
+def test_beit_layer_decay_optimizer_constructor():
+
+    # paramwise_cfg with BEiTExampleModel
+    backbone = ToyBEiT()
+    model = PseudoDataParallel(ToySegmentor(backbone))
+    optimizer_cfg = dict(
+        type='AdamW', lr=1, betas=(0.9, 0.999), weight_decay=0.05)
+    paramwise_cfg = dict(layer_decay_rate=2, num_layers=3)
+    optim_constructor = LayerDecayOptimizerConstructor(optimizer_cfg,
+                                                       paramwise_cfg)
+    optimizer = optim_constructor(model)
+    check_optimizer_lr_wd(optimizer, expected_layer_wise_wd_lr_beit)

--- a/tests/test_core/test_optimizer.py
+++ b/tests/test_core/test_optimizer.py
@@ -1,19 +1,53 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import pytest
 import torch
 import torch.nn as nn
+from mmcv.runner import DefaultOptimizerConstructor
 
-from mmpose.core import build_optimizers
+from mmpose.core import (OPTIMIZER_BUILDERS, build_optimizer_constructor,
+                         build_optimizers)
 
 
 class ExampleModel(nn.Module):
 
     def __init__(self):
         super().__init__()
-        self.model1 = nn.Conv2d(3, 8, kernel_size=3)
-        self.model2 = nn.Conv2d(3, 4, kernel_size=3)
+        self.param1 = nn.Parameter(torch.ones(1))
+        self.conv1 = nn.Conv2d(3, 4, kernel_size=1, bias=False)
+        self.conv2 = nn.Conv2d(4, 2, kernel_size=1)
+        self.bn = nn.BatchNorm2d(2)
 
     def forward(self, x):
         return x
+
+
+base_lr = 0.01
+base_wd = 0.0001
+momentum = 0.9
+
+
+def test_build_optimizer_constructor():
+    optimizer_cfg = dict(
+        type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+    optim_constructor_cfg = dict(
+        type='DefaultOptimizerConstructor', optimizer_cfg=optimizer_cfg)
+    optim_constructor = build_optimizer_constructor(optim_constructor_cfg)
+    # Test whether optimizer constructor can be built from parent.
+    assert type(optim_constructor) is DefaultOptimizerConstructor
+
+    @OPTIMIZER_BUILDERS.register_module()
+    class MyOptimizerConstructor(DefaultOptimizerConstructor):
+        pass
+
+    optim_constructor_cfg = dict(
+        type='MyOptimizerConstructor', optimizer_cfg=optimizer_cfg)
+    optim_constructor = build_optimizer_constructor(optim_constructor_cfg)
+    # Test optimizer constructor can be built from child registry.
+    assert type(optim_constructor) is MyOptimizerConstructor
+
+    # Test unregistered constructor cannot be built
+    with pytest.raises(KeyError):
+        build_optimizer_constructor(dict(type='A'))
 
 
 def test_build_optimizers():

--- a/tests/test_core/test_optimizer.py
+++ b/tests/test_core/test_optimizer.py
@@ -12,10 +12,8 @@ class ExampleModel(nn.Module):
 
     def __init__(self):
         super().__init__()
-        self.param1 = nn.Parameter(torch.ones(1))
-        self.conv1 = nn.Conv2d(3, 4, kernel_size=1, bias=False)
-        self.conv2 = nn.Conv2d(4, 2, kernel_size=1)
-        self.bn = nn.BatchNorm2d(2)
+        self.model1 = nn.Conv2d(3, 8, kernel_size=3)
+        self.model2 = nn.Conv2d(3, 4, kernel_size=3)
 
     def forward(self, x):
         return x

--- a/tests/test_models/test_mesh_forward.py
+++ b/tests/test_models/test_mesh_forward.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import torch
 
-from mmpose.core.optimizer import build_optimizers
+from mmpose.core.optimizers import build_optimizers
 from mmpose.models.detectors.mesh import ParametricMesh
 from tests.utils.mesh_utils import generate_smpl_weight_file
 


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->
1. Add layer decay optimizer constructor 
2. Add learning rate decay optimizer constructor
These two optimizers will be used in BEiT, MAE, ViT, ConvNeXt backbones. 

The codes are from mmsegmentation.

Related PRs: https://github.com/open-mmlab/mmsegmentation/commit/f16bb060923a2dcb638e84eb96dbf7fc8c1dbb9b

## Modification

<!-- Please briefly describe what modification is made in this PR. -->
1. rename mmpose/core/optimizer --> mmpose/core/optimizers
2. Add mmpose/core/optimizers/layer_decay_optimizer_constructor.py
3. move tests/test_optimizer.py to tests/test_core/test_optimizer.py




## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
