### PR TITLE
[Refactor] Add verified configs for topdown heatmap models with CocoMetric

### DIFF
--- a/configs/body_2d_keypoint/topdown_heatmap/aic/hrnet_w32_aic_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/aic/hrnet_w32_aic_256x192.py
@@ -1,0 +1,124 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='HRNet',
+        in_channels=3,
+        extra=dict(
+            stage1=dict(
+                num_modules=1,
+                num_branches=1,
+                block='BOTTLENECK',
+                num_blocks=(4, ),
+                num_channels=(64, )),
+            stage2=dict(
+                num_modules=1,
+                num_branches=2,
+                block='BASIC',
+                num_blocks=(4, 4),
+                num_channels=(32, 64)),
+            stage3=dict(
+                num_modules=4,
+                num_branches=3,
+                block='BASIC',
+                num_blocks=(4, 4, 4),
+                num_channels=(32, 64, 128)),
+            stage4=dict(
+                num_modules=3,
+                num_branches=4,
+                block='BASIC',
+                num_blocks=(4, 4, 4, 4),
+                num_channels=(32, 64, 128, 256))),
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='https://download.openmmlab.com/mmpose'
+            '/pretrain_models/hrnet_w32-36af842e.pth'),
+    ),
+    head=dict(
+        type='HeatmapHead',
+        in_channels=32,
+        out_channels=14,
+        deconv_out_channels=None,
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'AicDataset'
+data_mode = 'topdown'
+data_root = 'data/aic/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/aic_train.json',
+        data_prefix=dict(img='ai_challenger_keypoint_train_20170902/'
+                         'keypoint_train_images_20170902/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/aic_val.json',
+        data_prefix=dict(img='ai_challenger_keypoint_validation_20170911/'
+                         'keypoint_validation_images_20170911/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/aic_val.json',
+    use_area=False)
+test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/hrformer_small_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/hrformer_small_coco_256x192.py
@@ -1,0 +1,142 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+norm_cfg = dict(type='SyncBN', requires_grad=True)
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='HRFormer',
+        in_channels=3,
+        norm_cfg=norm_cfg,
+        extra=dict(
+            drop_path_rate=0.1,
+            with_rpe=True,
+            stage1=dict(
+                num_modules=1,
+                num_branches=1,
+                block='BOTTLENECK',
+                num_blocks=(2, ),
+                num_channels=(64, ),
+                num_heads=[2],
+                num_mlp_ratios=[4]),
+            stage2=dict(
+                num_modules=1,
+                num_branches=2,
+                block='HRFORMERBLOCK',
+                num_blocks=(2, 2),
+                num_channels=(32, 64),
+                num_heads=[1, 2],
+                mlp_ratios=[4, 4],
+                window_sizes=[7, 7]),
+            stage3=dict(
+                num_modules=4,
+                num_branches=3,
+                block='HRFORMERBLOCK',
+                num_blocks=(2, 2, 2),
+                num_channels=(32, 64, 128),
+                num_heads=[1, 2, 4],
+                mlp_ratios=[4, 4, 4],
+                window_sizes=[7, 7, 7]),
+            stage4=dict(
+                num_modules=2,
+                num_branches=4,
+                block='HRFORMERBLOCK',
+                num_blocks=(2, 2, 2, 2),
+                num_channels=(32, 64, 128, 256),
+                num_heads=[1, 2, 4, 8],
+                mlp_ratios=[4, 4, 4, 4],
+                window_sizes=[7, 7, 7, 7])),
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='https://download.openmmlab.com/mmpose/'
+            'pretrain_models/hrformer_small-09516375_20220226.pth'),
+    ),
+    head=dict(
+        type='HeatmapHead',
+        in_channels=32,
+        out_channels=17,
+        deconv_out_channels=None,
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator
+
+# fp16 settings
+fp16 = dict(loss_scale='dynamic')

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/litehrnet_18_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/litehrnet_18_coco_256x192.py
@@ -1,0 +1,110 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='LiteHRNet',
+        in_channels=3,
+        extra=dict(
+            stem=dict(stem_channels=32, out_channels=32, expand_ratio=1),
+            num_stages=3,
+            stages_spec=dict(
+                num_modules=(2, 4, 2),
+                num_branches=(2, 3, 4),
+                num_blocks=(2, 2, 2),
+                module_type=('LITE', 'LITE', 'LITE'),
+                with_fuse=(True, True, True),
+                reduce_ratios=(8, 8, 8),
+                num_channels=(
+                    (40, 80),
+                    (40, 80, 160),
+                    (40, 80, 160, 320),
+                )),
+            with_head=True,
+        )),
+    head=dict(
+        type='HeatmapHead',
+        in_channels=40,
+        out_channels=17,
+        deconv_out_channels=None,
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/mobilenetv2_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/mobilenetv2_coco_256x192.py
@@ -1,0 +1,97 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='MobileNetV2',
+        widen_factor=1.,
+        out_indices=(7, ),
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='mmcls://mobilenet_v2',
+        )),
+    head=dict(
+        type='HeatmapHead',
+        in_channels=1280,
+        out_channels=17,
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/mspn50_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/mspn50_coco_256x192.py
@@ -112,5 +112,6 @@ test_dataloader = val_dataloader
 
 val_evaluator = dict(
     type='CocoMetric',
-    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json',
+    nms_mode='none')
 test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/mspn50_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/mspn50_coco_256x192.py
@@ -1,0 +1,116 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MegviiHeatmap',
+    input_size=(192, 256),
+    heatmap_size=(48, 64),
+    kernel_size=5)
+
+# model settings
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='MSPN',
+        unit_channels=256,
+        num_stages=1,
+        num_units=4,
+        num_blocks=[3, 4, 6, 3],
+        norm_cfg=dict(type='BN'),
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='torchvision://resnet50',
+        )),
+    head=dict(
+        type='MSPNHead',
+        out_shape=(64, 48),
+        unit_channels=256,
+        out_channels=17,
+        num_stages=1,
+        norm_cfg=dict(type='BN'),
+        loss=[
+            dict(
+                type='KeypointMSELoss',
+                use_target_weight=True,
+                loss_weight=0.25)
+        ] * 3 + [
+            dict(
+                type='KeypointOHKMMSELoss',
+                use_target_weight=True,
+                loss_weight=1.)
+        ],
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=False,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/pvt-s_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/pvt-s_coco_256x192.py
@@ -1,0 +1,100 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+norm_cfg = dict(type='SyncBN', requires_grad=True)
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='PyramidVisionTransformer',
+        num_layers=[3, 4, 6, 3],
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='https://github.com/whai362/PVT/'
+            'releases/download/v2/pvt_small.pth'),
+    ),
+    head=dict(
+        type='HeatmapHead',
+        in_channels=(64, 128, 320, 512),
+        out_channels=17,
+        input_index=3,
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/rsn18_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/rsn18_coco_256x192.py
@@ -1,0 +1,119 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MegviiHeatmap',
+    input_size=(192, 256),
+    heatmap_size=(48, 64),
+    kernel_size=5)
+
+# model settings
+norm_cfg = dict(type='SyncBN', requires_grad=True)
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='RSN',
+        unit_channels=256,
+        num_stages=1,
+        num_units=4,
+        num_blocks=[2, 2, 2, 2],
+        num_steps=4,
+        norm_cfg=dict(type='BN'),
+    ),
+    head=dict(
+        type='MSPNHead',
+        out_shape=(64, 48),
+        unit_channels=256,
+        out_channels=17,
+        num_stages=1,
+        norm_cfg=dict(type='BN'),
+        loss=[
+            dict(
+                type='KeypointMSELoss',
+                use_target_weight=True,
+                loss_weight=0.25)
+        ] * 3 + [
+            dict(
+                type='KeypointOHKMMSELoss',
+                use_target_weight=True,
+                loss_weight=1.)
+        ],
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=False,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator
+
+# fp16 settings
+fp16 = dict(loss_scale='dynamic')

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/rsn18_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/rsn18_coco_256x192.py
@@ -112,7 +112,8 @@ test_dataloader = val_dataloader
 
 val_evaluator = dict(
     type='CocoMetric',
-    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json',
+    nms_mode='none')
 test_evaluator = val_evaluator
 
 # fp16 settings

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/swin_t_p4_w7_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/swin_t_p4_w7_coco_256x192.py
@@ -1,0 +1,113 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+norm_cfg = dict(type='SyncBN', requires_grad=True)
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='SwinTransformer',
+        embed_dims=96,
+        depths=[2, 2, 6, 2],
+        num_heads=[3, 6, 12, 24],
+        window_size=7,
+        mlp_ratio=4,
+        qkv_bias=True,
+        qk_scale=None,
+        drop_rate=0.,
+        attn_drop_rate=0.,
+        drop_path_rate=0.2,
+        patch_norm=True,
+        out_indices=(0, 1, 2, 3),
+        with_cp=False,
+        convert_weights=True,
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='https://github.com/SwinTransformer/storage/releases/'
+            'download/v1.0.0/swin_tiny_patch4_window7_224.pth'),
+    ),
+    head=dict(
+        type='HeatmapHead',
+        in_channels=(96, 192, 384, 768),
+        out_channels=17,
+        input_index=3,
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/vipnas_mbv3_coco_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/vipnas_mbv3_coco_256x192.py
@@ -1,0 +1,92 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(type='ViPNAS_MobileNetV3'),
+    head=dict(
+        type='ViPNASHead',
+        in_channels=160,
+        out_channels=17,
+        deconv_out_channels=(160, 160, 160),
+        deconv_num_groups=(160, 160, 160),
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/crowdpose/hrnet_w32_crowdpose_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/crowdpose/hrnet_w32_crowdpose_256x192.py
@@ -1,0 +1,122 @@
+_base_ = [
+    '../../../_base_/default_runtime.py',
+    '../../../_base_/schedules/schedule_bs512_ep210.py',
+]
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='HRNet',
+        in_channels=3,
+        extra=dict(
+            stage1=dict(
+                num_modules=1,
+                num_branches=1,
+                block='BOTTLENECK',
+                num_blocks=(4, ),
+                num_channels=(64, )),
+            stage2=dict(
+                num_modules=1,
+                num_branches=2,
+                block='BASIC',
+                num_blocks=(4, 4),
+                num_channels=(32, 64)),
+            stage3=dict(
+                num_modules=4,
+                num_branches=3,
+                block='BASIC',
+                num_blocks=(4, 4, 4),
+                num_channels=(32, 64, 128)),
+            stage4=dict(
+                num_modules=3,
+                num_branches=4,
+                block='BASIC',
+                num_blocks=(4, 4, 4, 4),
+                num_channels=(32, 64, 128, 256))),
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='https://download.openmmlab.com/mmpose'
+            '/pretrain_models/hrnet_w32-36af842e.pth'),
+    ),
+    head=dict(
+        type='HeatmapHead',
+        in_channels=32,
+        out_channels=14,
+        deconv_out_channels=None,
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'CrowdPoseDataset'
+data_mode = 'topdown'
+data_root = 'data/crowdpose/'
+
+file_client_args = dict(backend='disk')
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownGenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+test_pipeline = [
+    dict(type='LoadImage', file_client_args=file_client_args),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/mmpose_crowdpose_trainval.json',
+        data_prefix=dict(img='images/'),
+        pipeline=train_pipeline,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/mmpose_crowdpose_test.json',
+        data_prefix=dict(img='images/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/mmpose_crowdpose_test.json',
+    use_area=False)
+test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/crowdpose/hrnet_w32_crowdpose_256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/crowdpose/hrnet_w32_crowdpose_256x192.py
@@ -109,6 +109,7 @@ val_dataloader = dict(
         type=dataset_type,
         data_root=data_root,
         ann_file='annotations/mmpose_crowdpose_test.json',
+        bbox_file='data/crowdpose/annotations/det_for_crowd_test_0.1_0.5.json',
         data_prefix=dict(img='images/'),
         test_mode=True,
         pipeline=test_pipeline,
@@ -118,5 +119,6 @@ test_dataloader = val_dataloader
 val_evaluator = dict(
     type='CocoMetric',
     ann_file=data_root + 'annotations/mmpose_crowdpose_test.json',
-    use_area=False)
+    use_area=False,
+    iou_type='keypoints_crowd')
 test_evaluator = val_evaluator

--- a/mmpose/evaluation/metrics/coco_metric.py
+++ b/mmpose/evaluation/metrics/coco_metric.py
@@ -30,6 +30,10 @@ class CocoMetric(BaseMetric):
             If the ground truth annotations (e.g. CrowdPose, AIC) do not have
             the field ``'area'``, please set ``use_area=False``.
             Default: ``True``.
+        iou_type (str): The same parameter as `iouType` in
+            :class:`xtcocotools.COCOeval`, which can be ``'keypoints'``, or
+            ``'keypoints_crowd'`` (used in CrowdPose dataset).
+            Defaults to ``'keypoints'``.
         score_mode (str): The mode to score the prediction results which
             should be one of the following options:
 
@@ -81,6 +85,7 @@ class CocoMetric(BaseMetric):
     def __init__(self,
                  ann_file: str,
                  use_area: bool = True,
+                 iou_type: str = 'keypoints',
                  score_mode: str = 'bbox_keypoint',
                  keypoint_score_thr: float = 0.2,
                  nms_mode: str = 'oks_nms',
@@ -95,6 +100,7 @@ class CocoMetric(BaseMetric):
         self.coco = COCO(ann_file)
 
         self.use_area = use_area
+        self.iou_type = iou_type
 
         allowed_score_modes = ['bbox', 'bbox_keypoint', 'bbox_rle']
         if score_mode not in allowed_score_modes:
@@ -334,7 +340,7 @@ class CocoMetric(BaseMetric):
         res_file = f'{outfile_prefix}.keypoints.json'
         coco_det = self.coco.loadRes(res_file)
         sigmas = self.dataset_meta['sigmas']
-        coco_eval = COCOeval(self.coco, coco_det, 'keypoints', sigmas,
+        coco_eval = COCOeval(self.coco, coco_det, self.iou_type, sigmas,
                              self.use_area)
         coco_eval.params.useSegm = None
         coco_eval.evaluate()


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->
Add configs for top-down heatmap models on COCO, AIC, CrowdPose. The performance of these models matches that on logs

## Modification

<!-- Please briefly describe what modification is made in this PR. -->
1. Add configs for top-down heatmap models on COCO, AIC, CrowdPose.
2. Fix `CocoMetric` to support customized `iou_type`

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
