### PR TITLE
[Enhance] Refine body3d_two_stage_video_demo.py

### DIFF
--- a/mmpose/apis/inference_3d.py
+++ b/mmpose/apis/inference_3d.py
@@ -78,9 +78,12 @@ def _gather_pose_lifter_inputs(pose_results,
                     ``with_track_id==True```
                 - bbox ((4, ) or (5, )): left, right, top, bottom, [score]
 
-        bbox_center (ndarray[1, 2]): x, y. The average center coordinate of the
-            bboxes in the dataset.
-        bbox_scale (int|float): The average scale of the bboxes in the dataset.
+        bbox_center (ndarray[1, 2], optional): x, y. The average center
+            coordinate of the bboxes in the dataset. `bbox_center` will be
+            used only when `norm_pose_2d` is `True`.
+        bbox_scale (int|float, optional): The average scale of the bboxes
+            in the dataset.
+            `bbox_scale` will be used only when `norm_pose_2d` is `True`.
         norm_pose_2d (bool): If True, scale the bbox (along with the 2D
             pose) to bbox_scale, and move the bbox (along with the 2D pose) to
             bbox_center. Default: False.
@@ -259,9 +262,13 @@ def inference_pose_lifter_model(model,
 
     if dataset_info is not None:
         flip_pairs = dataset_info.flip_pairs
-        assert 'stats_info' in dataset_info._dataset_info
-        bbox_center = dataset_info._dataset_info['stats_info']['bbox_center']
-        bbox_scale = dataset_info._dataset_info['stats_info']['bbox_scale']
+        if 'stats_info' in dataset_info._dataset_info:
+            bbox_center = dataset_info._dataset_info['stats_info'][
+                'bbox_center']
+            bbox_scale = dataset_info._dataset_info['stats_info']['bbox_scale']
+        else:
+            bbox_center = None
+            bbox_scale = None
     else:
         warnings.warn(
             'dataset is deprecated.'


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

Inrich the keypoint definition from pose_lift_dataset to pose_det_dataset.

Now, the demo support the following conversions:
1. from `Body3DH36MDataset` to `['TopDownCocoDataset', 'TopDownPoseTrack18Dataset', 'TopDownPoseTrack18VideoDataset', 'TopDownAicDataset'], ['TopDownCrowdPoseDataset']`;
2. from `Body3DMpiInf3dhpDataset` to `['TopDownCocoDataset', 'TopDownPoseTrack18Dataset', 'TopDownPoseTrack18VideoDataset', 'TopDownAicDataset'], ['TopDownCrowdPoseDataset']`;

Fix the problem mentioned in https://github.com/open-mmlab/mmpose/issues/1485. 
Credit to @pallgeuer.


## Modification

<!-- Please briefly describe what modification is made in this PR. -->


## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
