### PR TITLE
Improve control of 3D visualisation of pose lifter

### DIFF
--- a/mmpose/apis/inference_3d.py
+++ b/mmpose/apis/inference_3d.py
@@ -364,7 +364,9 @@ def vis_3d_pose_result(model,
                        kpt_score_thr=0.3,
                        radius=8,
                        thickness=2,
+                       vis_height=400,
                        num_instances=-1,
+                       axis_azimuth=70,
                        show=False,
                        out_file=None):
     """Visualize the 3D pose estimation results.
@@ -459,7 +461,9 @@ def vis_3d_pose_result(model,
         thickness=thickness,
         pose_kpt_color=pose_kpt_color,
         pose_link_color=pose_link_color,
+        vis_height=vis_height,
         num_instances=num_instances,
+        axis_azimuth=axis_azimuth,
         show=show,
         out_file=out_file)
 

--- a/mmpose/models/detectors/pose_lifter.py
+++ b/mmpose/models/detectors/pose_lifter.py
@@ -296,6 +296,7 @@ class PoseLifter(BasePose):
                     thickness=2,
                     vis_height=400,
                     num_instances=-1,
+                    axis_azimuth=70,
                     win_name='',
                     show=False,
                     wait_time=0,
@@ -327,6 +328,7 @@ class PoseLifter(BasePose):
                 smaller than 0, all the instances in the result will be shown.
                 Otherwise, pad or truncate the result to a length of
                 num_instances.
+            axis_azimuth (float): axis azimuth angle for 3D visualizations.
             win_name (str): The window name.
             show (bool): Whether to directly show the visualization.
             wait_time (int): Value of waitKey param.
@@ -388,7 +390,9 @@ class PoseLifter(BasePose):
             pose_kpt_color,
             pose_link_color,
             vis_height,
-            num_instances=num_instances)
+            num_instances=num_instances,
+            axis_azimuth=axis_azimuth,
+        )
 
         if show:
             mmcv.visualization.imshow(img_vis, win_name, wait_time)

--- a/mmpose/models/detectors/pose_lifter.py
+++ b/mmpose/models/detectors/pose_lifter.py
@@ -323,7 +323,12 @@ class PoseLifter(BasePose):
             vis_height (int): The image height of the visualization. The width
                 will be N*vis_height depending on the number of visualized
                 items.
+            num_instances (int): Number of instances to be shown in 3D. If
+                smaller than 0, all the instances in the result will be shown.
+                Otherwise, pad or truncate the result to a length of
+                num_instances.
             win_name (str): The window name.
+            show (bool): Whether to directly show the visualization.
             wait_time (int): Value of waitKey param.
                 Default: 0.
             out_file (str or None): The filename to write the image.


### PR DESCRIPTION
## Motivation

When visualising the 3D output poses coming from a pose lifter, it is currently not possible to control the visualisation height (pixels) and viewpoint angle, even though both are already implemented just under the hood, and would only need to be patched through. The former can be important for instance if a higher resolution output is desired, or as in my case, if you require it to have the exact same pixel height as the input image sequence (for post-processing reasons). I have also noticed  that the default viewpoint of the 3D visualisation is quite frontal, so in many cases the output looks correct, but if you look at it from a significantly different azimuth you can quickly tell it's not actually correct at all. In order to be able to properly evaluate and understand the outputs of various pose lifter models it is crucial to be able to visualise it from different viewing angles (I always use two views and plot them side by side for optimal understanding). Hence, why exposing `axis_azimuth` is quite important.

## Modification

I added arguments to allow `vis_height` and `axis_azimuth` to be set when calling `vis_3d_pose_result()`.
I also added some missing parameter documentation that I noticed was missing.

## BC-breaking

Nothing.

## Use cases

See motivation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
