### PR TITLE
[Fix] fix f-string missing in shared_transform.py

### DIFF
--- a/mmpose/datasets/pipelines/shared_transform.py
+++ b/mmpose/datasets/pipelines/shared_transform.py
@@ -261,8 +261,8 @@ class Albumentation:
             if albumentations is None:
                 raise RuntimeError('albumentations is not installed')
             if not hasattr(albumentations.augmentations.transforms, obj_type):
-                warnings.warn('{obj_type} is not pixel-level transformations. '
-                              'Please use with caution.')
+                warnings.warn(f'{obj_type} is not pixel-level transformations.'
+                              ' Please use with caution.')
             obj_cls = getattr(albumentations, obj_type)
         else:
             raise TypeError(f'type must be a str, but got {type(obj_type)}')


### PR DESCRIPTION
## Motivation
there is 'f-string' missing in Albumentation transforms.

## Modification

just simply add 'f'......

## BC-breaking (Optional)

## Use cases (Optional)

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
