### PR TITLE
Added the 'Optional' extra require in setup.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,9 @@ jobs:
           pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/${{matrix.torch_version}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install other dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          pip install albumentations>=0.3.2 --no-binary imgaug,albumentations
       - name: Build and install
         run: rm -rf .eggs && pip install -e .
       - name: Run unittests and generate coverage report
@@ -122,6 +124,7 @@ jobs:
           python -V
           python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/${{matrix.torch_version}}/index.html
           python -m pip install -r requirements.txt
+          python -m pip install albumentations>=0.3.2 --no-binary imgaug,albumentations
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Build and install
         run: |
@@ -185,6 +188,7 @@ jobs:
           python -V
           python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/${{matrix.torch_version}}/index.html
           python -m pip install -r requirements.txt
+          python -m pip install albumentations>=0.3.2 --no-binary imgaug,albumentations
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Build and install
         run: |

--- a/requirements/albu.txt
+++ b/requirements/albu.txt
@@ -1,0 +1,1 @@
+albumentations>=0.3.2 --no-binary qudida,albumentations

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,3 @@
-albumentations>=0.3.2 --no-binary qudida,albumentations
 onnx
 onnxruntime
 poseval@git+https://github.com/svenkreiss/poseval.git

--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,7 @@ if __name__ == '__main__':
             'tests': parse_requirements('requirements/tests.txt'),
             'build': parse_requirements('requirements/build.txt'),
             'runtime': parse_requirements('requirements/runtime.txt'),
+            'optional': parse_requirements('requirements/optional.txt'),
             'mim': parse_requirements('requirements/mminstall.txt'),
         },
         zip_safe=False)


### PR DESCRIPTION


## Motivation

Without it, users who are used to install mmlab packages will automatically add the "optional" extra and will encounter a pip error

## Modification

Added the missing extra of "optional" as seen in other MM repos as mmaction2  (https://github.com/open-mmlab/mmaction2/blob/master/setup.py#L193)   and mmdetection  (https://github.com/open-mmlab/mmdetection/blob/master/setup.py#L216)  



