### PR TITLE
[Fix] Fix a visualization bug and refine dataset browser

### DIFF
--- a/mmpose/apis/webcam/utils/buffer.py
+++ b/mmpose/apis/webcam/utils/buffer.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from __future__ import annotations
 from functools import wraps
 from queue import Queue
 from typing import Any, Dict, List, Optional
@@ -174,7 +173,7 @@ class BufferManager():
         """
         return self._buffers[name].full()
 
-    def get_sub_manager(self, buffer_names: List[str]) -> BufferManager:
+    def get_sub_manager(self, buffer_names: List[str]) -> 'BufferManager':
         """Return a :class:`BufferManager` instance that covers a subset of the
         buffers in the parent. The is usually used to partially share the
         buffers of the executor to the node.

--- a/mmpose/engine/hooks/visualization_hook.py
+++ b/mmpose/engine/hooks/visualization_hook.py
@@ -10,7 +10,7 @@ from mmengine.runner import Runner
 from mmengine.visualization import Visualizer
 
 from mmpose.registry import HOOKS
-from mmpose.structures import PoseDataSample
+from mmpose.structures import PoseDataSample, merge_data_samples
 
 
 @HOOKS.register_module()
@@ -89,6 +89,8 @@ class PoseVisualizationHook(Hook):
         if self.file_client is None:
             self.file_client = mmengine.FileClient(**self.file_client_args)
 
+        self._visualizer.set_dataset_meta(runner.val_evaluator.dataset_meta)
+
         # There is no guarantee that the same batch of images
         # is visualized for each evaluation.
         total_curr_iter = runner.iter + batch_idx
@@ -133,12 +135,15 @@ class PoseVisualizationHook(Hook):
         if self.file_client is None:
             self.file_client = mmengine.FileClient(**self.file_client_args)
 
+        self._visualizer.set_dataset_meta(runner.test_evaluator.dataset_meta)
+
         for data_sample in outputs:
             self._test_index += 1
 
             img_path = data_sample.get('img_path')
             img_bytes = self.file_client.get(img_path)
             img = mmcv.imfrombytes(img_bytes, channel_order='rgb')
+            data_sample = merge_data_samples([data_sample])
 
             out_file = None
             if self.out_dir is not None:

--- a/mmpose/visualization/local_visualizer.py
+++ b/mmpose/visualization/local_visualizer.py
@@ -136,12 +136,18 @@ class PoseLocalVisualizer(Visualizer):
         Args:
             dataset_meta (dict): meta information of dataset.
         """
-        self.dataset_meta = dataset_meta
-        self.bbox_color = dataset_meta.get('bbox_color', self.bbox_color)
-        self.kpt_color = dataset_meta.get('keypoint_colors', self.kpt_color)
-        self.link_color = dataset_meta.get('skeleton_link_colors',
-                                           self.link_color)
-        self.skeleton = self.dataset_meta.get('skeleton_links', None)
+        if isinstance(dataset_meta, dict):
+            self.dataset_meta = dataset_meta.copy()
+            self.bbox_color = dataset_meta.get('bbox_color', self.bbox_color)
+            self.kpt_color = dataset_meta.get('keypoint_colors',
+                                              self.kpt_color)
+            self.link_color = dataset_meta.get('skeleton_link_colors',
+                                               self.link_color)
+            self.skeleton = dataset_meta.get('skeleton_links', self.skeleton)
+        # sometimes self.dataset_meta is manually set, which might be None.
+        # it should be converted to a dict at these times
+        if self.dataset_meta is None:
+            self.dataset_meta = {}
 
     def _draw_instances_bbox(self, image: np.ndarray,
                              instances: InstanceData) -> np.ndarray:

--- a/mmpose/visualization/local_visualizer.py
+++ b/mmpose/visualization/local_visualizer.py
@@ -464,11 +464,16 @@ class PoseLocalVisualizer(Visualizer):
         else:
             drawn_img = pred_img_data
 
-        # display & save visualized results
+        # It is convenient for users to obtain the drawn image.
+        # For example, the user wants to obtain the drawn image and
+        # save it as a video during video inference.
+        self.set_image(drawn_img)
+
         if show:
             self.show(drawn_img, win_name=name, wait_time=wait_time)
-        else:
-            self.add_image(name, drawn_img, step)
 
         if out_file is not None:
             mmcv.imwrite(drawn_img[..., ::-1], out_file)
+        else:
+            # save drawn_img to backends
+            self.add_image(name, drawn_img, step)

--- a/tests/test_engine/test_hooks/test_visualization_hook.py
+++ b/tests/test_engine/test_hooks/test_visualization_hook.py
@@ -47,7 +47,8 @@ class TestVisualizationHook(TestCase):
     def test_after_val_iter(self):
         runner = MagicMock()
         runner.iter = 1
-        hook = PoseVisualizationHook()
+        runner.val_evaluator.dataset_meta = dict()
+        hook = PoseVisualizationHook(interval=1)
         hook.after_val_iter(runner, 1, self.data_batch, self.outputs)
 
     def test_after_test_iter(self):

--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -80,7 +80,8 @@ def main():
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    file_client = mmengine.FileClient(**cfg.file_client_args)
+    file_client_args = cfg.get('file_client_args', dict(backend='disk'))
+    file_client = mmengine.FileClient(**file_client_args)
 
     # register all modules in mmpose into the registries
     register_all_modules()

--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -80,6 +80,7 @@ def main():
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
+    file_client = mmengine.FileClient(**cfg.file_client_args)
 
     # register all modules in mmpose into the registries
     register_all_modules()
@@ -90,10 +91,6 @@ def main():
         # pack transformed keypoints for visualization
         cfg[f'{args.phase}_dataloader'].dataset.pipeline[
             -1].pack_transformed = True
-
-    # unset `bbox_file` to make dataset read in reasonable keypoints
-    if 'bbox_file' in cfg[f'{args.phase}_dataloader'].dataset:
-        cfg[f'{args.phase}_dataloader'].dataset.bbox_file = None
 
     dataset = build_from_cfg(cfg[f'{args.phase}_dataloader'].dataset, DATASETS)
 
@@ -123,8 +120,9 @@ def main():
                 progress_bar.update()
                 continue
             else:
-                img = mmcv.imread(item['img_path'])
                 img_path = item['img_path']
+                img_bytes = file_client.get(img_path)
+                img = mmcv.imfrombytes(img_bytes, channel_order='bgr')
 
                 # forge pseudo data_sample
                 gt_instances = InstanceData()
@@ -146,7 +144,7 @@ def main():
             osp.basename(img_path)) if args.output_dir is not None else None
         out_file = generate_dup_file_name(out_file)
 
-        img = img[..., [2, 1, 0]]  # bgr to rgb
+        img = mmcv.bgr2rgb(img)
 
         visualizer.add_datasample(
             osp.basename(img_path),


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

## Modification

<!-- Please briefly describe what modification is made in this PR. -->
1. fix a bug about visualizer's dataset_meta.
      When testing with multiple GPUs, there are multiple processes but only one `visualizer`. The `visualizer.dataset_meta` is manually set to `None` occasionally in some processes in test_loop. This may lead to `AttributeError` in other processes when getting items from `visualizer.dataset_meta`.
3. refine dataset browser
    - use `file_client` to read image instead of `mmcv.imread`
    - keep `bbox_file` in dataset configs. Thus the visualization results match the images model receives indeed.


## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
