### PR TITLE
[Refactor] support flip test for regression and simcc heads

### DIFF
--- a/mmpose/codecs/simcc_label.py
+++ b/mmpose/codecs/simcc_label.py
@@ -104,7 +104,8 @@ class SimCCLabel(BaseKeypointCodec):
         coordinates are in the input image space.
 
         Args:
-            encoded (Tuple[np.ndarray, np.ndarray]): SimCC labels for x and y
+            encoded (Tuple[np.ndarray, np.ndarray]): SimCC labels for x-axis
+                and y-axis
 
         Returns:
             tuple:

--- a/mmpose/models/heads/heatmap_heads/heatmap_head.py
+++ b/mmpose/models/heads/heatmap_heads/heatmap_head.py
@@ -270,7 +270,7 @@ class HeatmapHead(BaseHead):
         """
 
         if test_cfg.get('flip_test', False):
-            # TTA: flip test
+            # TTA: flip test -> feats = [orig, flipped]
             assert isinstance(feats, list) and len(feats) == 2
             flip_indices = batch_data_samples[0].metainfo['flip_indices']
             _feats, _feats_flip = feats

--- a/mmpose/models/heads/regression_heads/integral_regression_head.py
+++ b/mmpose/models/heads/regression_heads/integral_regression_head.py
@@ -211,7 +211,7 @@ class IntegralRegressionHead(BaseHead):
 
         if test_cfg.get('flip_test', False):
             # TTA: flip test -> feats = [orig, flipped]
-            assert isinstance(feats, list) and len(feats == 2)
+            assert isinstance(feats, list) and len(feats) == 2
             flip_indices = batch_data_samples[0].metainfo['flip_indices']
             _feats, _feats_flip = feats
 

--- a/mmpose/models/heads/regression_heads/integral_regression_head.py
+++ b/mmpose/models/heads/regression_heads/integral_regression_head.py
@@ -213,6 +213,7 @@ class IntegralRegressionHead(BaseHead):
             # TTA: flip test -> feats = [orig, flipped]
             assert isinstance(feats, list) and len(feats) == 2
             flip_indices = batch_data_samples[0].metainfo['flip_indices']
+            img_shape = batch_data_samples[0].metainfo['img_shape']
             _feats, _feats_flip = feats
 
             _batch_coords, _batch_heatmaps = self.forward(_feats)
@@ -220,12 +221,15 @@ class IntegralRegressionHead(BaseHead):
             _batch_coords_flip, _batch_heatmaps_flip = self.forward(
                 _feats_flip)
             _batch_coords_flip = flip_coordinates(
-                _batch_coords_flip, flip_indices=flip_indices)
+                _batch_coords_flip,
+                flip_indices=flip_indices,
+                shift_coords=test_cfg.get('shift_coords', True),
+                img_shape=img_shape)
             _batch_heatmaps_flip = flip_heatmaps(
                 _batch_heatmaps_flip,
                 flip_mode='heatmap',
                 flip_indices=flip_indices,
-                shift_heatmap=False)
+                shift_heatmap=test_cfg.get('shift_heatmap', False))
 
             batch_coords = (_batch_coords + _batch_coords_flip) * 0.5
             batch_heatmaps = (_batch_heatmaps + _batch_heatmaps_flip) * 0.5

--- a/mmpose/models/heads/regression_heads/regression_head.py
+++ b/mmpose/models/heads/regression_heads/regression_head.py
@@ -101,11 +101,15 @@ class RegressionHead(BaseHead):
             # TTA: flip test -> feats = [orig, flipped]
             assert isinstance(feats, list) and len(feats) == 2
             flip_indices = batch_data_samples[0].metainfo['flip_indices']
+            img_shape = batch_data_samples[0].metainfo['img_shape']
             _feats, _feats_flip = feats
 
             _batch_coords = self.forward(_feats)
             _batch_coords_flip = flip_coordinates(
-                self.forward(_feats_flip), flip_indices=flip_indices)
+                self.forward(_feats_flip),
+                flip_indices=flip_indices,
+                shift_coords=test_cfg.get('shift_coords', True),
+                img_shape=img_shape)
             batch_coords = (_batch_coords + _batch_coords_flip) * 0.5
         else:
             batch_coords = self.forward(feats)  # (B, K, D)

--- a/mmpose/models/heads/regression_heads/regression_head.py
+++ b/mmpose/models/heads/regression_heads/regression_head.py
@@ -6,6 +6,7 @@ import torch
 from torch import Tensor, nn
 
 from mmpose.evaluation.functional import keypoint_pck_accuracy
+from mmpose.models.utils.tta import flip_coordinates
 from mmpose.registry import KEYPOINT_CODECS, MODELS
 from mmpose.utils.tensor_utils import to_numpy
 from mmpose.utils.typing import (ConfigType, OptConfigType, OptSampleList,
@@ -96,8 +97,21 @@ class RegressionHead(BaseHead):
                 test_cfg: ConfigType = {}) -> SampleList:
         """Predict results from outputs."""
 
-        batch_coords = self.forward(feats)
+        if test_cfg.get('flip_test', False):
+            # TTA: flip test -> feats = [orig, flipped]
+            assert isinstance(feats, list) and len(feats == 2)
+            flip_indices = batch_data_samples[0].metainfo['flip_indices']
+            _feats, _feats_flip = feats
+
+            _batch_coords = self.forward(_feats)
+            _batch_coords_flip = flip_coordinates(
+                self.forward(_feats_flip), flip_indices=flip_indices)
+            batch_coords = (_batch_coords + _batch_coords_flip) * 0.5
+        else:
+            batch_coords = self.forward(feats)  # (B, K, D)
+
         batch_coords.unsqueeze_(dim=1)  # (B, N, K, D)
+
         preds = self.decode(batch_coords, batch_data_samples)
 
         return preds

--- a/mmpose/models/heads/regression_heads/regression_head.py
+++ b/mmpose/models/heads/regression_heads/regression_head.py
@@ -99,7 +99,7 @@ class RegressionHead(BaseHead):
 
         if test_cfg.get('flip_test', False):
             # TTA: flip test -> feats = [orig, flipped]
-            assert isinstance(feats, list) and len(feats == 2)
+            assert isinstance(feats, list) and len(feats) == 2
             flip_indices = batch_data_samples[0].metainfo['flip_indices']
             _feats, _feats_flip = feats
 

--- a/mmpose/models/heads/regression_heads/rle_head.py
+++ b/mmpose/models/heads/regression_heads/rle_head.py
@@ -104,11 +104,15 @@ class RLEHead(BaseHead):
             # TTA: flip test -> feats = [orig, flipped]
             assert isinstance(feats, list) and len(feats) == 2
             flip_indices = batch_data_samples[0].metainfo['flip_indices']
+            img_shape = batch_data_samples[0].metainfo['img_shape']
             _feats, _feats_flip = feats
 
             _batch_coords = self.forward(_feats)
             _batch_coords_flip = flip_coordinates(
-                self.forward(_feats_flip), flip_indices=flip_indices)
+                self.forward(_feats_flip),
+                flip_indices=flip_indices,
+                shift_coords=test_cfg.get('shift_coords', True),
+                img_shape=img_shape)
             batch_coords = (_batch_coords + _batch_coords_flip) * 0.5
         else:
             batch_coords = self.forward(feats)  # (B, K, D)

--- a/mmpose/models/heads/regression_heads/rle_head.py
+++ b/mmpose/models/heads/regression_heads/rle_head.py
@@ -102,7 +102,7 @@ class RLEHead(BaseHead):
 
         if test_cfg.get('flip_test', False):
             # TTA: flip test -> feats = [orig, flipped]
-            assert isinstance(feats, list) and len(feats == 2)
+            assert isinstance(feats, list) and len(feats) == 2
             flip_indices = batch_data_samples[0].metainfo['flip_indices']
             _feats, _feats_flip = feats
 

--- a/mmpose/models/utils/tta.py
+++ b/mmpose/models/utils/tta.py
@@ -59,8 +59,9 @@ def flip_vectors(x_labels: Tensor, y_labels: Tensor, flip_indices: List[int]):
         flip_indices (List[int]): The indices of each keypoint's symmetric
             keypoint
     """
-    assert len(x_labels) == 3
-    assert len(flip_indices) == x_labels.shape[1]
+    assert x_labels.ndim == 3 and y_labels.ndim == 3
+    assert len(flip_indices) == x_labels.shape[1] and len(
+        flip_indices) == y_labels.shape[1]
     x_labels = x_labels[:, flip_indices].flip(-1)
     y_labels = y_labels[:, flip_indices]
 
@@ -76,6 +77,7 @@ def flip_coordinates(coords: Tensor, flip_indices: List[int]):
         flip_indices (List[int]): The indices of each keypoint's symmetric
             keypoint
     """
+    assert coords.ndim == 3
     assert len(flip_indices) == coords.shape[1]
     coords[:, :, 0] = 1.0 - coords[:, :, 0]
     coords = coords[:, flip_indices]

--- a/mmpose/models/utils/tta.py
+++ b/mmpose/models/utils/tta.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import List
+from typing import List, Tuple
 
 from torch import Tensor
 
@@ -68,7 +68,8 @@ def flip_vectors(x_labels: Tensor, y_labels: Tensor, flip_indices: List[int]):
     return x_labels, y_labels
 
 
-def flip_coordinates(coords: Tensor, flip_indices: List[int]):
+def flip_coordinates(coords: Tensor, flip_indices: List[int],
+                     shift_coords: bool, img_shape: Tuple[int, int, int]):
     """Flip normalized coordinates for test-time augmentation.
 
     Args:
@@ -76,9 +77,19 @@ def flip_coordinates(coords: Tensor, flip_indices: List[int]):
             [B, K, D]
         flip_indices (List[int]): The indices of each keypoint's symmetric
             keypoint
+        shift_heatmap (bool): Shift the flipped coordinates to align with the
+            original coordinates and improve accuracy. Defaults to ``True``
+        img_shape (Tuple[int, int]): The shape of input image, channels are
+            ordered by [C, H, W]
     """
     assert coords.ndim == 3
     assert len(flip_indices) == coords.shape[1]
+
     coords[:, :, 0] = 1.0 - coords[:, :, 0]
+
+    if shift_coords:
+        img_width = img_shape[2]
+        coords[:, :, 0] -= 1.0 / img_width
+
     coords = coords[:, flip_indices]
     return coords

--- a/mmpose/models/utils/tta.py
+++ b/mmpose/models/utils/tta.py
@@ -48,8 +48,23 @@ def flip_heatmaps(heatmaps: Tensor,
     return heatmaps
 
 
-def flip_vectors():
-    pass
+def flip_vectors(x_labels: Tensor, y_labels: Tensor, flip_indices: List[int]):
+    """Flip instance-level labels in specific axis for test-time augmentation.
+
+    Args:
+        x_labels (Tensor): The vector labels in x-axis to flip. Should be
+            a tensor in shape [B, C, Wx]
+        y_labels (Tensor): The vector labels in y-axis to flip. Should be
+            a tensor in shape [B, C, Wy]
+        flip_indices (List[int]): The indices of each keypoint's symmetric
+            keypoint
+    """
+    assert len(x_labels) == 3
+    assert len(flip_indices) == x_labels.shape[1]
+    x_labels = x_labels[:, flip_indices].flip(-1)
+    y_labels = y_labels[:, flip_indices]
+
+    return x_labels, y_labels
 
 
 def flip_coordinates(coords: Tensor, flip_indices: List[int]):
@@ -61,7 +76,7 @@ def flip_coordinates(coords: Tensor, flip_indices: List[int]):
         flip_indices (List[int]): The indices of each keypoint's symmetric
             keypoint
     """
-
+    assert len(flip_indices) == coords.shape[1]
     coords[:, :, 0] = 1.0 - coords[:, :, 0]
     coords = coords[:, flip_indices]
     return coords

--- a/mmpose/models/utils/tta.py
+++ b/mmpose/models/utils/tta.py
@@ -46,3 +46,22 @@ def flip_heatmaps(heatmaps: Tensor,
         heatmaps[..., 1:] = heatmaps[..., :-1]
 
     return heatmaps
+
+
+def flip_vectors():
+    pass
+
+
+def flip_coordinates(coords: Tensor, flip_indices: List[int]):
+    """Flip normalized coordinates for test-time augmentation.
+
+    Args:
+        coords (Tensor): The coordinates to flip. Should be a tensor in shape
+            [B, K, D]
+        flip_indices (List[int]): The indices of each keypoint's symmetric
+            keypoint
+    """
+
+    coords[:, :, 0] = 1.0 - coords[:, :, 0]
+    coords = coords[:, flip_indices]
+    return coords

--- a/tests/test_models/test_heads/test_regression_heads/test_dsnt_head.py
+++ b/tests/test_models/test_heads/test_regression_heads/test_dsnt_head.py
@@ -185,6 +185,35 @@ class TestDSNTHead(TestCase):
         self.assertEqual(preds[0].pred_fields.heatmaps.shape,
                          (17, 8 * 8, 6 * 8))
 
+    def test_tta(self):
+        decoder_cfg = dict(type='RegressionLabel', input_size=(192, 256))
+
+        # inputs transform: select
+        head = DSNTHead(
+            in_channels=[16, 32],
+            in_featuremap_size=(6, 8),
+            num_joints=17,
+            input_transform='select',
+            input_index=-1,
+            decoder=decoder_cfg,
+        )
+
+        feats = self._get_feats(
+            batch_size=2, feat_shapes=[(16, 16, 12), (32, 8, 6)])
+        batch_data_samples = self._get_data_samples(
+            batch_size=2, with_reg_label=False)
+        preds = head.predict([feats, feats],
+                             batch_data_samples,
+                             test_cfg=dict(flip_test=True))
+
+        self.assertEqual(len(preds), 2)
+        self.assertIsInstance(preds[0], PoseDataSample)
+        self.assertIn('pred_instances', preds[0])
+        self.assertEqual(
+            preds[0].pred_instances.keypoints.shape,
+            preds[0].gt_instances.keypoints.shape,
+        )
+
     def test_loss(self):
         for dist_loss in ['l1', 'l2']:
             for div_reg in ['kl', 'js']:

--- a/tests/test_models/test_heads/test_regression_heads/test_integral_regression_head.py
+++ b/tests/test_models/test_heads/test_regression_heads/test_integral_regression_head.py
@@ -185,6 +185,35 @@ class TestIntegralRegressionHead(TestCase):
         self.assertEqual(preds[0].pred_fields.heatmaps.shape,
                          (17, 8 * 8, 6 * 8))
 
+    def test_tta(self):
+        decoder_cfg = dict(type='RegressionLabel', input_size=(192, 256))
+
+        # inputs transform: select
+        head = IntegralRegressionHead(
+            in_channels=[16, 32],
+            in_featuremap_size=(6, 8),
+            num_joints=17,
+            input_transform='select',
+            input_index=-1,
+            decoder=decoder_cfg,
+        )
+
+        feats = self._get_feats(
+            batch_size=2, feat_shapes=[(16, 16, 12), (32, 8, 6)])
+        batch_data_samples = self._get_data_samples(
+            batch_size=2, with_heatmap=False)
+        preds = head.predict([feats, feats],
+                             batch_data_samples,
+                             test_cfg=dict(flip_test=True))
+
+        self.assertEqual(len(preds), 2)
+        self.assertIsInstance(preds[0], PoseDataSample)
+        self.assertIn('pred_instances', preds[0])
+        self.assertEqual(
+            preds[0].pred_instances.keypoints.shape,
+            preds[0].gt_instances.keypoints.shape,
+        )
+
     def test_loss(self):
         head = IntegralRegressionHead(
             in_channels=[16, 32],

--- a/tests/test_models/test_heads/test_regression_heads/test_integral_regression_head.py
+++ b/tests/test_models/test_heads/test_regression_heads/test_integral_regression_head.py
@@ -204,7 +204,10 @@ class TestIntegralRegressionHead(TestCase):
             batch_size=2, with_heatmap=False)
         preds = head.predict([feats, feats],
                              batch_data_samples,
-                             test_cfg=dict(flip_test=True))
+                             test_cfg=dict(
+                                 flip_test=True,
+                                 shift_coords=True,
+                                 shift_heatmap=True))
 
         self.assertEqual(len(preds), 2)
         self.assertIsInstance(preds[0], PoseDataSample)

--- a/tests/test_models/test_heads/test_regression_heads/test_regression_head.py
+++ b/tests/test_models/test_heads/test_regression_heads/test_regression_head.py
@@ -134,7 +134,7 @@ class TestRegressionHead(TestCase):
             batch_size=2, with_heatmap=False)
         preds = head.predict([feats, feats],
                              batch_data_samples,
-                             test_cfg=dict(flip_test=True))
+                             test_cfg=dict(flip_test=True, shift_coords=True))
 
         self.assertEqual(len(preds), 2)
         self.assertIsInstance(preds[0], PoseDataSample)

--- a/tests/test_models/test_heads/test_regression_heads/test_regression_head.py
+++ b/tests/test_models/test_heads/test_regression_heads/test_regression_head.py
@@ -116,6 +116,34 @@ class TestRegressionHead(TestCase):
 
         self.assertNotIn('pred_fields', preds[0])
 
+    def test_tta(self):
+        decoder_cfg = dict(type='RegressionLabel', input_size=(192, 256))
+
+        # inputs transform: select
+        head = RegressionHead(
+            in_channels=[16, 32],
+            num_joints=17,
+            input_transform='select',
+            input_index=-1,
+            decoder=decoder_cfg,
+        )
+
+        feats = self._get_feats(
+            batch_size=2, feat_shapes=[(16, 1, 1), (32, 1, 1)])
+        batch_data_samples = self._get_data_samples(
+            batch_size=2, with_heatmap=False)
+        preds = head.predict([feats, feats],
+                             batch_data_samples,
+                             test_cfg=dict(flip_test=True))
+
+        self.assertEqual(len(preds), 2)
+        self.assertIsInstance(preds[0], PoseDataSample)
+        self.assertIn('pred_instances', preds[0])
+        self.assertEqual(
+            preds[0].pred_instances.keypoints.shape,
+            preds[0].gt_instances.keypoints.shape,
+        )
+
     def test_loss(self):
         head = RegressionHead(
             in_channels=[16, 32],

--- a/tests/test_models/test_heads/test_regression_heads/test_rle_head.py
+++ b/tests/test_models/test_heads/test_regression_heads/test_rle_head.py
@@ -117,6 +117,34 @@ class TestRLEHead(TestCase):
 
         self.assertNotIn('pred_fields', preds[0])
 
+    def test_tta(self):
+        decoder_cfg = dict(type='RegressionLabel', input_size=(192, 256))
+
+        # inputs transform: select
+        head = RLEHead(
+            in_channels=[16, 32],
+            num_joints=17,
+            input_transform='select',
+            input_index=-1,
+            decoder=decoder_cfg,
+        )
+
+        feats = self._get_feats(
+            batch_size=2, feat_shapes=[(16, 1, 1), (32, 1, 1)])
+        batch_data_samples = self._get_data_samples(
+            batch_size=2, with_heatmap=False)
+        preds = head.predict([feats, feats],
+                             batch_data_samples,
+                             test_cfg=dict(flip_test=True))
+
+        self.assertEqual(len(preds), 2)
+        self.assertIsInstance(preds[0], PoseDataSample)
+        self.assertIn('pred_instances', preds[0])
+        self.assertEqual(
+            preds[0].pred_instances.keypoints.shape,
+            preds[0].gt_instances.keypoints.shape,
+        )
+
     def test_loss(self):
         head = RLEHead(
             in_channels=[16, 32],


### PR DESCRIPTION

## Motivation

Support test time augmentation by flipping for regression heads (`RegressionHead`, `RLEHead`, `DSNTHead` and `IntegralRegressionHead`)

Support test time augmentation by flipping for simcc heads (`SimCCHead`)

## Modification



## BC-breaking (Optional)


## Use cases (Optional)


## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
