### PR TITLE
 [Feature] Support evaluating CocoMetric without ann_file.

### DIFF
--- a/configs/animal_2d_keypoint/topdown_heatmap/ap10k/td-hm_hrnet-w32_8xb64-210e_ap10k-256x256.py
+++ b/configs/animal_2d_keypoint/topdown_heatmap/ap10k/td-hm_hrnet-w32_8xb64-210e_ap10k-256x256.py
@@ -27,7 +27,7 @@ param_scheduler = [
 auto_scale_lr = dict(base_batch_size=512)
 
 # hooks
-default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
+default_hooks = dict(checkpoint=dict(save_best='ap10k/AP', rule='greater'))
 
 # codec settings
 codec = dict(

--- a/configs/animal_2d_keypoint/topdown_heatmap/ap10k/td-hm_hrnet-w48_8xb64-210e_ap10k-256x256.py
+++ b/configs/animal_2d_keypoint/topdown_heatmap/ap10k/td-hm_hrnet-w48_8xb64-210e_ap10k-256x256.py
@@ -27,7 +27,7 @@ param_scheduler = [
 auto_scale_lr = dict(base_batch_size=512)
 
 # hooks
-default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
+default_hooks = dict(checkpoint=dict(save_best='ap10k/AP', rule='greater'))
 
 # codec settings
 codec = dict(

--- a/configs/animal_2d_keypoint/topdown_heatmap/ap10k/td-hm_res101_8xb64-210e_ap10k-256x256.py
+++ b/configs/animal_2d_keypoint/topdown_heatmap/ap10k/td-hm_res101_8xb64-210e_ap10k-256x256.py
@@ -27,7 +27,7 @@ param_scheduler = [
 auto_scale_lr = dict(base_batch_size=512)
 
 # hooks
-default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
+default_hooks = dict(checkpoint=dict(save_best='ap10k/AP', rule='greater'))
 
 # codec settings
 codec = dict(

--- a/configs/animal_2d_keypoint/topdown_heatmap/ap10k/td-hm_res50_8xb64-210e_ap10k-256x256.py
+++ b/configs/animal_2d_keypoint/topdown_heatmap/ap10k/td-hm_res50_8xb64-210e_ap10k-256x256.py
@@ -27,7 +27,7 @@ param_scheduler = [
 auto_scale_lr = dict(base_batch_size=512)
 
 # hooks
-default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
+default_hooks = dict(checkpoint=dict(save_best='ap10k/AP', rule='greater'))
 
 # codec settings
 codec = dict(

--- a/mmpose/datasets/datasets/base/base_coco_style_dataset.py
+++ b/mmpose/datasets/datasets/base/base_coco_style_dataset.py
@@ -269,6 +269,9 @@ class BaseCocoStyleDataset(BaseDataset):
             'raw_ann_info': copy.deepcopy(ann),
         }
 
+        if 'crowdIndex' in img:
+            data_info['crowdIndex'] = img['crowdIndex']
+
         return data_info
 
     @staticmethod

--- a/mmpose/datasets/datasets/base/base_coco_style_dataset.py
+++ b/mmpose/datasets/datasets/base/base_coco_style_dataset.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import copy
 import os.path as osp
 from copy import deepcopy
 from itertools import filterfalse, groupby
@@ -184,6 +185,10 @@ class BaseCocoStyleDataset(BaseDataset):
         check_file_exist(self.ann_file)
 
         coco = COCO(self.ann_file)
+        # set the metainfo about categories, which is a list of dict
+        # and each dict contains the 'id', 'name', etc. about this category
+        self._metainfo['CLASSES'] = coco.loadCats(coco.getCatIds())
+
         data_list = []
 
         for img_id in coco.getImgIds():
@@ -259,6 +264,10 @@ class BaseCocoStyleDataset(BaseDataset):
             'iscrowd': ann.get('iscrowd', 0),
             'segmentation': ann.get('segmentation', None),
             'id': ann['id'],
+            # store the raw annotation of the instance
+            # it is useful for evaluation without providing ann_file
+            'raw_ann_info': copy.deepcopy(ann),
+            'raw_img_info': copy.deepcopy(img),
         }
 
         return data_info
@@ -347,6 +356,9 @@ class BaseCocoStyleDataset(BaseDataset):
 
         # load coco annotations to build image id-to-name index
         coco = COCO(self.ann_file)
+        # set the metainfo about categories, which is a list of dict
+        # and each dict contains the 'id', 'name', etc. about this category
+        self._metainfo['CLASSES'] = coco.loadCats(coco.getCatIds())
 
         num_keypoints = self.metainfo['num_keypoints']
         data_list = []

--- a/mmpose/datasets/datasets/base/base_coco_style_dataset.py
+++ b/mmpose/datasets/datasets/base/base_coco_style_dataset.py
@@ -267,7 +267,6 @@ class BaseCocoStyleDataset(BaseDataset):
             # store the raw annotation of the instance
             # it is useful for evaluation without providing ann_file
             'raw_ann_info': copy.deepcopy(ann),
-            'raw_img_info': copy.deepcopy(img),
         }
 
         return data_info

--- a/mmpose/datasets/transforms/formatting.py
+++ b/mmpose/datasets/transforms/formatting.py
@@ -63,6 +63,8 @@ class PackPoseInputs(BaseTransform):
 
         - ``flip_indices``: the indices of each keypoint's symmetric keypoint
 
+        - ``raw_ann_info``: raw annotation of the instance(s)
+
     Args:
         meta_keys (Sequence[str], optional): Meta keys which will be stored in
             :obj: `PoseDataSample` as meta info. Defaults to ``('id',
@@ -96,7 +98,7 @@ class PackPoseInputs(BaseTransform):
     def __init__(self,
                  meta_keys=('id', 'img_id', 'img_path', 'ori_shape',
                             'img_shape', 'input_size', 'flip',
-                            'flip_direction', 'flip_indices'),
+                            'flip_direction', 'flip_indices', 'raw_ann_info'),
                  pack_transformed=False):
         self.meta_keys = meta_keys
         self.pack_transformed = pack_transformed

--- a/mmpose/datasets/transforms/formatting.py
+++ b/mmpose/datasets/transforms/formatting.py
@@ -96,8 +96,8 @@ class PackPoseInputs(BaseTransform):
     }
 
     def __init__(self,
-                 meta_keys=('id', 'img_id', 'img_path', 'ori_shape',
-                            'img_shape', 'input_size', 'flip',
+                 meta_keys=('id', 'img_id', 'img_path', 'crowdIndex',
+                            'ori_shape', 'img_shape', 'input_size', 'flip',
                             'flip_direction', 'flip_indices', 'raw_ann_info'),
                  pack_transformed=False):
         self.meta_keys = meta_keys

--- a/mmpose/datasets/transforms/formatting.py
+++ b/mmpose/datasets/transforms/formatting.py
@@ -49,7 +49,7 @@ class PackPoseInputs(BaseTransform):
 
         - ``img_path``: path to the image file
 
-        - ``crowdIndex`` (optional): measure the crowding level of an image,
+        - ``crowd_index`` (optional): measure the crowding level of an image,
             defined in CrowdPose dataset
 
         - ``ori_shape``: original shape of the image as a tuple (h, w, c)
@@ -71,7 +71,7 @@ class PackPoseInputs(BaseTransform):
     Args:
         meta_keys (Sequence[str], optional): Meta keys which will be stored in
             :obj: `PoseDataSample` as meta info. Defaults to ``('id',
-            'img_id', 'img_path', 'crowdIndex, 'ori_shape', 'img_shape',
+            'img_id', 'img_path', 'crowd_index, 'ori_shape', 'img_shape',
             'input_size', 'flip', 'flip_direction', 'flip_indices',
             'raw_ann_info')``
     """
@@ -100,7 +100,7 @@ class PackPoseInputs(BaseTransform):
     }
 
     def __init__(self,
-                 meta_keys=('id', 'img_id', 'img_path', 'crowdIndex',
+                 meta_keys=('id', 'img_id', 'img_path', 'crowd_index',
                             'ori_shape', 'img_shape', 'input_size', 'flip',
                             'flip_direction', 'flip_indices', 'raw_ann_info'),
                  pack_transformed=False):

--- a/mmpose/datasets/transforms/formatting.py
+++ b/mmpose/datasets/transforms/formatting.py
@@ -49,6 +49,9 @@ class PackPoseInputs(BaseTransform):
 
         - ``img_path``: path to the image file
 
+        - ``crowdIndex`` (optional): measure the crowding level of an image,
+            defined in CrowdPose dataset
+
         - ``ori_shape``: original shape of the image as a tuple (h, w, c)
 
         - ``img_shape``: shape of the image input to the network as a tuple \
@@ -63,13 +66,14 @@ class PackPoseInputs(BaseTransform):
 
         - ``flip_indices``: the indices of each keypoint's symmetric keypoint
 
-        - ``raw_ann_info``: raw annotation of the instance(s)
+        - ``raw_ann_info`` (optional): raw annotation of the instance(s)
 
     Args:
         meta_keys (Sequence[str], optional): Meta keys which will be stored in
             :obj: `PoseDataSample` as meta info. Defaults to ``('id',
-            'img_id', 'img_path', 'ori_shape', 'img_shape', 'input_size',
-            'flip', 'flip_direction', 'flip_indices', 'raw_ann_info')``
+            'img_id', 'img_path', 'crowdIndex, 'ori_shape', 'img_shape',
+            'input_size', 'flip', 'flip_direction', 'flip_indices',
+            'raw_ann_info')``
     """
 
     # items in `instance_mapping_table` will be directly packed into

--- a/mmpose/datasets/transforms/formatting.py
+++ b/mmpose/datasets/transforms/formatting.py
@@ -69,7 +69,7 @@ class PackPoseInputs(BaseTransform):
         meta_keys (Sequence[str], optional): Meta keys which will be stored in
             :obj: `PoseDataSample` as meta info. Defaults to ``('id',
             'img_id', 'img_path', 'ori_shape', 'img_shape', 'input_size',
-            'flip', 'flip_direction', 'flip_indices)``
+            'flip', 'flip_direction', 'flip_indices', 'raw_ann_info')``
     """
 
     # items in `instance_mapping_table` will be directly packed into

--- a/mmpose/evaluation/functional/nms.py
+++ b/mmpose/evaluation/functional/nms.py
@@ -8,11 +8,11 @@ from typing import List, Optional
 import numpy as np
 
 
-def nms(dets: List[list], thr: float) -> List[int]:
+def nms(dets: np.ndarray, thr: float) -> List[int]:
     """Greedily select boxes with high confidence and overlap <= thr.
 
     Args:
-        dets (List[list]): [[x1, y1, x2, y2, score]].
+        dets (np.ndarray): [[x1, y1, x2, y2, score]].
         thr (float): Retain overlap < thr.
 
     Returns:

--- a/mmpose/evaluation/metrics/__init__.py
+++ b/mmpose/evaluation/metrics/__init__.py
@@ -1,11 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .coco_metric import CocoMetric
+from .coco_metric import AP10KCocoMetric, CocoMetric
 from .coco_wholebody_metric import CocoWholeBodyMetric
 from .keypoint_2d_metrics import (AUC, EPE, NME, JhmdbPCKAccuracy,
                                   MpiiPCKAccuracy, PCKAccuracy)
 from .posetrack18_metric import PoseTrack18Metric
 
 __all__ = [
-    'CocoMetric', 'PCKAccuracy', 'MpiiPCKAccuracy', 'JhmdbPCKAccuracy', 'AUC',
-    'EPE', 'NME', 'PoseTrack18Metric', 'CocoWholeBodyMetric'
+    'CocoMetric', 'AP10KCocoMetric', 'PCKAccuracy', 'MpiiPCKAccuracy',
+    'JhmdbPCKAccuracy', 'AUC', 'EPE', 'NME', 'PoseTrack18Metric',
+    'CocoWholeBodyMetric'
 ]

--- a/mmpose/evaluation/metrics/coco_metric.py
+++ b/mmpose/evaluation/metrics/coco_metric.py
@@ -28,15 +28,15 @@ class CocoMetric(BaseMetric):
     Args:
         ann_file (str, optional): Path to the coco format annotation file.
             If not specified, ground truth annotations from the dataset will
-            be converted to coco format. Defaults to None.
+            be converted to coco format. Defaults to None
         use_area (bool): Whether to use ``'area'`` message in the annotations.
             If the ground truth annotations (e.g. CrowdPose, AIC) do not have
             the field ``'area'``, please set ``use_area=False``.
-            Default: ``True``.
+            Default: ``True``
         iou_type (str): The same parameter as `iouType` in
             :class:`xtcocotools.COCOeval`, which can be ``'keypoints'``, or
             ``'keypoints_crowd'`` (used in CrowdPose dataset).
-            Defaults to ``'keypoints'``.
+            Defaults to ``'keypoints'``
         score_mode (str): The mode to score the prediction results which
             should be one of the following options:
 
@@ -71,17 +71,18 @@ class CocoMetric(BaseMetric):
             doing quantitative evaluation. This is designed for the need of
             test submission when the ground truth annotations are absent. If
             set to ``True``, ``outfile_prefix`` should specify the path to
-            store the output results. Default: ``False``.
-        outfile_prefix (str | None): The prefix of json files. It includes
+            store the output results. Defaults to ``False``
+        outfile_prefix (str, optional): The prefix of json files. It includes
             the file path and the prefix of filename, e.g., ``'a/b/prefix'``.
-            If not specified, a temp file will be created. Default: ``None``.
+            If not specified, a temp file will be created.
+            Defaults to ``None``
         collect_device (str): Device name used for collecting results from
             different ranks during distributed training. Must be ``'cpu'`` or
-            ``'gpu'``. Default: ``'cpu'``.
+            ``'gpu'``. Defaults to ``'cpu'``
         prefix (str, optional): The prefix that will be added in the metric
             names to disambiguate homonymous metrics of different evaluators.
             If prefix is not provided in the argument, ``self.default_prefix``
-            will be used instead. Default: ``None``.
+            will be used instead. Defaults to ``None``
     """
     default_prefix: Optional[str] = 'coco'
 
@@ -190,10 +191,10 @@ class CocoMetric(BaseMetric):
                 gt['height'] = data_sample['ori_shape'][0]
                 gt['img_id'] = data_sample['img_id']
                 if self.iou_type == 'keypoints_crowd':
-                    assert 'crowdIndex' in data_sample, \
-                        '`crowdIndex` is required when `self.iou_type` is ' \
+                    assert 'crowd_index' in data_sample, \
+                        '`crowd_index` is required when `self.iou_type` is ' \
                         '`keypoints_crowd`'
-                    gt['crowdIndex'] = data_sample['crowdIndex']
+                    gt['crowd_index'] = data_sample['crowd_index']
                 assert 'raw_ann_info' in data_sample, \
                     'The row ground truth annotations are required for ' \
                     'evaluation when `ann_file` is not provided'
@@ -201,7 +202,7 @@ class CocoMetric(BaseMetric):
                 gt['raw_ann_info'] = anns if isinstance(anns, list) else [anns]
 
             # add converted result to the results list
-            self.results.append((gt, pred))
+            self.results.append((pred, gt))
 
     def gt_to_coco_json(self, gt_dicts: Sequence[dict],
                         outfile_prefix: str) -> str:
@@ -210,50 +211,32 @@ class CocoMetric(BaseMetric):
         Args:
             gt_dicts (Sequence[dict]): Ground truth of the dataset. Each dict
                 contains the ground truth information about the data sample.
-
                 Required keys of the each `gt_dict` in `gt_dicts`:
-
                     - `img_id`: image id of the data sample
-
                     - `width`: original image width
-
                     - `height`: original image height
-
                     - `raw_ann_info`: the raw annotation information
-
                 Optional keys:
-
-                    - `crowdIndex`: measure the crowding level of an image,
+                    - `crowd_index`: measure the crowding level of an image,
                         defined in CrowdPose dataset
-
-                It is worth mentioning that, in order to compute CocoMetric,
+                It is worth mentioning that, in order to compute `CocoMetric`,
                 there are some required keys in the `raw_ann_info`:
-
-                    - `id`: the id to distinguish different GT annotations
-
+                    - `id`: the id to distinguish different annotations
                     - `image_id`: the image id of this annotation
-
-                    - `category_id`: the category of the object.
-
+                    - `category_id`: the category of the instance.
                     - `bbox`: the object bounding box
-
                     - `keypoints`: the keypoints cooridinates along with their
                         visibilities. Note that it need to be aligned
                         with the official COCO format, e.g., a list with length
                         N * 3, in which N is the number of keypoints. And each
                         triplet represent the [x, y, visible] of the keypoint.
-
                     - `iscrowd`: indicating whether the annotation is a crowd.
                         It is useful when matching the detection results to
-                        the ground truth. Set it as `0` by default.
-
+                        the ground truth.
                 There are some optional keys as well:
-
                     - `area`: it is necessary when `self.use_area` is `True`
-
                     - `num_keypoints`: it is necessary when `self.iou_type`
                         is set as `keypoints_crowd`.
-
             outfile_prefix (str): The filename prefix of the json files. If the
                 prefix is "somepath/xxx", the json file will be named
                 "somepath/xxx.gt.json".
@@ -274,7 +257,7 @@ class CocoMetric(BaseMetric):
                     height=gt_dict['height'],
                 )
                 if self.iou_type == 'keypoints_crowd':
-                    image_info['crowdIndex'] = gt_dict['crowdIndex']
+                    image_info['crowdIndex'] = gt_dict['crowd_index']
 
                 image_infos.append(image_info)
                 img_ids.append(gt_dict['img_id'])
@@ -329,8 +312,8 @@ class CocoMetric(BaseMetric):
         """
         logger: MMLogger = MMLogger.get_current_instance()
 
-        # split gt and prediction list
-        gts, preds = zip(*results)
+        # split prediction and gt list
+        preds, gts = zip(*results)
 
         tmp_dir = None
         if self.outfile_prefix is None:
@@ -609,6 +592,8 @@ class AP10KCocoMetric(CocoMetric):
             If prefix is not provided in the argument, ``self.default_prefix``
             will be used instead. Default: ``None``.
     """
+
+    default_prefix: Optional[str] = 'ap10k'
 
     def process(self, data_batch: Sequence[dict],
                 predictions: Sequence[dict]) -> None:

--- a/mmpose/evaluation/metrics/posetrack18_metric.py
+++ b/mmpose/evaluation/metrics/posetrack18_metric.py
@@ -90,39 +90,16 @@ class PoseTrack18Metric(CocoMetric):
             raise ImportError('Please install ``poseval`` package for '
                               'evaluation on PoseTrack dataset '
                               '(see `requirements/optional.txt`)')
-        super(CocoMetric, self).__init__(
-            collect_device=collect_device, prefix=prefix)
-        self.ann_file = ann_file
-
-        allowed_score_modes = ['bbox', 'bbox_keypoint']
-        if score_mode not in allowed_score_modes:
-            raise ValueError(
-                "`score_mode` should be one of 'bbox', 'bbox_keypoint', "
-                f"'bbox_rle', but got {score_mode}")
-        self.score_mode = score_mode
-        self.keypoint_score_thr = keypoint_score_thr
-
-        allowed_nms_modes = ['oks_nms', 'soft_oks_nms', 'none']
-        if nms_mode not in allowed_nms_modes:
-            raise ValueError(
-                "`nms_mode` should be one of 'oks_nms', 'soft_oks_nms', "
-                f"'none', but got {nms_mode}")
-        self.nms_mode = nms_mode
-        self.nms_thr = nms_thr
-
-        if format_only:
-            assert outfile_prefix is not None, '`outfile_prefix` can not be '\
-                'None when `format_only` is True, otherwise the result file '\
-                'will be saved to a temp directory which will be cleaned up '\
-                'in the end.'
-        else:
-            # do evaluation only if the ground truth annotations exist
-            assert 'annotations' in load(ann_file), \
-                'Ground truth annotations are required for evaluation '\
-                'when `format_only` is False.'
-        self.format_only = format_only
-
-        self.outfile_prefix = outfile_prefix
+        super().__init__(
+            ann_file=ann_file,
+            score_mode=score_mode,
+            keypoint_score_thr=keypoint_score_thr,
+            nms_mode=nms_mode,
+            nms_thr=nms_thr,
+            format_only=format_only,
+            outfile_prefix=outfile_prefix,
+            collect_device=collect_device,
+            prefix=prefix)
 
     def results2json(self, keypoints: Dict[int, list],
                      outfile_prefix: str) -> str:

--- a/tests/test_evaluation/test_metrics/test_coco_metric.py
+++ b/tests/test_evaluation/test_metrics/test_coco_metric.py
@@ -10,7 +10,7 @@ from mmengine.fileio import dump, load
 from xtcocotools.coco import COCO
 
 from mmpose.datasets.datasets.utils import parse_pose_metainfo
-from mmpose.evaluation.metrics import CocoMetric
+from mmpose.evaluation.metrics import AP10KCocoMetric, CocoMetric
 
 
 class TestCocoMetric(TestCase):
@@ -47,6 +47,77 @@ class TestCocoMetric(TestCase):
             'coco/AR (M)': 1.0,
             'coco/AR (L)': 1.0,
         }
+
+        self.crowdpose_coco = COCO(self.ann_file)
+        self.crowdpose_ann_file = 'tests/data/crowdpose/test_crowdpose.json'
+        crowdpose_meta_info = dict(
+            from_file='configs/_base_/datasets/crowdpose.py')
+        self.crowdpose_dataset_meta = parse_pose_metainfo(crowdpose_meta_info)
+        self.crowdpose_dataset_meta['CLASSES'] = self.crowdpose_coco.loadCats(
+            self.crowdpose_coco.getCatIds())
+
+        self.crowdpose_db = load(self.crowdpose_ann_file)
+
+        self.crowdpose_topdown_data = self._convert_ann_to_topdown_batch_data()
+        assert len(self.topdown_data) == 14
+        self.bottomup_data = self._convert_ann_to_bottomup_batch_data()
+        assert len(self.bottomup_data) == 4
+
+        self.crowdpose_target = {
+            'crowdpose/AP': 1.0,
+            'crowdpose/AP .5': 1.0,
+            'crowdpose/AP .75': 1.0,
+            'crowdpose/AR': 1.0,
+            'crowdpose/AR .5': 1.0,
+            'crowdpose/AR .75': 1.0,
+            'crowdpose/AP(E)': -1.0,
+            'crowdpose/AP(M)': 1.0,
+            'crowdpose/AP(H)': -1.0,
+        }
+        self.crowdpose_data = self._collect_crowdpose_data()
+        assert len(self.topdown_data) == 14
+
+    def _collect_crowdpose_data(self):
+        """Collect crowdpose annotations to batch data."""
+        crowdpose_data = []
+        img_crowdIndex = dict()
+        for img in self.crowdpose_db['images']:
+            img_crowdIndex[img['id']] = img['crowdIndex']
+        for ann in self.crowdpose_db['annotations']:
+            w, h = ann['bbox'][2], ann['bbox'][3]
+            bboxes = np.array(ann['bbox'], dtype=np.float32).reshape(-1, 4)
+            bbox_scales = np.array([w * 1.25, h * 1.25]).reshape(-1, 2)
+            keypoints = np.array(ann['keypoints']).reshape((1, -1, 3))
+
+            gt_instances = {
+                'bbox_scales': bbox_scales,
+                'bbox_scores': np.ones((1, ), dtype=np.float32),
+                'bboxes': bboxes,
+            }
+            pred_instances = {
+                'keypoints': keypoints[..., :2],
+                'keypoint_scores': keypoints[..., -1],
+            }
+
+            data = {'inputs': None}
+            data_sample = {
+                'id': ann['id'],
+                'img_id': ann['image_id'],
+                'gt_instances': gt_instances,
+                'pred_instances': pred_instances,
+                # record the 'crowd_index' information
+                'crowd_index': img_crowdIndex[ann['image_id']],
+                # dummy image_shape for testing
+                'ori_shape': [640, 480],
+                # store the raw annotation info to test without ann_file
+                'raw_ann_info': copy.deepcopy(ann),
+            }
+            # batch size = 1
+            data_batch = [data]
+            data_samples = [data_sample]
+            crowdpose_data.append((data_batch, data_samples))
+
+        return crowdpose_data
 
     def _convert_ann_to_topdown_batch_data(self):
         """Convert annotations to topdown-style batch data."""
@@ -204,6 +275,40 @@ class TestCocoMetric(TestCase):
             coco_metric.process(data_batch, data_samples)
         eval_results = coco_metric.evaluate(size=len(self.topdown_data))
         self.assertDictEqual(eval_results, self.target)
+        # test whether convert the annotation to COCO format
+        self.assertTrue(
+            osp.isfile(osp.join(self.tmp_dir.name, 'test.gt.json')))
+        self.assertTrue(
+            osp.isfile(osp.join(self.tmp_dir.name, 'test.keypoints.json')))
+
+        # case 5: test Crowdpose dataset
+        crowdpose_metric = CocoMetric(
+            ann_file=self.crowdpose_ann_file,
+            outfile_prefix=f'{self.tmp_dir.name}/test',
+            use_area=False,
+            iou_type='keypoints_crowd',
+            prefix='crowdpose')
+        crowdpose_metric.dataset_meta = self.crowdpose_dataset_meta
+        # process samples
+        for data_batch, data_samples in self.crowdpose_data:
+            crowdpose_metric.process(data_batch, data_samples)
+        eval_results = crowdpose_metric.evaluate(size=len(self.crowdpose_data))
+        self.assertDictEqual(eval_results, self.crowdpose_target)
+        self.assertTrue(
+            osp.isfile(osp.join(self.tmp_dir.name, 'test.keypoints.json')))
+
+        # case 6: test Crowdpose dataset + without ann_file
+        crowdpose_metric = CocoMetric(
+            outfile_prefix=f'{self.tmp_dir.name}/test',
+            use_area=False,
+            iou_type='keypoints_crowd',
+            prefix='crowdpose')
+        crowdpose_metric.dataset_meta = self.crowdpose_dataset_meta
+        # process samples
+        for data_batch, data_samples in self.crowdpose_data:
+            crowdpose_metric.process(data_batch, data_samples)
+        eval_results = crowdpose_metric.evaluate(size=len(self.crowdpose_data))
+        self.assertDictEqual(eval_results, self.crowdpose_target)
         # test whether convert the annotation to COCO format
         self.assertTrue(
             osp.isfile(osp.join(self.tmp_dir.name, 'test.gt.json')))
@@ -469,5 +574,90 @@ class TestCocoMetric(TestCase):
         for key in eval_results.keys():
             self.assertAlmostEqual(eval_results[key], target[key])
 
+        self.assertTrue(
+            osp.isfile(osp.join(self.tmp_dir.name, 'test.keypoints.json')))
+
+
+class TestAP10KCocoMetric(TestCase):
+
+    def setUp(self):
+        """Setup some variables which are used in every test method.
+
+        TestCase calls functions in this order: setUp() -> testMethod() ->
+        tearDown() -> cleanUp()
+        """
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.ann_file = 'tests/data/ap10k/test_ap10k.json'
+        ap10k_meta_info = dict(from_file='configs/_base_/datasets/ap10k.py')
+        self.ap10k_meta_info = parse_pose_metainfo(ap10k_meta_info)
+
+        self.db = load(self.ann_file)
+
+        self.topdown_data = self._convert_ann_to_topdown_batch_data()
+        assert len(self.topdown_data) == 2
+        self.target = {
+            'ap10k/AP': 1.0,
+            'ap10k/AP .5': 1.0,
+            'ap10k/AP .75': 1.0,
+            'ap10k/AP (M)': -1.0,
+            'ap10k/AP (L)': 1.0,
+            'ap10k/AR': 1.0,
+            'ap10k/AR .5': 1.0,
+            'ap10k/AR .75': 1.0,
+            'ap10k/AR (M)': -1.0,
+            'ap10k/AR (L)': 1.0,
+        }
+
+    def _convert_ann_to_topdown_batch_data(self):
+        """Convert annotations to topdown-style batch data."""
+        topdown_data = []
+        for ann in self.db['annotations']:
+            w, h = ann['bbox'][2], ann['bbox'][3]
+            bboxes = np.array(ann['bbox'], dtype=np.float32).reshape(-1, 4)
+            bbox_scales = np.array([w * 1.25, h * 1.25]).reshape(-1, 2)
+            keypoints = np.array(ann['keypoints']).reshape((1, -1, 3))
+
+            gt_instances = {
+                'bbox_scales': bbox_scales,
+                'bboxes': bboxes,
+            }
+            pred_instances = {
+                'keypoints': keypoints[..., :2],
+                'keypoint_scores': keypoints[..., -1],
+                'bbox_scores': np.ones((1, ), dtype=np.float32),
+            }
+
+            data = {'inputs': None}
+            data_sample = {
+                'id': ann['id'],
+                'img_id': ann['image_id'],
+                'category': ann['category_id'],
+                'gt_instances': gt_instances,
+                'pred_instances': pred_instances
+            }
+            # batch size = 1
+            data_batch = [data]
+            data_samples = [data_sample]
+            topdown_data.append((data_batch, data_samples))
+
+        return topdown_data
+
+    def test_topdown_evaluate(self):
+        """test topdown-style COCO metric evaluation."""
+        # case 1: score_mode='bbox', nms_mode='none'
+        ap10k_metric = AP10KCocoMetric(
+            ann_file=self.ann_file,
+            outfile_prefix=f'{self.tmp_dir.name}/test',
+            score_mode='bbox',
+            nms_mode='none')
+        ap10k_metric.dataset_meta = self.ap10k_meta_info
+
+        # process samples
+        for data_batch, data_samples in self.topdown_data:
+            ap10k_metric.process(data_batch, data_samples)
+
+        eval_results = ap10k_metric.evaluate(size=len(self.topdown_data))
+        for key in self.target:
+            self.assertTrue(abs(eval_results[key] - self.target[key]) < 1e-7)
         self.assertTrue(
             osp.isfile(osp.join(self.tmp_dir.name, 'test.keypoints.json')))


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

Support evaluating coco metric without ann_file thus other non-COCO format datasets can take CocoMetric as well.

## Modification

<!-- Please briefly describe what modification is made in this PR. -->

1. Add the `'CLASSES'` in the dataset metainfo to store the information about category.
2. Add  `'raw_ann_info'` key in the definition of `BaseCocoStyleDataset`
3. Add  `'raw_ann_info'` key in `mmpose/datasets/transforms/formatting.py`
4. Modify `CocoMetric`, add `gt_to_coco_json` function. Also fix the inheritance dependency of `PoseTrack18Metric`
5. Add unittests.

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

In order to use this function, we need to change some places:

1.  Add `'raw_ann_info'` to the data_info in the dataset to store the raw annotation information:

```python
data_info = {
    'img_id': ann['image_id'],
    'img_path': img_path,
    'bbox': bbox,
    'bbox_score': np.ones(1, dtype=np.float32),
    'num_keypoints': num_keypoints,
    'keypoints': keypoints,
    'keypoints_visible': keypoints_visible,
    'iscrowd': ann.get('iscrowd', 0),
    'segmentation': ann.get('segmentation', None),
    'id': ann['id'],
    # store the raw annotation of the instance
    # it is useful for evaluation without providing ann_file
    'raw_ann_info': copy.deepcopy(ann),
}
```

2. Add 'raw_ann_info' to meta_keys so that the annotation can be readed in the CocoMetric
```python
test_pipeline = [
    dict(type='LoadImageFromFile'),
    ...,
    dict(type='PackPoseInputs', meta_keys=('id',
            'img_id', 'img_path', 'ori_shape', 'img_shape', 'input_size',
            'flip', 'flip_direction', 'flip_indices', 'raw_ann_info'))
]
```

3. Remove the `'ann_file'` in CocoMetric:

```python
val_evaluator = dict(
    type='CocoMetric',
    # ann_file=data_root + 'annotations/person_keypoints_val2017.json',
)
```

## Verification

I have tested on these following datasets and the results are exactly the same:

Comment some codes of `mmpose/datasets/datasets/base/base_coco_style_dataset.py` to omit the filtering:

![image](https://user-images.githubusercontent.com/87690686/197152471-47454d8f-7fc9-40fb-9e1a-67065dc8f103.png)


![image](https://user-images.githubusercontent.com/87690686/197152239-ce434dae-72f6-4b52-8a96-69ff48be53d2.png)

![image](https://user-images.githubusercontent.com/87690686/197152009-ca3edcff-dfab-4856-b062-d13f3a12f40f.png)


1. CocoDataset: can only evaluate `gt_bbox`, because can not assign gt `keypoints` and `bboxes` information to each detection bbox. Besides, the filtering condition should be deleted, so that each gt instance will be inferenced. Under these conditions, the results with and without ann_file are exactly the same (with 11004 samples in total, which is equal to the number of samples before filtering).

Test command:
```
python tools/test.py configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-256x192.py https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_256x192-c78dce93_20200708.pth
```

With ann_file:

![image](https://user-images.githubusercontent.com/87690686/197150665-1ddd34ff-584a-4e8f-9dc0-b46dc111bd0e.png)


Without ann_file:

![image](https://user-images.githubusercontent.com/87690686/197149632-0c3485d2-c3de-4098-b861-772fa4fc5e25.png)


2. AnimalPose dataset: it only evaluates on gt_bbox so it can fit this function naturally.  The results with and without ann_file are exactly the same (with 1117 samples in total).

Test command:
```
python tools/test.py configs/animal_2d_keypoint/topdown_heatmap/animalpose/td-hm_hrnet-w32_8xb64-210e_animalpose-256x256.py https://download.openmmlab.com/mmpose/animal/hrnet/hrnet_w32_animalpose_256x256-1aa7f075_20210426.pth
```

With ann_file:
![image](https://user-images.githubusercontent.com/87690686/197151733-d6431506-d3d6-43df-9830-f65ef64347a9.png)


Without ann_file:
![image](https://user-images.githubusercontent.com/87690686/197153053-4a456e08-a029-4d59-a64c-23c3edafdb56.png)


3. CrowdPose dataset: Fix some evaluation metric items, modified the `_do_python_keypoint_eval` function in `CocoMetric`.

Can only evaluate `gt_bbox`, because can not assign gt `keypoints` and `bboxes` information to each detection bbox. Besides, the filtering condition should be deleted, so that each gt instance will be inferenced. Under these conditions, the results with and without ann_file are exactly the same (with 35283 samples in total, which is equal to the number of samples before filtering).

Test command:
```
python tools/test.py configs/body_2d_keypoint/topdown_heatmap/crowdpose/td-hm_hrnet-w32_8xb64-210e_crowdpose-256x192.py https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_crowdpose_256x192-960be101_20201227.pth
```

With ann_file:
![image](https://user-images.githubusercontent.com/87690686/197155357-7e72330c-5c4e-4015-8a5a-eaffd8f27c10.png)


Without ann_file:
![image](https://user-images.githubusercontent.com/87690686/197157281-6474a518-2a69-4190-8e59-efa8fa209861.png)


## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
