### PR TITLE
Fix fliplr_joints bug when joints_3d_visible has float values

### DIFF
--- a/mmpose/core/post_processing/post_transforms.py
+++ b/mmpose/core/post_processing/post_transforms.py
@@ -46,7 +46,7 @@ def fliplr_joints(joints_3d, joints_3d_visible, img_width, flip_pairs):
 
     # Flip horizontally
     joints_3d_flipped[:, 0] = img_width - 1 - joints_3d_flipped[:, 0]
-    joints_3d_flipped = joints_3d_flipped * joints_3d_visible_flipped
+    joints_3d_flipped = joints_3d_flipped * (joints_3d_visible_flipped > 0)
 
     return joints_3d_flipped, joints_3d_visible_flipped
 

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -24,10 +24,24 @@ def test_rotate_point():
 
 
 def test_fliplr_joints():
+    # binary visibility
     joints = np.array([[0, 0, 0], [1, 1, 0]])
     joints_vis = np.array([[1], [1]])
     joints_flip, _ = fliplr_joints(joints, joints_vis, 5, [[0, 1]])
     res = np.array([[3, 1, 0], [4, 0, 0]])
+    assert_array_almost_equal(joints_flip, res)
+
+    # float visibility
+    joints = np.array([[0, 0, 0], [1, 1, 0]])
+    joints_vis = np.array([[0.5], [1]])
+    joints_flip, _ = fliplr_joints(joints, joints_vis, 5, [[0, 1]])
+    res = np.array([[3, 1, 0], [4, 0, 0]])
+    assert_array_almost_equal(joints_flip, res)
+
+    joints = np.array([[0, 0, 0], [1, 1, 0]])
+    joints_vis = np.array([[0], [1]])
+    joints_flip, _ = fliplr_joints(joints, joints_vis, 5, [[0, 1]])
+    res = np.array([[3, 1, 0], [0, 0, 0]])
     assert_array_almost_equal(joints_flip, res)
 
 


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation
- Fix bug when `joints_3d_visible` has float values
- `TopDownRandomFlip` transformation will output wrong joints coordinates if  `joints_3d_visible` has float values

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

## Modification
- Make `joints_3d_visible_flipped` be 0 or 1 during random flip

<!-- Please briefly describe what modification is made in this PR. -->

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
