### PR TITLE
[Refactor] Modify some scripts to fit `MultilevelPixelData`

### DIFF
--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xmspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xmspn50_8xb32-210e_coco-256x192.py
@@ -31,7 +31,7 @@ default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
 # multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
-kernel_sizes = [15, 11, 9, 7] + [11, 9, 7, 5]
+kernel_sizes = [15, 11, 9, 7, 5]
 codec = [
     dict(
         type='MegviiHeatmap',
@@ -65,7 +65,11 @@ model = dict(
         unit_channels=256,
         out_channels=17,
         num_stages=2,
+        num_units=4,
         norm_cfg=dict(type='BN'),
+        # each sub list is for a stage
+        # and each element in each list if for a unit
+        level_indices=[0, 1, 2, 3] + [1, 2, 3, 4],
         loss=([
             dict(
                 type='KeypointMSELoss',

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xmspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xmspn50_8xb32-210e_coco-256x192.py
@@ -68,7 +68,7 @@ model = dict(
         num_units=4,
         norm_cfg=dict(type='BN'),
         # each sub list is for a stage
-        # and each element in each list if for a unit
+        # and each element in each list is for a unit
         level_indices=[0, 1, 2, 3] + [1, 2, 3, 4],
         loss=([
             dict(

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xmspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xmspn50_8xb32-210e_coco-256x192.py
@@ -30,11 +30,15 @@ auto_scale_lr = dict(base_batch_size=256)
 default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
-codec = dict(
-    type='MegviiHeatmap',
-    input_size=(192, 256),
-    heatmap_size=(48, 64),
-    kernel_size=5)
+# multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
+kernel_sizes = [15, 11, 9, 7] + [11, 9, 7, 5]
+codec = [
+    dict(
+        type='MegviiHeatmap',
+        input_size=(192, 256),
+        heatmap_size=(48, 64),
+        kernel_size=kernel_size) for kernel_size in kernel_sizes
+]
 
 # model settings
 model = dict(
@@ -73,7 +77,7 @@ model = dict(
                 use_target_weight=True,
                 loss_weight=1.)
         ]) * 2,
-        decoder=codec),
+        decoder=codec[-1]),
     test_cfg=dict(
         flip_test=True,
         flip_mode='heatmap',
@@ -94,14 +98,16 @@ train_pipeline = [
     dict(type='RandomFlip', direction='horizontal'),
     dict(type='RandomHalfBody'),
     dict(type='RandomBBoxTransform'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
-    dict(type='GenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
+    dict(
+        type='GenerateTarget', target_type='multilevel_heatmap',
+        encoder=codec),
     dict(type='PackPoseInputs')
 ]
 test_pipeline = [
     dict(type='LoadImage', file_client_args=file_client_args),
     dict(type='GetBBoxCenterScale'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
     dict(type='PackPoseInputs')
 ]
 

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xrsn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xrsn50_8xb32-210e_coco-256x192.py
@@ -30,11 +30,15 @@ auto_scale_lr = dict(base_batch_size=256)
 default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
-codec = dict(
-    type='MegviiHeatmap',
-    input_size=(192, 256),
-    heatmap_size=(48, 64),
-    kernel_size=5)
+# multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
+kernel_sizes = [15, 11, 9, 7] + [11, 9, 7, 5]
+codec = [
+    dict(
+        type='MegviiHeatmap',
+        input_size=(192, 256),
+        heatmap_size=(48, 64),
+        kernel_size=kernel_size) for kernel_size in kernel_sizes
+]
 
 # model settings
 model = dict(
@@ -71,7 +75,7 @@ model = dict(
                 use_target_weight=True,
                 loss_weight=1.)
         ]) * 2,
-        decoder=codec),
+        decoder=codec[-1]),
     test_cfg=dict(
         flip_test=True,
         flip_mode='heatmap',
@@ -92,15 +96,17 @@ train_pipeline = [
     dict(type='RandomFlip', direction='horizontal'),
     dict(type='RandomHalfBody'),
     dict(type='RandomBBoxTransform'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
-    dict(type='GenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
+    dict(
+        type='GenerateTarget', target_type='multilevel_heatmap',
+        encoder=codec),
     dict(type='PackPoseInputs')
 ]
 
 test_pipeline = [
     dict(type='LoadImage', file_client_args=file_client_args),
     dict(type='GetBBoxCenterScale'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
     dict(type='PackPoseInputs')
 ]
 

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xrsn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xrsn50_8xb32-210e_coco-256x192.py
@@ -31,7 +31,7 @@ default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
 # multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
-kernel_sizes = [15, 11, 9, 7] + [11, 9, 7, 5]
+kernel_sizes = [15, 11, 9, 7, 5]
 codec = [
     dict(
         type='MegviiHeatmap',
@@ -63,7 +63,11 @@ model = dict(
         unit_channels=256,
         out_channels=17,
         num_stages=2,
+        num_units=4,
         norm_cfg=dict(type='BN'),
+        # each sub list is for a stage
+        # and each element in each list if for a unit
+        level_indices=[0, 1, 2, 3] + [1, 2, 3, 4],
         loss=([
             dict(
                 type='KeypointMSELoss',

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xrsn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xrsn50_8xb32-210e_coco-256x192.py
@@ -66,7 +66,7 @@ model = dict(
         num_units=4,
         norm_cfg=dict(type='BN'),
         # each sub list is for a stage
-        # and each element in each list if for a unit
+        # and each element in each list is for a unit
         level_indices=[0, 1, 2, 3] + [1, 2, 3, 4],
         loss=([
             dict(

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xmspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xmspn50_8xb32-210e_coco-256x192.py
@@ -31,7 +31,7 @@ default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
 # multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
-kernel_sizes = [15, 11, 9, 7] * 2 + [11, 9, 7, 5]
+kernel_sizes = [15, 11, 9, 7, 5]
 codec = [
     dict(
         type='MegviiHeatmap',
@@ -65,7 +65,11 @@ model = dict(
         unit_channels=256,
         out_channels=17,
         num_stages=3,
+        num_units=4,
         norm_cfg=dict(type='BN'),
+        # each sub list is for a stage
+        # and each element in each list if for a unit
+        level_indices=[0, 1, 2, 3] * 2 + [1, 2, 3, 4],
         loss=([
             dict(
                 type='KeypointMSELoss',

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xmspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xmspn50_8xb32-210e_coco-256x192.py
@@ -68,7 +68,7 @@ model = dict(
         num_units=4,
         norm_cfg=dict(type='BN'),
         # each sub list is for a stage
-        # and each element in each list if for a unit
+        # and each element in each list is for a unit
         level_indices=[0, 1, 2, 3] * 2 + [1, 2, 3, 4],
         loss=([
             dict(

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xmspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xmspn50_8xb32-210e_coco-256x192.py
@@ -30,11 +30,15 @@ auto_scale_lr = dict(base_batch_size=256)
 default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
-codec = dict(
-    type='MegviiHeatmap',
-    input_size=(192, 256),
-    heatmap_size=(48, 64),
-    kernel_size=5)
+# multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
+kernel_sizes = [15, 11, 9, 7] * 2 + [11, 9, 7, 5]
+codec = [
+    dict(
+        type='MegviiHeatmap',
+        input_size=(192, 256),
+        heatmap_size=(48, 64),
+        kernel_size=kernel_size) for kernel_size in kernel_sizes
+]
 
 # model settings
 model = dict(
@@ -73,7 +77,7 @@ model = dict(
                 use_target_weight=True,
                 loss_weight=1.)
         ]) * 3,
-        decoder=codec),
+        decoder=codec[-1]),
     test_cfg=dict(
         flip_test=True,
         flip_mode='heatmap',
@@ -94,14 +98,16 @@ train_pipeline = [
     dict(type='RandomFlip', direction='horizontal'),
     dict(type='RandomHalfBody'),
     dict(type='RandomBBoxTransform'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
-    dict(type='GenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
+    dict(
+        type='GenerateTarget', target_type='multilevel_heatmap',
+        encoder=codec),
     dict(type='PackPoseInputs')
 ]
 test_pipeline = [
     dict(type='LoadImage', file_client_args=file_client_args),
     dict(type='GetBBoxCenterScale'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
     dict(type='PackPoseInputs')
 ]
 

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xrsn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xrsn50_8xb32-210e_coco-256x192.py
@@ -31,7 +31,7 @@ default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
 # multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
-kernel_sizes = [15, 11, 9, 7] * 2 + [11, 9, 7, 5]
+kernel_sizes = [15, 11, 9, 7, 5]
 codec = [
     dict(
         type='MegviiHeatmap',
@@ -63,7 +63,11 @@ model = dict(
         unit_channels=256,
         out_channels=17,
         num_stages=3,
+        num_units=4,
         norm_cfg=dict(type='BN'),
+        # each sub list is for a stage
+        # and each element in each list if for a unit
+        level_indices=[0, 1, 2, 3] * 2 + [1, 2, 3, 4],
         loss=([
             dict(
                 type='KeypointMSELoss',

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xrsn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xrsn50_8xb32-210e_coco-256x192.py
@@ -30,11 +30,15 @@ auto_scale_lr = dict(base_batch_size=256)
 default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
-codec = dict(
-    type='MegviiHeatmap',
-    input_size=(192, 256),
-    heatmap_size=(48, 64),
-    kernel_size=5)
+# multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
+kernel_sizes = [15, 11, 9, 7] * 2 + [11, 9, 7, 5]
+codec = [
+    dict(
+        type='MegviiHeatmap',
+        input_size=(192, 256),
+        heatmap_size=(48, 64),
+        kernel_size=kernel_size) for kernel_size in kernel_sizes
+]
 
 # model settings
 model = dict(
@@ -71,7 +75,7 @@ model = dict(
                 use_target_weight=True,
                 loss_weight=1.)
         ]) * 3,
-        decoder=codec),
+        decoder=codec[-1]),
     test_cfg=dict(
         flip_test=True,
         flip_mode='heatmap',
@@ -92,15 +96,17 @@ train_pipeline = [
     dict(type='RandomFlip', direction='horizontal'),
     dict(type='RandomHalfBody'),
     dict(type='RandomBBoxTransform'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
-    dict(type='GenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
+    dict(
+        type='GenerateTarget', target_type='multilevel_heatmap',
+        encoder=codec),
     dict(type='PackPoseInputs')
 ]
 
 test_pipeline = [
     dict(type='LoadImage', file_client_args=file_client_args),
     dict(type='GetBBoxCenterScale'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
     dict(type='PackPoseInputs')
 ]
 

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xrsn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_3xrsn50_8xb32-210e_coco-256x192.py
@@ -66,7 +66,7 @@ model = dict(
         num_units=4,
         norm_cfg=dict(type='BN'),
         # each sub list is for a stage
-        # and each element in each list if for a unit
+        # and each element in each list is for a unit
         level_indices=[0, 1, 2, 3] * 2 + [1, 2, 3, 4],
         loss=([
             dict(

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_4xmspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_4xmspn50_8xb32-210e_coco-256x192.py
@@ -31,7 +31,7 @@ default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
 # multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
-kernel_sizes = [15, 11, 9, 7] * 3 + [11, 9, 7, 5]
+kernel_sizes = [15, 11, 9, 7, 5]
 codec = [
     dict(
         type='MegviiHeatmap',
@@ -65,7 +65,11 @@ model = dict(
         unit_channels=256,
         out_channels=17,
         num_stages=4,
+        num_units=4,
         norm_cfg=dict(type='BN'),
+        # each sub list is for a stage
+        # and each element in each list if for a unit
+        level_indices=[0, 1, 2, 3] * 3 + [1, 2, 3, 4],
         loss=([
             dict(
                 type='KeypointMSELoss',

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_4xmspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_4xmspn50_8xb32-210e_coco-256x192.py
@@ -68,7 +68,7 @@ model = dict(
         num_units=4,
         norm_cfg=dict(type='BN'),
         # each sub list is for a stage
-        # and each element in each list if for a unit
+        # and each element in each list is for a unit
         level_indices=[0, 1, 2, 3] * 3 + [1, 2, 3, 4],
         loss=([
             dict(

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_4xmspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_4xmspn50_8xb32-210e_coco-256x192.py
@@ -30,11 +30,15 @@ auto_scale_lr = dict(base_batch_size=256)
 default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
-codec = dict(
-    type='MegviiHeatmap',
-    input_size=(192, 256),
-    heatmap_size=(48, 64),
-    kernel_size=5)
+# multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
+kernel_sizes = [15, 11, 9, 7] * 3 + [11, 9, 7, 5]
+codec = [
+    dict(
+        type='MegviiHeatmap',
+        input_size=(192, 256),
+        heatmap_size=(48, 64),
+        kernel_size=kernel_size) for kernel_size in kernel_sizes
+]
 
 # model settings
 model = dict(
@@ -73,7 +77,7 @@ model = dict(
                 use_target_weight=True,
                 loss_weight=1.)
         ]) * 4,
-        decoder=codec),
+        decoder=codec[-1]),
     test_cfg=dict(
         flip_test=True,
         flip_mode='heatmap',
@@ -94,14 +98,16 @@ train_pipeline = [
     dict(type='RandomFlip', direction='horizontal'),
     dict(type='RandomHalfBody'),
     dict(type='RandomBBoxTransform'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
-    dict(type='GenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
+    dict(
+        type='GenerateTarget', target_type='multilevel_heatmap',
+        encoder=codec),
     dict(type='PackPoseInputs')
 ]
 test_pipeline = [
     dict(type='LoadImage', file_client_args=file_client_args),
     dict(type='GetBBoxCenterScale'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
     dict(type='PackPoseInputs')
 ]
 

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_mspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_mspn50_8xb32-210e_coco-256x192.py
@@ -65,7 +65,11 @@ model = dict(
         unit_channels=256,
         out_channels=17,
         num_stages=1,
+        num_units=4,
         norm_cfg=dict(type='BN'),
+        # each sub list is for a stage
+        # and each element in each list if for a unit
+        level_indices=[0, 1, 2, 3],
         loss=[
             dict(
                 type='KeypointMSELoss',

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_mspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_mspn50_8xb32-210e_coco-256x192.py
@@ -30,11 +30,15 @@ auto_scale_lr = dict(base_batch_size=256)
 default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
 
 # codec settings
-codec = dict(
-    type='MegviiHeatmap',
-    input_size=(192, 256),
-    heatmap_size=(48, 64),
-    kernel_size=5)
+# multiple kernel_sizes of heatmap gaussian for 'Megvii' approach.
+kernel_sizes = [11, 9, 7, 5]
+codec = [
+    dict(
+        type='MegviiHeatmap',
+        input_size=(192, 256),
+        heatmap_size=(48, 64),
+        kernel_size=kernel_size) for kernel_size in kernel_sizes
+]
 
 # model settings
 model = dict(
@@ -73,7 +77,7 @@ model = dict(
                 use_target_weight=True,
                 loss_weight=1.)
         ],
-        decoder=codec),
+        decoder=codec[-1]),
     test_cfg=dict(
         flip_test=True,
         flip_mode='heatmap',
@@ -94,14 +98,16 @@ train_pipeline = [
     dict(type='RandomFlip', direction='horizontal'),
     dict(type='RandomHalfBody'),
     dict(type='RandomBBoxTransform'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
-    dict(type='GenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
+    dict(
+        type='GenerateTarget', target_type='multilevel_heatmap',
+        encoder=codec),
     dict(type='PackPoseInputs')
 ]
 test_pipeline = [
     dict(type='LoadImage', file_client_args=file_client_args),
     dict(type='GetBBoxCenterScale'),
-    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='TopdownAffine', input_size=codec[0]['input_size']),
     dict(type='PackPoseInputs')
 ]
 

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_mspn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_mspn50_8xb32-210e_coco-256x192.py
@@ -68,7 +68,7 @@ model = dict(
         num_units=4,
         norm_cfg=dict(type='BN'),
         # each sub list is for a stage
-        # and each element in each list if for a unit
+        # and each element in each list is for a unit
         level_indices=[0, 1, 2, 3],
         loss=[
             dict(

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_rsn18_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_rsn18_8xb32-210e_coco-256x192.py
@@ -66,7 +66,7 @@ model = dict(
         num_units=4,
         norm_cfg=dict(type='BN'),
         # each sub list is for a stage
-        # and each element in each list if for a unit
+        # and each element in each list is for a unit
         level_indices=[0, 1, 2, 3],
         loss=[
             dict(

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_rsn18_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_rsn18_8xb32-210e_coco-256x192.py
@@ -63,7 +63,11 @@ model = dict(
         unit_channels=256,
         out_channels=17,
         num_stages=1,
+        num_units=4,
         norm_cfg=dict(type='BN'),
+        # each sub list is for a stage
+        # and each element in each list if for a unit
+        level_indices=[0, 1, 2, 3],
         loss=[
             dict(
                 type='KeypointMSELoss',

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_rsn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_rsn50_8xb32-210e_coco-256x192.py
@@ -66,7 +66,7 @@ model = dict(
         num_units=4,
         norm_cfg=dict(type='BN'),
         # each sub list is for a stage
-        # and each element in each list if for a unit
+        # and each element in each list is for a unit
         level_indices=[0, 1, 2, 3],
         loss=[
             dict(

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_rsn50_8xb32-210e_coco-256x192.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_rsn50_8xb32-210e_coco-256x192.py
@@ -63,7 +63,11 @@ model = dict(
         unit_channels=256,
         out_channels=17,
         num_stages=1,
+        num_units=4,
         norm_cfg=dict(type='BN'),
+        # each sub list is for a stage
+        # and each element in each list if for a unit
+        level_indices=[0, 1, 2, 3],
         loss=[
             dict(
                 type='KeypointMSELoss',

--- a/mmpose/datasets/transforms/common_transforms.py
+++ b/mmpose/datasets/transforms/common_transforms.py
@@ -898,10 +898,11 @@ class GenerateTarget(BaseTransform):
 
             - ``'heatmap'``: The encoded should be instance-irrelevant
                 heatmaps and will be stored in ``results['heatmaps']``
-            - ``'multiscale_heatmap'`` The encoded should be a list of
-                heatmaps and will be stored in ``results['heatmaps']``. Note
-                that in this case ``self.encoder`` is also a list, each
-                encoder for a single scale of heatmaps
+            - ``'multilevel_heatmap'`` The encoded should be a list of
+                heatmaps and will be stored in
+                ``results['multilevel_heatmaps']``. Note that in this case,
+                ``self.encoder`` is also a list, each encoder for a single
+                level of heatmaps.
             - ``'keypoint_label'``: The encoded should be instance-level
                 labels and will be stored in ``results['keypoint_label']``
             - ``'keypoint_xy_label'``: The encoed should be instance-level
@@ -924,11 +925,11 @@ class GenerateTarget(BaseTransform):
         self.target_type = target_type
         self.use_dataset_keypoint_weights = use_dataset_keypoint_weights
 
-        if self.target_type == 'multiscale_heatmap':
+        if self.target_type == 'multilevel_heatmap':
             if not isinstance(self.encoder_cfg, list):
                 raise ValueError(
                     'The encoder should be a list if target type is '
-                    '"multiscale_heatmap"')
+                    '"multilevel_heatmap"')
             self.encoder = [
                 KEYPOINT_CODECS.build(cfg) for cfg in self.encoder_cfg
             ]
@@ -980,7 +981,7 @@ class GenerateTarget(BaseTransform):
             results['keypoint_labels'] = keypoint_labels
             results['keypoint_weights'] = keypoint_weights
 
-        elif self.target_type == 'multiscale_heatmap':
+        elif self.target_type == 'multilevel_heatmap':
             heatmaps = []
             keypoint_weights = []
 
@@ -990,7 +991,7 @@ class GenerateTarget(BaseTransform):
                 heatmaps.append(_heatmaps)
                 keypoint_weights.append(_keypoint_weights)
 
-            results['heatmaps'] = heatmaps
+            results['multilevel_heatmaps'] = heatmaps
             # keypoint_weights.shape: [N, K] -> [N, n, K]
             results['keypoint_weights'] = np.stack(keypoint_weights, axis=1)
 

--- a/mmpose/datasets/transforms/common_transforms.py
+++ b/mmpose/datasets/transforms/common_transforms.py
@@ -991,7 +991,7 @@ class GenerateTarget(BaseTransform):
                 heatmaps.append(_heatmaps)
                 keypoint_weights.append(_keypoint_weights)
 
-            results['multilevel_heatmaps'] = heatmaps
+            results['heatmaps'] = heatmaps
             # keypoint_weights.shape: [N, K] -> [N, n, K]
             results['keypoint_weights'] = np.stack(keypoint_weights, axis=1)
 

--- a/mmpose/datasets/transforms/common_transforms.py
+++ b/mmpose/datasets/transforms/common_transforms.py
@@ -899,10 +899,9 @@ class GenerateTarget(BaseTransform):
             - ``'heatmap'``: The encoded should be instance-irrelevant
                 heatmaps and will be stored in ``results['heatmaps']``
             - ``'multilevel_heatmap'`` The encoded should be a list of
-                heatmaps and will be stored in
-                ``results['multilevel_heatmaps']``. Note that in this case,
-                ``self.encoder`` is also a list, each encoder for a single
-                level of heatmaps.
+                heatmaps and will be stored in ``results['heatmaps']``.
+                Note that in this case, ``self.encoder`` should also be
+                a list, and each encoder encodes a single-level heatmaps.
             - ``'keypoint_label'``: The encoded should be instance-level
                 labels and will be stored in ``results['keypoint_label']``
             - ``'keypoint_xy_label'``: The encoed should be instance-level

--- a/mmpose/datasets/transforms/formatting.py
+++ b/mmpose/datasets/transforms/formatting.py
@@ -147,12 +147,19 @@ class PackPoseInputs(BaseTransform):
         for key, packed_key in self.field_mapping_table.items():
             if key in results:
                 if isinstance(results[key], list):
-                    data_type = MultilevelPixelData
+                    if gt_fields is None:
+                        gt_fields = MultilevelPixelData()
+                    else:
+                        assert isinstance(
+                            gt_fields, MultilevelPixelData
+                        ), 'Got mixed single-level and multi-level pixel data.'
                 else:
-                    data_type = PixelData
-
-                if gt_fields is None:
-                    gt_fields = data_type()
+                    if gt_fields is None:
+                        gt_fields = PixelData()
+                    else:
+                        assert isinstance(
+                            gt_fields, PixelData
+                        ), 'Got mixed single-level and multi-level pixel data.'
 
                 gt_fields.set_field(results[key], packed_key)
 

--- a/mmpose/datasets/transforms/formatting.py
+++ b/mmpose/datasets/transforms/formatting.py
@@ -93,8 +93,6 @@ class PackPoseInputs(BaseTransform):
         'heatmaps': 'heatmaps',
     }
 
-    multilevel_field_mapping_table = {'multilevel_heatmaps': 'heatmaps'}
-
     def __init__(self,
                  meta_keys=('id', 'img_id', 'img_path', 'ori_shape',
                             'img_shape', 'input_size', 'flip',

--- a/mmpose/datasets/transforms/formatting.py
+++ b/mmpose/datasets/transforms/formatting.py
@@ -145,18 +145,21 @@ class PackPoseInputs(BaseTransform):
         data_sample.gt_instance_labels = gt_instance_labels.to_tensor()
 
         # pack fields
-        gt_fields = PixelData()
+        gt_fields = None
         for key, packed_key in self.field_mapping_table.items():
             if key in results:
-                gt_fields.set_field(results[key], packed_key)
-        data_sample.gt_fields = gt_fields.to_tensor()
+                if isinstance(results[key], list):
+                    data_type = MultilevelPixelData
+                else:
+                    data_type = PixelData
 
-        # pack multilevel fields
-        multilevel_gt_fields = MultilevelPixelData()
-        for key, packed_key in self.multilevel_field_mapping_table.items():
-            if key in results:
-                multilevel_gt_fields.set_field(results[key], packed_key)
-        data_sample.multilevel_gt_fields = multilevel_gt_fields.to_tensor()
+                if gt_fields is None:
+                    gt_fields = data_type()
+
+                gt_fields.set_field(results[key], packed_key)
+
+        if gt_fields:
+            data_sample.gt_fields = gt_fields.to_tensor()
 
         img_meta = {k: results[k] for k in self.meta_keys if k in results}
         data_sample.set_metainfo(img_meta)

--- a/mmpose/datasets/transforms/formatting.py
+++ b/mmpose/datasets/transforms/formatting.py
@@ -8,7 +8,7 @@ from mmengine.structures import InstanceData, PixelData
 from mmengine.utils import is_seq_of
 
 from mmpose.registry import TRANSFORMS
-from mmpose.structures import PoseDataSample
+from mmpose.structures import MultilevelPixelData, PoseDataSample
 
 
 def image_to_tensor(img: Union[np.ndarray,
@@ -93,6 +93,8 @@ class PackPoseInputs(BaseTransform):
         'heatmaps': 'heatmaps',
     }
 
+    multilevel_field_mapping_table = {'multilevel_heatmaps': 'heatmaps'}
+
     def __init__(self,
                  meta_keys=('id', 'img_id', 'img_path', 'ori_shape',
                             'img_shape', 'input_size', 'flip',
@@ -148,6 +150,13 @@ class PackPoseInputs(BaseTransform):
             if key in results:
                 gt_fields.set_field(results[key], packed_key)
         data_sample.gt_fields = gt_fields.to_tensor()
+
+        # pack multilevel fields
+        multilevel_gt_fields = MultilevelPixelData()
+        for key, packed_key in self.multilevel_field_mapping_table.items():
+            if key in results:
+                multilevel_gt_fields.set_field(results[key], packed_key)
+        data_sample.multilevel_gt_fields = multilevel_gt_fields.to_tensor()
 
         img_meta = {k: results[k] for k in self.meta_keys if k in results}
         data_sample.set_metainfo(img_meta)

--- a/mmpose/models/heads/heatmap_heads/mspn_head.py
+++ b/mmpose/models/heads/heatmap_heads/mspn_head.py
@@ -315,7 +315,7 @@ class MSPNHead(BaseHead):
                 features (or multiple MSMU features for TTA)
             batch_data_samples (List[:obj:`PoseDataSample`]): The Data
                 Samples. It usually includes information such as
-                `gt_instances`
+                `gt_instance_labels`.
             test_cfg (Config, optional): The testing/inference config
 
         Returns:
@@ -383,7 +383,7 @@ class MSPNHead(BaseHead):
                 stages and units
             batch_data_samples (List[:obj:`PoseDataSample`]): The Data
                 Samples. It usually includes information such as
-                `gt_instance_labels`and `gt_fields`.
+                `gt_instance_labels` and `gt_fields`.
             train_cfg (Config, optional): The training config
 
         Returns:

--- a/mmpose/structures/pose_data_sample.py
+++ b/mmpose/structures/pose_data_sample.py
@@ -1,6 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from mmengine.structures import BaseDataElement, InstanceData, PixelData
 
+from .multilevel_pixel_data import MultilevelPixelData
+
 
 class PoseDataSample(BaseDataElement):
     """The base data structure of MMPose that is used as the interface between
@@ -86,6 +88,19 @@ class PoseDataSample(BaseDataElement):
     @gt_fields.deleter
     def gt_fields(self):
         del self._gt_fields
+
+    @property
+    def multilevel_gt_fields(self) -> MultilevelPixelData:
+        return self._multilevel_gt_fields
+
+    @multilevel_gt_fields.setter
+    def multilevel_gt_fields(self, value: MultilevelPixelData):
+        self.set_field(
+            value, '_multilevel_gt_fields', dtype=MultilevelPixelData)
+
+    @multilevel_gt_fields.deleter
+    def multilevel_gt_fields(self):
+        del self._multilevel_gt_fields
 
     @property
     def pred_fields(self) -> PixelData:

--- a/mmpose/structures/pose_data_sample.py
+++ b/mmpose/structures/pose_data_sample.py
@@ -1,7 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import Union
+
 from mmengine.structures import BaseDataElement, InstanceData, PixelData
 
-from .multilevel_pixel_data import MultilevelPixelData
+from mmpose.structures import MultilevelPixelData
 
 
 class PoseDataSample(BaseDataElement):
@@ -78,29 +80,16 @@ class PoseDataSample(BaseDataElement):
         del self._pred_instances
 
     @property
-    def gt_fields(self) -> PixelData:
+    def gt_fields(self) -> Union[PixelData, MultilevelPixelData]:
         return self._gt_fields
 
     @gt_fields.setter
-    def gt_fields(self, value: PixelData):
-        self.set_field(value, '_gt_fields', dtype=PixelData)
+    def gt_fields(self, value: Union[PixelData, MultilevelPixelData]):
+        self.set_field(value, '_gt_fields', dtype=type(value))
 
     @gt_fields.deleter
     def gt_fields(self):
         del self._gt_fields
-
-    @property
-    def multilevel_gt_fields(self) -> MultilevelPixelData:
-        return self._multilevel_gt_fields
-
-    @multilevel_gt_fields.setter
-    def multilevel_gt_fields(self, value: MultilevelPixelData):
-        self.set_field(
-            value, '_multilevel_gt_fields', dtype=MultilevelPixelData)
-
-    @multilevel_gt_fields.deleter
-    def multilevel_gt_fields(self):
-        del self._multilevel_gt_fields
 
     @property
     def pred_fields(self) -> PixelData:

--- a/mmpose/testing/_utils.py
+++ b/mmpose/testing/_utils.py
@@ -160,7 +160,6 @@ def get_packed_inputs(batch_size=2,
                 W, H = heatmap_size
                 heatmaps = rng.rand(num_keypoints, H, W)
                 gt_fields.heatmaps = torch.FloatTensor(heatmaps)
-                data_sample.gt_fields = gt_fields
             else:
                 # generate multilevel heatmaps
                 heatmaps = []
@@ -169,9 +168,9 @@ def get_packed_inputs(batch_size=2,
                     heatmaps_ = rng.rand(num_keypoints, H, W)
                     heatmaps.append(torch.FloatTensor(heatmaps_))
                 # [num_levels*K, H, W]
-                multilevel_gt_fields = MultilevelPixelData()
-                multilevel_gt_fields.heatmaps = heatmaps
-                data_sample.multilevel_gt_fields = multilevel_gt_fields
+                gt_fields = MultilevelPixelData()
+                gt_fields.heatmaps = heatmaps
+            data_sample.gt_fields = gt_fields
 
         data_sample.gt_instances = gt_instances
         data_sample.gt_instance_labels = gt_instance_labels

--- a/mmpose/testing/_utils.py
+++ b/mmpose/testing/_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 from mmengine.structures import InstanceData, PixelData
 
-from mmpose.structures import PoseDataSample
+from mmpose.structures import MultilevelPixelData, PoseDataSample
 from mmpose.structures.bbox import bbox_xyxy2cs
 
 
@@ -153,27 +153,28 @@ def get_packed_inputs(batch_size=2,
                 _rand_simcc_label(rng, num_instances, num_keypoints, len_y))
 
         # gt_fields
-        gt_fields = PixelData()
         if with_heatmap:
             if num_levels == 1:
-                # generate single-scale heatmaps
+                gt_fields = PixelData()
+                # generate single-level heatmaps
                 W, H = heatmap_size
                 heatmaps = rng.rand(num_keypoints, H, W)
                 gt_fields.heatmaps = torch.FloatTensor(heatmaps)
+                data_sample.gt_fields = gt_fields
             else:
-                # generate multi-scale heatmaps
+                # generate multilevel heatmaps
                 heatmaps = []
                 for _ in range(num_levels):
                     W, H = heatmap_size
                     heatmaps_ = rng.rand(num_keypoints, H, W)
-                    heatmaps.append(heatmaps_)
+                    heatmaps.append(torch.FloatTensor(heatmaps_))
                 # [num_levels*K, H, W]
-                heatmaps = np.concatenate(heatmaps)
-                gt_fields.heatmaps = torch.FloatTensor(heatmaps)
+                multilevel_gt_fields = MultilevelPixelData()
+                multilevel_gt_fields.heatmaps = heatmaps
+                data_sample.multilevel_gt_fields = multilevel_gt_fields
 
         data_sample.gt_instances = gt_instances
         data_sample.gt_instance_labels = gt_instance_labels
-        data_sample.gt_fields = gt_fields
 
         inputs['data_sample'] = data_sample
         packed_inputs.append(inputs)

--- a/tests/test_datasets/test_transforms/test_common_transforms.py
+++ b/tests/test_datasets/test_transforms/test_common_transforms.py
@@ -500,7 +500,7 @@ class TestGenerateTarget(TestCase):
             np.allclose(results['keypoint_weights'],
                         self.data_info['dataset_keypoint_weights'][None]))
 
-    def test_generate_multiscale_heatmap(self):
+    def test_generate_multilevel_heatmap(self):
         encoder_0 = dict(
             type='MSRAHeatmap',
             input_size=(192, 256),
@@ -508,18 +508,18 @@ class TestGenerateTarget(TestCase):
             sigma=2.0)
         encoder_1 = dict(encoder_0, heatmap_size=(24, 32))
 
-        # generate multi-scale heatmap
+        # generate multilevel heatmap
         pipeline = Compose([
             TopdownAffine(input_size=(192, 256)),
             GenerateTarget(
-                target_type='multiscale_heatmap',
+                target_type='multilevel_heatmap',
                 encoder=[encoder_0, encoder_1])
         ])
         results = pipeline(deepcopy(self.data_info))
 
-        self.assertTrue(is_list_of(results['heatmaps'], np.ndarray))
-        self.assertEqual(results['heatmaps'][0].shape, (17, 64, 48))
-        self.assertEqual(results['heatmaps'][1].shape, (17, 32, 24))
+        self.assertTrue(is_list_of(results['multilevel_heatmaps'], np.ndarray))
+        self.assertEqual(results['multilevel_heatmaps'][0].shape, (17, 64, 48))
+        self.assertEqual(results['multilevel_heatmaps'][1].shape, (17, 32, 24))
         self.assertEqual(results['keypoint_weights'].shape, (1, 2, 17))
 
     def test_generate_keypoint_label(self):

--- a/tests/test_datasets/test_transforms/test_common_transforms.py
+++ b/tests/test_datasets/test_transforms/test_common_transforms.py
@@ -517,9 +517,9 @@ class TestGenerateTarget(TestCase):
         ])
         results = pipeline(deepcopy(self.data_info))
 
-        self.assertTrue(is_list_of(results['multilevel_heatmaps'], np.ndarray))
-        self.assertEqual(results['multilevel_heatmaps'][0].shape, (17, 64, 48))
-        self.assertEqual(results['multilevel_heatmaps'][1].shape, (17, 32, 24))
+        self.assertTrue(is_list_of(results['heatmaps'], np.ndarray))
+        self.assertEqual(results['heatmaps'][0].shape, (17, 64, 48))
+        self.assertEqual(results['heatmaps'][1].shape, (17, 32, 24))
         self.assertEqual(results['keypoint_weights'].shape, (1, 2, 17))
 
     def test_generate_keypoint_label(self):

--- a/tests/test_models/test_heads/test_heatmap_heads/test_mspn_head.py
+++ b/tests/test_models/test_heads/test_heatmap_heads/test_mspn_head.py
@@ -58,6 +58,7 @@ class TestMSPNHead(TestCase):
             out_channels=17,
             use_prm=False,
             norm_cfg=dict(type='BN'),
+            level_indices=[0, 1, 2, 3],
             decoder=dict(
                 type='MegviiHeatmap',
                 input_size=(192, 256),
@@ -75,6 +76,7 @@ class TestMSPNHead(TestCase):
             use_prm=False,
             norm_cfg=dict(type='BN'),
             loss=dict(type='KeypointMSELoss', use_target_weight=True),
+            level_indices=[0, 1, 2, 3],
         )
         self.assertTrue(isinstance(head.loss_module, nn.Module))
 
@@ -88,6 +90,7 @@ class TestMSPNHead(TestCase):
             use_prm=False,
             norm_cfg=dict(type='BN'),
             loss=[dict(type='KeypointMSELoss', use_target_weight=True)] * 8,
+            level_indices=[0, 1, 2, 3, 1, 2, 3, 4],
         )
         self.assertTrue(isinstance(head.loss_module, nn.ModuleList))
         self.assertTrue(len(head.loss_module), 8)
@@ -101,7 +104,8 @@ class TestMSPNHead(TestCase):
             num_units=4,
             out_shape=(64, 48),
             unit_channels=unit_channels,
-            out_channels=17)
+            out_channels=17,
+            level_indices=[0, 1, 2, 3])
 
         with self.assertRaisesRegex(
                 AssertionError,
@@ -176,7 +180,8 @@ class TestMSPNHead(TestCase):
                     type='KeypointOHKMMSELoss',
                     use_target_weight=True,
                     loss_weight=0.1)
-            ]) * 4)
+            ]) * 4,
+            level_indices=[0, 1, 2, 3] * 3 + [1, 2, 3, 4])
 
         feats = self._get_feats(
             num_stages=4,
@@ -207,6 +212,7 @@ class TestMSPNHead(TestCase):
             out_shape=(64, 48),
             unit_channels=unit_channels,
             out_channels=17,
+            level_indices=[0, 1, 2, 3],
             decoder=decoder_cfg)
 
         with self.assertRaisesRegex(
@@ -272,6 +278,7 @@ class TestMSPNHead(TestCase):
             out_shape=(64, 48),
             unit_channels=unit_channels,
             out_channels=17,
+            level_indices=[0, 1, 2, 3] * 3 + [1, 2, 3, 4],
             decoder=decoder_cfg)
         feats = self._get_feats(
             num_stages=4,
@@ -307,6 +314,7 @@ class TestMSPNHead(TestCase):
             out_shape=(64, 48),
             unit_channels=unit_channels,
             out_channels=17,
+            level_indices=[0, 1, 2, 3],
             decoder=decoder_cfg)
 
         feats = self._get_feats(
@@ -331,6 +339,14 @@ class TestMSPNHead(TestCase):
 
     def test_errors(self):
         # Invalid arguments
+        with self.assertRaisesRegex(ValueError, 'The length of level_indices'):
+            _ = MSPNHead(
+                num_stages=2,
+                num_units=4,
+                out_shape=(64, 48),
+                unit_channels=256,
+                out_channels=17,
+                level_indices=[0])
         with self.assertRaisesRegex(ValueError, 'The length of loss_module'):
             _ = MSPNHead(
                 num_stages=2,
@@ -338,5 +354,6 @@ class TestMSPNHead(TestCase):
                 out_shape=(64, 48),
                 unit_channels=256,
                 out_channels=17,
+                level_indices=[0, 1, 2, 3, 1, 2, 3, 4],
                 loss=[dict(type='KeypointMSELoss', use_target_weight=True)] *
                 3)

--- a/tests/test_structures/test_multilevel_pixel_data.py
+++ b/tests/test_structures/test_multilevel_pixel_data.py
@@ -50,17 +50,11 @@ class TestMultilevelPixelData(TestCase):
         self.assertTrue(isinstance(data[0].heatmaps, np.ndarray))
         self.assertTrue(data[0].masks.device.type == 'cpu')
 
-        # test `cuda`
-        data = self.get_multi_level_pixel_data()
-        self.assertTrue(data[0].masks.device.type == 'cpu')
-        data = data.cuda()
-        self.assertTrue(data[0].masks.device.type == 'cuda')
-
         # test `to`
         data = self.get_multi_level_pixel_data()
         self.assertTrue(data[0].masks.device.type == 'cpu')
-        data = data.to('cuda')
-        self.assertTrue(data[0].masks.device.type == 'cuda')
+        data = data.to('cpu')
+        self.assertTrue(data[0].masks.device.type == 'cpu')
 
         # test `numpy`
         data = self.get_multi_level_pixel_data()

--- a/tests/test_structures/test_multilevel_pixel_data.py
+++ b/tests/test_structures/test_multilevel_pixel_data.py
@@ -1,0 +1,78 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from unittest import TestCase
+
+import numpy as np
+import torch
+from mmengine.structures import PixelData
+
+from mmpose.structures import MultilevelPixelData
+
+
+class TestMultilevelPixelData(TestCase):
+
+    def get_multi_level_pixel_data(self):
+        metainfo = dict(num_keypoints=17)
+        sizes = [(64, 48), (32, 24), (16, 8)]
+        heatmaps = [np.random.rand(17, h, w) for h, w in sizes]
+        masks = [torch.rand(1, h, w) for h, w in sizes]
+        data = MultilevelPixelData(
+            metainfo=metainfo, heatmaps=heatmaps, masks=masks)
+
+        return data
+
+    def test_init(self):
+
+        data = self.get_multi_level_pixel_data()
+        self.assertIn('num_keypoints', data)
+        self.assertTrue(data.nlevel == 3)
+        self.assertTrue(data.shape == ((64, 48), (32, 24), (16, 8)))
+        self.assertTrue(isinstance(data[0], PixelData))
+
+    def test_setter(self):
+        # test `set_field`
+        data = self.get_multi_level_pixel_data()
+        sizes = [(64, 48), (32, 24), (16, 8)]
+        offset_maps = [torch.rand(2, h, w) for h, w in sizes]
+        data.offset_maps = offset_maps
+
+        # test `to_tensor`
+        data = self.get_multi_level_pixel_data()
+        self.assertTrue(isinstance(data[0].heatmaps, np.ndarray))
+        data = data.to_tensor()
+        self.assertTrue(isinstance(data[0].heatmaps, torch.Tensor))
+
+        # test `cpu`
+        data = self.get_multi_level_pixel_data()
+        self.assertTrue(isinstance(data[0].heatmaps, np.ndarray))
+        self.assertTrue(isinstance(data[0].masks, torch.Tensor))
+        self.assertTrue(data[0].masks.device.type == 'cpu')
+        data = data.cpu()
+        self.assertTrue(isinstance(data[0].heatmaps, np.ndarray))
+        self.assertTrue(data[0].masks.device.type == 'cpu')
+
+        # test `cuda`
+        data = self.get_multi_level_pixel_data()
+        self.assertTrue(data[0].masks.device.type == 'cpu')
+        data = data.cuda()
+        self.assertTrue(data[0].masks.device.type == 'cuda')
+
+        # test `to`
+        data = self.get_multi_level_pixel_data()
+        self.assertTrue(data[0].masks.device.type == 'cpu')
+        data = data.to('cuda')
+        self.assertTrue(data[0].masks.device.type == 'cuda')
+
+        # test `numpy`
+        data = self.get_multi_level_pixel_data()
+        self.assertTrue(isinstance(data[0].masks, torch.Tensor))
+        data = data.numpy()
+        self.assertTrue(isinstance(data[0].masks, np.ndarray))
+
+    def test_deleter(self):
+
+        data = self.get_multi_level_pixel_data()
+
+        for key in ['heatmaps', 'masks']:
+            self.assertIn(key, data)
+            exec(f'del data.{key}')
+            self.assertNotIn(key, data)

--- a/tests/test_structures/test_multilevel_pixel_data.py
+++ b/tests/test_structures/test_multilevel_pixel_data.py
@@ -12,7 +12,7 @@ class TestMultilevelPixelData(TestCase):
 
     def get_multi_level_pixel_data(self):
         metainfo = dict(num_keypoints=17)
-        sizes = [(64, 48), (32, 24), (16, 8)]
+        sizes = [(64, 48), (32, 24), (16, 12)]
         heatmaps = [np.random.rand(17, h, w) for h, w in sizes]
         masks = [torch.rand(1, h, w) for h, w in sizes]
         data = MultilevelPixelData(
@@ -25,7 +25,7 @@ class TestMultilevelPixelData(TestCase):
         data = self.get_multi_level_pixel_data()
         self.assertIn('num_keypoints', data)
         self.assertTrue(data.nlevel == 3)
-        self.assertTrue(data.shape == ((64, 48), (32, 24), (16, 8)))
+        self.assertTrue(data.shape == ((64, 48), (32, 24), (16, 12)))
         self.assertTrue(isinstance(data[0], PixelData))
 
     def test_setter(self):

--- a/tests/test_structures/test_pose_data_sample.py
+++ b/tests/test_structures/test_pose_data_sample.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 from mmengine.structures import InstanceData, PixelData
 
-from mmpose.structures import PoseDataSample
+from mmpose.structures import MultilevelPixelData, PoseDataSample
 
 
 class TestPoseDataSample(TestCase):
@@ -32,6 +32,14 @@ class TestPoseDataSample(TestCase):
         gt_fields = PixelData()
         gt_fields.heatmaps = torch.rand(17, 64, 48)
 
+        # multilevel_gt_fields
+        metainfo = dict(num_keypoints=17)
+        sizes = [(64, 48), (128, 96), (256, 192)]
+        heatmaps = [np.random.rand(17, h, w) for h, w in sizes]
+        masks = [torch.rand(1, h, w) for h, w in sizes]
+        multilevel_gt_fields = MultilevelPixelData(
+            metainfo=metainfo, heatmaps=heatmaps, masks=masks)
+
         # pred_fields
         pred_fields = PixelData()
         pred_fields.heatmaps = torch.rand(17, 64, 48)
@@ -40,6 +48,7 @@ class TestPoseDataSample(TestCase):
             gt_instances=gt_instances,
             pred_instances=pred_instances,
             gt_fields=gt_fields,
+            multilevel_gt_fields=multilevel_gt_fields,
             pred_fields=pred_fields,
             metainfo=pose_meta)
 
@@ -72,6 +81,9 @@ class TestPoseDataSample(TestCase):
         # test gt_fields
         data_sample.gt_fields = PixelData()
 
+        # test multilevel_gt_fields
+        data_sample.multilevel_gt_fields = MultilevelPixelData()
+
         # test pred_instances as pytorch tensor
         pred_instances_data = dict(
             keypoints=torch.rand(1, 17, 2), scores=torch.rand(1, 17, 1))
@@ -103,7 +115,8 @@ class TestPoseDataSample(TestCase):
         data_sample = self.get_pose_data_sample()
 
         for key in [
-                'gt_instances', 'pred_instances', 'gt_fields', 'pred_fields'
+                'gt_instances', 'pred_instances', 'gt_fields', 'pred_fields',
+                'multilevel_gt_fields'
         ]:
             self.assertIn(key, data_sample)
             exec(f'del data_sample.{key}')


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->
1. Unify the `multiscale`, `multi-scale`, `multi-level` to `multilevel`; add `multilevel_gt_fields` in `PoseDataSample`;
2. Modify `MSPNHead` to fit `MultilevelPixelData`;
3. Fix some bugs in `MultilevelPixelData` add unittests for `MultilevelPixelData`;
4. Modify the MSPNd and RSN configs according to the above modificatios.

All unitetsts passed locally.
The test accuracy for `configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_2xmspn50_8xb32-210e_coco-256x192.py` is verified, will also verify other modified configs.

## Modification

<!-- Please briefly describe what modification is made in this PR. -->

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
