### PR TITLE
[Refactor] Reorganize HeatmapHead and BaseHead class in order to develop RegressionHead

### DIFF
--- a/mmpose/core/utils/tensor_utils.py
+++ b/mmpose/core/utils/tensor_utils.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 import numpy as np
 from torch import Tensor
 

--- a/mmpose/core/utils/tensor_utils.py
+++ b/mmpose/core/utils/tensor_utils.py
@@ -1,0 +1,14 @@
+import numpy as np
+from torch import Tensor
+
+
+def _to_numpy(x: Tensor) -> np.ndarray:
+    """Convert a torch tensor to numpy.ndarray.
+
+    Args:
+        x (Tensor): A torch tensor
+
+    Returns:
+        np.ndarray: The converted numpy array
+    """
+    return x.detach().cpu().numpy()

--- a/mmpose/models/heads/base_head.py
+++ b/mmpose/models/heads/base_head.py
@@ -4,7 +4,7 @@ from typing import Tuple, Union
 
 import torch
 import torch.nn.functional as F
-from mmengine.data import InstanceData, PixelData
+from mmengine.data import InstanceData
 from mmengine.model import BaseModule
 from torch import Tensor
 
@@ -132,9 +132,5 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
                 data_sample.pred_instances = InstanceData()
             data_sample.pred_instances.keypoints = keypoints
             data_sample.pred_instances.keypoint_scores = scores
-
-            # Store the heatmap predictions in the data sample
-            if 'pred_fileds' not in data_sample:
-                data_sample.pred_fields = PixelData()
 
         return batch_data_samples

--- a/mmpose/models/heads/base_head.py
+++ b/mmpose/models/heads/base_head.py
@@ -1,7 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import ABCMeta, abstractmethod
-from typing import Tuple
+from typing import Tuple, Union
 
+import torch
+import torch.nn.functional as F
 from mmengine.model import BaseModule
 from torch import Tensor
 
@@ -29,3 +31,51 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
     def loss(self, feats: Tuple[Tensor], batch_data_samples: OptSampleList,
              train_cfg: ConfigType) -> dict:
         """Calculate losses from a batch of inputs and data samples."""
+
+    def _get_in_channels(self):
+        """Get the input channel number of the network according to the feature
+        channel numbers and the input transform type."""
+
+        feat_channels = self.in_channels
+        if isinstance(feat_channels, int):
+            feat_channels = [feat_channels]
+
+        if self.input_transform == 'resize_concat':
+            if isinstance(self.input_index, int):
+                in_channels = feat_channels[self.input_index]
+            else:
+                in_channels = sum(feat_channels[i] for i in self.input_index)
+        elif self.input_transform == 'select':
+            if isinstance(self.input_index, int):
+                in_channels = feat_channels[self.input_index]
+            else:
+                in_channels = [feat_channels[i] for i in self.input_index]
+        else:
+            raise (ValueError,
+                   f'Invalid input transform mode "{self.input_transform}"')
+
+        return in_channels
+
+    def _transform_inputs(
+            self, feats: Tuple[Tensor]) -> Union[Tensor, Tuple[Tensor]]:
+        """Transform multi scale features into the network input."""
+        if self.input_transform == 'resize_concat':
+            inputs = [feats[i] for i in self.input_index]
+            resized_inputs = [
+                F.interpolate(
+                    x,
+                    size=inputs[0].shape[2:],
+                    mode='bilinear',
+                    align_corners=self.align_corners) for x in inputs
+            ]
+            inputs = torch.cat(resized_inputs, dim=1)
+        elif self.input_transform == 'select':
+            if isinstance(self.input_index, int):
+                inputs = feats[self.input_index]
+            else:
+                inputs = tuple(feats[i] for i in self.input_index)
+        else:
+            raise (ValueError,
+                   f'Invalid input transform mode "{self.input_transform}"')
+
+        return inputs

--- a/mmpose/models/heads/base_head.py
+++ b/mmpose/models/heads/base_head.py
@@ -4,9 +4,11 @@ from typing import Tuple, Union
 
 import torch
 import torch.nn.functional as F
+from mmengine.data import InstanceData, PixelData
 from mmengine.model import BaseModule
 from torch import Tensor
 
+from mmpose.core.utils.tensor_utils import _to_numpy
 from mmpose.core.utils.typing import ConfigType, OptSampleList, SampleList
 
 
@@ -79,3 +81,78 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
                    f'Invalid input transform mode "{self.input_transform}"')
 
         return inputs
+
+    def decode(self, batch_outputs: Union[Tensor, Tuple[Tensor]],
+               batch_data_samples: OptSampleList,
+               test_cfg: ConfigType) -> SampleList:
+        """Decode keypoints from outputs."""
+
+        if self.decoder is None:
+            raise RuntimeError(
+                f'The decoder has not been set in {self.__class__.__name__}. '
+                'Please set the decoder configs in the init parameters to '
+                'enable head methods `head.predict()` and `head.decode()`')
+
+        if batch_data_samples is None:
+            raise ValueError(
+                '`batch_data_samples` is required to decode keypoitns.')
+
+        if isinstance(batch_outputs, Tensor):
+            batch_outputs_np = _to_numpy(batch_outputs)
+            batch_heatmaps_np = batch_outputs_np
+
+            head_type = type(self).__name__.lower()
+            if 'regression' in head_type:
+                out_heatmaps = False
+            else:
+                out_heatmaps = True
+
+        elif isinstance(batch_outputs, Tuple):
+            assert len(batch_outputs) == 2, (
+                'batch_outputs should contain coordinates and heatmaps in '
+                f'{self.__class__.__name__}')
+
+            batch_coords, batch_heatmaps = batch_outputs
+            batch_outputs_np = _to_numpy(batch_coords)
+            batch_heatmaps_np = _to_numpy(batch_heatmaps)
+
+            out_heatmaps = True
+
+        # Whether to visualize the predicted heatmps
+        vis_heatmaps = test_cfg.get('vis_heatmaps', True) and out_heatmaps
+
+        # TODO: support decoding with tensor data
+        for idx, (outputs, data_sample) in enumerate(
+                zip(batch_outputs_np, batch_data_samples)):
+            keypoints, scores = self.decoder.decode(outputs)
+
+            # Convert the decoded local keypoints (in input space)
+            # to the image coordinate space
+            # Convert keypoint coordinates from input space to image space
+            if 'gt_instances' in data_sample:
+                bbox_centers = data_sample.gt_instances.bbox_centers
+                bbox_scales = data_sample.get_instances.bbox_scales
+                input_size = data_sample.metainfo.input_size
+                keypoints = keypoints / input_size * bbox_scales + \
+                    bbox_centers - 0.5 * bbox_scales
+
+            else:
+                raise ValueError(
+                    '`gt_instances` is required to convert keypoints from'
+                    ' from the heatmap space to the image space.')
+
+            # Store the keypoint predictions in the data sample
+            if 'pred_instances' not in data_sample:
+                data_sample.pred_instances = InstanceData()
+            data_sample.pred_instances.keypoints = keypoints
+            data_sample.pred_instances.keypoint_scores = scores
+
+            # Store the heatmap predictions in the data sample
+            if 'pred_fileds' not in data_sample:
+                data_sample.pred_fields = PixelData()
+
+            if vis_heatmaps:
+                heatmaps = batch_heatmaps_np[idx]
+                data_sample.pred_fields.heatmaps = heatmaps
+
+        return batch_data_samples

--- a/mmpose/models/heads/base_head.py
+++ b/mmpose/models/heads/base_head.py
@@ -58,8 +58,8 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
 
         return in_channels
 
-    def _transform_inputs(
-            self, feats: Tuple[Tensor]) -> Union[Tensor, Tuple[Tensor]]:
+    def _transform_inputs(self, feats: Tuple[Tensor]
+                          ) -> Union[Tensor, Tuple[Tensor]]:
         """Transform multi scale features into the network input."""
         if self.input_transform == 'resize_concat':
             inputs = [feats[i] for i in self.input_index]

--- a/mmpose/models/heads/heatmap_heads/heatmap_head.py
+++ b/mmpose/models/heads/heatmap_heads/heatmap_head.py
@@ -249,8 +249,8 @@ class HeatmapHead(BaseHead):
         # Whether to visualize the predicted heatmps
         vis_heatmaps = test_cfg.get('vis_heatmaps', True)
 
-        for heatmaps, data_sample in zip(batch_heatmaps, preds):
-            if vis_heatmaps:
+        if vis_heatmaps:
+            for heatmaps, data_sample in zip(batch_heatmaps, preds):
                 data_sample.pred_fields.heatmaps = heatmaps
 
         return preds

--- a/mmpose/models/heads/heatmap_heads/heatmap_head.py
+++ b/mmpose/models/heads/heatmap_heads/heatmap_head.py
@@ -247,9 +247,9 @@ class HeatmapHead(BaseHead):
         preds = self.decode(batch_heatmaps, batch_data_samples, test_cfg)
 
         # Whether to visualize the predicted heatmps
-        vis_heatmaps = test_cfg.get('vis_heatmaps', True)
+        out_heatmaps = test_cfg.get('out_heatmaps', True)
 
-        if vis_heatmaps:
+        if out_heatmaps:
             for heatmaps, data_sample in zip(batch_heatmaps, preds):
                 data_sample.pred_fields.heatmaps = heatmaps
 

--- a/mmpose/models/heads/heatmap_heads/heatmap_head.py
+++ b/mmpose/models/heads/heatmap_heads/heatmap_head.py
@@ -242,9 +242,18 @@ class HeatmapHead(BaseHead):
     def predict(self, feats: Tuple[Tensor], batch_data_samples: OptSampleList,
                 test_cfg: ConfigType) -> SampleList:
         """Predict results from features."""
-        heatmaps = self.forward(feats)
-        preds = self.decode(heatmaps, batch_data_samples, test_cfg)
-        return preds
+
+        batch_heatmaps = self.forward(feats)
+        pred_coords = self.decode(batch_heatmaps, batch_data_samples, test_cfg)
+
+        # Whether to visualize the predicted heatmps
+        vis_heatmaps = test_cfg.get('vis_heatmaps', True)
+
+        for heatmaps, data_sample in zip(batch_heatmaps, batch_data_samples):
+            if vis_heatmaps:
+                data_sample.pred_fields.heatmaps = heatmaps
+
+        return pred_coords
 
     def loss(self, feats: Tuple[Tensor], batch_data_samples: OptSampleList,
              train_cfg: ConfigType) -> dict:

--- a/mmpose/models/heads/heatmap_heads/heatmap_head.py
+++ b/mmpose/models/heads/heatmap_heads/heatmap_head.py
@@ -1,12 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from typing import Optional, Sequence, Tuple, Union
 
-import numpy as np
 import torch
 from mmcv.cnn import build_conv_layer, build_upsample_layer
-from mmengine.data import InstanceData, PixelData
 from torch import Tensor, nn
 
+from mmpose.core.utils.tensor_utils import _to_numpy
 from mmpose.core.utils.typing import (ConfigType, OptConfigType, OptSampleList,
                                       SampleList)
 from mmpose.metrics.utils import pose_pck_accuracy
@@ -14,18 +13,6 @@ from mmpose.registry import KEYPOINT_CODECS, MODELS
 from ..base_head import BaseHead
 
 OptIntSeq = Optional[Sequence[int]]
-
-
-def _to_numpy(x: Tensor) -> np.ndarray:
-    """Convert a torch tensor to numpy.ndarray.
-
-    Args:
-        x (Tensor): A torch tensor
-
-    Returns:
-        np.ndarray: The converted numpy array
-    """
-    return x.detach().cpu().numpy()
 
 
 @MODELS.register_module()
@@ -258,53 +245,6 @@ class HeatmapHead(BaseHead):
         heatmaps = self.forward(feats)
         preds = self.decode(heatmaps, batch_data_samples, test_cfg)
         return preds
-
-    def decode(self, batch_heatmaps: Tensor, batch_data_samples: OptSampleList,
-               test_cfg: ConfigType) -> SampleList:
-        """Decode keypoints from heatmaps."""
-        if self.decoder is None:
-            raise RuntimeError(
-                f'The decoder has not been set in {self.__class__.__name__}. '
-                'Please set the decoder configs in the init parameters to '
-                'enable head methods `head.predict()` and `head.decode()`')
-
-        if batch_data_samples is None:
-            raise ValueError(
-                '`batch_data_samples` is required to decode keypoitns.')
-
-        # TODO: support decoding with tensor data
-        batch_heatmaps_np = _to_numpy(batch_heatmaps)
-        for heatmaps, data_sample in zip(batch_heatmaps_np,
-                                         batch_data_samples):
-            keypoints, scores = self.decoder.decode(heatmaps)
-
-            # Convert the decoded local keypoints (in input space)
-            # to the image coordinate space
-            # Convert keypoint coordinates from input space to image space
-            if 'gt_instances' in data_sample:
-                bbox_centers = data_sample.gt_instances.bbox_centers
-                bbox_scales = data_sample.get_instances.bbox_scales
-                input_size = data_sample.metainfo.input_size
-                keypoints = keypoints / input_size * bbox_scales + \
-                    bbox_centers - 0.5 * bbox_scales
-
-            else:
-                raise ValueError(
-                    '`gt_instances` is required to convert keypoints from'
-                    ' from the heatmap space to the image space.')
-
-            # Store the keypoint predictions in the data sample
-            if 'pred_instances' not in data_sample:
-                data_sample.pred_instances = InstanceData()
-            data_sample.pred_instances.keypoints = keypoints
-            data_sample.pred_instances.keypoint_scores = scores
-
-            # Store the heatmap predictions in the data sample
-            if 'pred_fileds' not in data_sample:
-                data_sample.pred_fields = PixelData()
-            data_sample.pred_fields.heatmaps = heatmaps
-
-        return batch_data_samples
 
     def loss(self, feats: Tuple[Tensor], batch_data_samples: OptSampleList,
              train_cfg: ConfigType) -> dict:

--- a/mmpose/models/heads/heatmap_heads/heatmap_head.py
+++ b/mmpose/models/heads/heatmap_heads/heatmap_head.py
@@ -244,16 +244,16 @@ class HeatmapHead(BaseHead):
         """Predict results from features."""
 
         batch_heatmaps = self.forward(feats)
-        pred_coords = self.decode(batch_heatmaps, batch_data_samples, test_cfg)
+        preds = self.decode(batch_heatmaps, batch_data_samples, test_cfg)
 
         # Whether to visualize the predicted heatmps
         vis_heatmaps = test_cfg.get('vis_heatmaps', True)
 
-        for heatmaps, data_sample in zip(batch_heatmaps, batch_data_samples):
+        for heatmaps, data_sample in zip(batch_heatmaps, preds):
             if vis_heatmaps:
                 data_sample.pred_fields.heatmaps = heatmaps
 
-        return pred_coords
+        return preds
 
     def loss(self, feats: Tuple[Tensor], batch_data_samples: OptSampleList,
              train_cfg: ConfigType) -> dict:

--- a/mmpose/models/heads/heatmap_heads/heatmap_head.py
+++ b/mmpose/models/heads/heatmap_heads/heatmap_head.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence, Tuple, Union
 
 import torch
 from mmcv.cnn import build_conv_layer, build_upsample_layer
+from mmengine.data import PixelData
 from torch import Tensor, nn
 
 from mmpose.core.utils.tensor_utils import _to_numpy
@@ -247,10 +248,11 @@ class HeatmapHead(BaseHead):
         preds = self.decode(batch_heatmaps, batch_data_samples, test_cfg)
 
         # Whether to visualize the predicted heatmps
-        out_heatmaps = test_cfg.get('out_heatmaps', True)
-
-        if out_heatmaps:
+        if test_cfg.get('output_heatmaps', True):
             for heatmaps, data_sample in zip(batch_heatmaps, preds):
+                # Store the heatmap predictions in the data sample
+                if 'pred_fileds' not in data_sample:
+                    data_sample.pred_fields = PixelData()
                 data_sample.pred_fields.heatmaps = heatmaps
 
         return preds

--- a/mmpose/models/heads/regression_heads/regression_head.py
+++ b/mmpose/models/heads/regression_heads/regression_head.py
@@ -1,0 +1,150 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Sequence, Tuple, Union
+
+import numpy as np
+import torch
+from torch import Tensor, nn
+
+from mmpose.core.utils.tensor_utils import _to_numpy
+from mmpose.core.utils.typing import (ConfigType, OptConfigType, OptSampleList,
+                                      SampleList)
+from mmpose.metrics.utils import keypoint_pck_accuracy
+from mmpose.registry import KEYPOINT_CODECS, MODELS
+from ..base_head import BaseHead
+
+OptIntSeq = Optional[Sequence[int]]
+
+
+@MODELS.register_module()
+class RegressionHead(BaseHead):
+    """Top-down regression head introduced in `Deeppose`_ by Toshev et al
+    (2014). The head is composed of fully-connected layers to predict the
+    coordinates directly. It is also a base class for all regression-based 
+    methods.
+
+    Args:
+        in_channels (int | sequence[int]): Number of input channels
+        num_joints (int): Number of joints
+        out_sigma (bool): Predict the sigma (the variance of the joint
+            location) together with the joint location. Introduced in `RLE`_
+            by Li et al(2021). Default: False
+        loss (Config): Config for keypoint loss. Defaults to use
+            :class:`SmoothL1Loss`
+        decoder (Config, optional): The decoder config that controls decoding
+            keypoint coordinates from the network output. Defaults to ``None``
+        init_cfg (Config, optional): Config to control the initialization. See
+            :attr:`default_init_cfg` for default settings
+
+    .. _`Deeppose`: https://arxiv.org/abs/1312.4659
+    """
+
+    _version = 2
+
+    def __init__(self,
+                 in_channels: Union[int, Sequence[int]],
+                 num_joints: int,
+                 out_sigma: bool,
+                 input_transform: str = 'select',
+                 input_index: Union[int, Sequence[int]] = 0,
+                 align_corners: bool = False,
+                 loss: ConfigType = dict(
+                     type='SmoothL1Loss', use_target_weight=True),
+                 decoder: OptConfigType = None,
+                 init_cfg: OptConfigType = None):
+
+        if init_cfg is None:
+            init_cfg = self.default_init_cfg
+
+        super().__init__(init_cfg)
+
+        self.in_channels = in_channels
+        self.num_joints = num_joints
+        self.out_sigma = out_sigma
+        self.align_corners = align_corners
+        self.input_transform = input_transform
+        self.input_index = input_index
+        self.loss_module = MODELS.build(loss)
+        if decoder is not None:
+            self.decoder = KEYPOINT_CODECS.build(decoder)
+        else:
+            self.decoder = None
+
+        # Get model input channels according to feature
+        in_channels = self._get_in_channels()
+
+        # Define fully-connected layers
+        if self.out_sigma:
+            self.fc = nn.Linear(self.in_channels, self.num_joints * 4)
+        else:
+            self.fc = nn.Linear(self.in_channels, self.num_joints * 2)
+
+    def forward(self, feats: Tuple[Tensor]) -> Tensor:
+        """Forward the network. The input is multi scale feature maps and the
+        output is the coordinates.
+
+        Args:
+            feats (Tuple[Tensor]): Multi scale feature maps.
+
+        Returns:
+            Tensor: output coordinates(and sigmas[optional]).
+        """
+        x = self._transform_inputs(feats)
+
+        assert isinstance(x, Tensor), (
+            'Selecting multiple features as the inputs is not supported in '
+            f'{self.__class__.__name__}')
+
+        x = self.fc(x)
+
+        if self.out_sigma:
+            return x.reshape(-1, self.num_joints, 4)
+        else:
+            return x.reshape(-1, self.num_joints, 2)
+
+    def predict(self, feats: Tuple[Tensor], batch_data_samples: OptSampleList,
+                test_cfg: ConfigType) -> SampleList:
+        """Predict results from outputs."""
+
+        batch_coords = self.forward(feats)
+        preds = self.decode(batch_coords, batch_data_samples, test_cfg)
+
+        return preds
+
+    def loss(self, inputs: Tuple[Tensor], batch_data_samples: OptSampleList,
+             train_cfg: ConfigType) -> dict:
+        """Calculate losses from a batch of inputs and data samples."""
+
+        pred_outputs = self.forward(inputs)
+        target_coords = torch.stack(
+            [d.gt_fields.keypoints for d in batch_data_samples])
+        target_weights = torch.cat(
+            [d.gt_instance.target_weights for d in batch_data_samples])
+
+        # calculate losses
+        losses = dict()
+        loss = self.loss_module(pred_outputs, target_coords, target_weights)
+        if isinstance(loss, dict):
+            losses.update(loss)
+        else:
+            losses.update(loss_kpts=loss)
+
+        # calculate accuracy
+        pred_coords = pred_outputs[:, :, :2]
+
+        _, avg_acc, _ = keypoint_pck_accuracy(
+            pred=_to_numpy(pred_coords),
+            gt=_to_numpy(target_coords),
+            mask=_to_numpy(target_weights).squeeze(-1) > 0,
+            thr=0.05,
+            normalize=np.ones((pred_coords.size(0), 2), dtype=np.float32))
+
+        losses.update(acc_pose=float(avg_acc))
+
+    @property
+    def default_init_cfg(self):
+        init_cfg = [
+            dict(
+                type='Normal', layer=['Conv2d', 'ConvTranspose2d'], std=0.001),
+            dict(type='Constant', layer='BatchNorm2d', val=1)
+        ]
+        return init_cfg

--- a/mmpose/models/heads/regression_heads/regression_head.py
+++ b/mmpose/models/heads/regression_heads/regression_head.py
@@ -19,7 +19,7 @@ OptIntSeq = Optional[Sequence[int]]
 class RegressionHead(BaseHead):
     """Top-down regression head introduced in `Deeppose`_ by Toshev et al
     (2014). The head is composed of fully-connected layers to predict the
-    coordinates directly. It is also a base class for all regression-based 
+    coordinates directly. It is also a base class for all regression-based
     methods.
 
     Args:


### PR DESCRIPTION

## Motivation

Refactor `HeatmapHead` and `BaseHead` class

## Modification

Reorganized `decode`, `_get_in_channels`, `_transform_inputs` into `BaseHead`.
Modified `decode` for supporting `heatmap-based`, `regression-based` and `integral-regression` methods. Support heatmap visualization config via `test_cfg`.
Saved `_to_numpy` as a util function in /core/utils/tensor_utils.py

## BC-breaking (Optional)


## Use cases (Optional)


## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
