### PR TITLE
[Enhance] Support training with combined datasets

### DIFF
--- a/configs/_base_/datasets/coco_aic.py
+++ b/configs/_base_/datasets/coco_aic.py
@@ -1,0 +1,205 @@
+dataset_info = dict(
+    dataset_name='coco',
+    paper_info=[
+        dict(
+            author='Lin, Tsung-Yi and Maire, Michael and '
+            'Belongie, Serge and Hays, James and '
+            'Perona, Pietro and Ramanan, Deva and '
+            r'Doll{\'a}r, Piotr and Zitnick, C Lawrence',
+            title='Microsoft coco: Common objects in context',
+            container='European conference on computer vision',
+            year='2014',
+            homepage='http://cocodataset.org/',
+        ),
+        dict(
+            author='Wu, Jiahong and Zheng, He and Zhao, Bo and '
+            'Li, Yixin and Yan, Baoming and Liang, Rui and '
+            'Wang, Wenjia and Zhou, Shipei and Lin, Guosen and '
+            'Fu, Yanwei and others',
+            title='Ai challenger: A large-scale dataset for going '
+            'deeper in image understanding',
+            container='arXiv',
+            year='2017',
+            homepage='https://github.com/AIChallenger/AI_Challenger_2017',
+        ),
+    ],
+    keypoint_info={
+        0:
+        dict(name='nose', id=0, color=[51, 153, 255], type='upper', swap=''),
+        1:
+        dict(
+            name='left_eye',
+            id=1,
+            color=[51, 153, 255],
+            type='upper',
+            swap='right_eye'),
+        2:
+        dict(
+            name='right_eye',
+            id=2,
+            color=[51, 153, 255],
+            type='upper',
+            swap='left_eye'),
+        3:
+        dict(
+            name='left_ear',
+            id=3,
+            color=[51, 153, 255],
+            type='upper',
+            swap='right_ear'),
+        4:
+        dict(
+            name='right_ear',
+            id=4,
+            color=[51, 153, 255],
+            type='upper',
+            swap='left_ear'),
+        5:
+        dict(
+            name='left_shoulder',
+            id=5,
+            color=[0, 255, 0],
+            type='upper',
+            swap='right_shoulder'),
+        6:
+        dict(
+            name='right_shoulder',
+            id=6,
+            color=[255, 128, 0],
+            type='upper',
+            swap='left_shoulder'),
+        7:
+        dict(
+            name='left_elbow',
+            id=7,
+            color=[0, 255, 0],
+            type='upper',
+            swap='right_elbow'),
+        8:
+        dict(
+            name='right_elbow',
+            id=8,
+            color=[255, 128, 0],
+            type='upper',
+            swap='left_elbow'),
+        9:
+        dict(
+            name='left_wrist',
+            id=9,
+            color=[0, 255, 0],
+            type='upper',
+            swap='right_wrist'),
+        10:
+        dict(
+            name='right_wrist',
+            id=10,
+            color=[255, 128, 0],
+            type='upper',
+            swap='left_wrist'),
+        11:
+        dict(
+            name='left_hip',
+            id=11,
+            color=[0, 255, 0],
+            type='lower',
+            swap='right_hip'),
+        12:
+        dict(
+            name='right_hip',
+            id=12,
+            color=[255, 128, 0],
+            type='lower',
+            swap='left_hip'),
+        13:
+        dict(
+            name='left_knee',
+            id=13,
+            color=[0, 255, 0],
+            type='lower',
+            swap='right_knee'),
+        14:
+        dict(
+            name='right_knee',
+            id=14,
+            color=[255, 128, 0],
+            type='lower',
+            swap='left_knee'),
+        15:
+        dict(
+            name='left_ankle',
+            id=15,
+            color=[0, 255, 0],
+            type='lower',
+            swap='right_ankle'),
+        16:
+        dict(
+            name='right_ankle',
+            id=16,
+            color=[255, 128, 0],
+            type='lower',
+            swap='left_ankle'),
+        17:
+        dict(
+            name='head_top',
+            id=12,
+            color=[51, 153, 255],
+            type='upper',
+            swap=''),
+        18:
+        dict(name='neck', id=13, color=[51, 153, 255], type='upper', swap='')
+    },
+    skeleton_info={
+        0:
+        dict(link=('left_ankle', 'left_knee'), id=0, color=[0, 255, 0]),
+        1:
+        dict(link=('left_knee', 'left_hip'), id=1, color=[0, 255, 0]),
+        2:
+        dict(link=('right_ankle', 'right_knee'), id=2, color=[255, 128, 0]),
+        3:
+        dict(link=('right_knee', 'right_hip'), id=3, color=[255, 128, 0]),
+        4:
+        dict(link=('left_hip', 'right_hip'), id=4, color=[51, 153, 255]),
+        5:
+        dict(link=('left_shoulder', 'left_hip'), id=5, color=[51, 153, 255]),
+        6:
+        dict(link=('right_shoulder', 'right_hip'), id=6, color=[51, 153, 255]),
+        7:
+        dict(
+            link=('left_shoulder', 'right_shoulder'),
+            id=7,
+            color=[51, 153, 255]),
+        8:
+        dict(link=('left_shoulder', 'left_elbow'), id=8, color=[0, 255, 0]),
+        9:
+        dict(
+            link=('right_shoulder', 'right_elbow'), id=9, color=[255, 128, 0]),
+        10:
+        dict(link=('left_elbow', 'left_wrist'), id=10, color=[0, 255, 0]),
+        11:
+        dict(link=('right_elbow', 'right_wrist'), id=11, color=[255, 128, 0]),
+        12:
+        dict(link=('left_eye', 'right_eye'), id=12, color=[51, 153, 255]),
+        13:
+        dict(link=('nose', 'left_eye'), id=13, color=[51, 153, 255]),
+        14:
+        dict(link=('nose', 'right_eye'), id=14, color=[51, 153, 255]),
+        15:
+        dict(link=('left_eye', 'left_ear'), id=15, color=[51, 153, 255]),
+        16:
+        dict(link=('right_eye', 'right_ear'), id=16, color=[51, 153, 255]),
+        17:
+        dict(link=('left_ear', 'left_shoulder'), id=17, color=[51, 153, 255]),
+        18:
+        dict(
+            link=('right_ear', 'right_shoulder'), id=18, color=[51, 153, 255]),
+        19:
+        dict(link=('head_top', 'neck'), id=11, color=[51, 153, 255]),
+    },
+    joint_weights=[
+        1., 1., 1., 1., 1., 1., 1., 1.2, 1.2, 1.5, 1.5, 1., 1., 1.2, 1.2, 1.5,
+        1.5, 1.5
+    ],
+    sigmas=[
+        0.026, 0.025, 0.025, 0.035, 0.035, 0.079, 0.079, 0.072, 0.072, 0.062,
+        0.062, 0.107, 0.107, 0.087, 0.087, 0.089, 0.089, 0.026, 0.026
+    ])

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/hrnet_coco_aic.md
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/hrnet_coco_aic.md
@@ -47,9 +47,15 @@
 
 </details>
 
+MMPose supports training model with combined datasets. [coco-aic-merge](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py) and [coco-aic-combine](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py) are two examples.
+
+- [coco-aic-merge](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py) leverages AIC data with partial keypoints to train a COCO model
+- [coco-aic-combine](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py) trains a model that predicts both COCO and AIC keypoints
+
 Results on COCO val2017 with detector having human AP of 56.4 on COCO val2017 dataset
 
 | Train Set                                    | Arch           | Input Size |  AP   | AP<sup>50</sup> | AP<sup>75</sup> |  AR   | AR<sup>50</sup> |                  ckpt                   |                  log                   |
 | :------------------------------------------- | :------------- | :--------: | :---: | :-------------: | :-------------: | :---: | :-------------: | :-------------------------------------: | :------------------------------------: |
+| [coco](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-256x192.py) | pose_hrnet_w32 |  256x192   | 0.749 |      0.906      |      0.821      | 0.804 |      0.945      | [ckpt](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-256x192-81c58e40_20220909.pth) | [log](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-256x192_20220909.log) |
 | [coco-aic-merge](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py) | pose_hrnet_w32 |  256x192   | 0.757 |      0.907      |      0.829      | 0.809 |      0.944      | [ckpt](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge-b05435b9_20221025.pth) | [log](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge_20221025.log) |
 | [coco-aic-combine](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py) | pose_hrnet_w32 |  256x192   | 0.756 |      0.906      |      0.826      | 0.807 |      0.943      | [ckpt](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine-4ce66880_20221026.pth) | [log](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine_20221026.log) |

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/hrnet_coco_aic.md
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/hrnet_coco_aic.md
@@ -1,0 +1,55 @@
+<!-- [ALGORITHM] -->
+
+<details>
+<summary align="right"><a href="http://openaccess.thecvf.com/content_CVPR_2019/html/Sun_Deep_High-Resolution_Representation_Learning_for_Human_Pose_Estimation_CVPR_2019_paper.html">HRNet (CVPR'2019)</a></summary>
+
+```bibtex
+@inproceedings{sun2019deep,
+  title={Deep high-resolution representation learning for human pose estimation},
+  author={Sun, Ke and Xiao, Bin and Liu, Dong and Wang, Jingdong},
+  booktitle={Proceedings of the IEEE conference on computer vision and pattern recognition},
+  pages={5693--5703},
+  year={2019}
+}
+```
+
+</details>
+
+<!-- [DATASET] -->
+
+<details>
+<summary align="right"><a href="https://link.springer.com/chapter/10.1007/978-3-319-10602-1_48">COCO (ECCV'2014)</a></summary>
+
+```bibtex
+@inproceedings{lin2014microsoft,
+  title={Microsoft coco: Common objects in context},
+  author={Lin, Tsung-Yi and Maire, Michael and Belongie, Serge and Hays, James and Perona, Pietro and Ramanan, Deva and Doll{\'a}r, Piotr and Zitnick, C Lawrence},
+  booktitle={European conference on computer vision},
+  pages={740--755},
+  year={2014},
+  organization={Springer}
+}
+```
+
+</details>
+
+<details>
+<summary align="right"><a href="https://arxiv.org/abs/1711.06475">AI Challenger (ArXiv'2017)</a></summary>
+
+```bibtex
+@article{wu2017ai,
+  title={Ai challenger: A large-scale dataset for going deeper in image understanding},
+  author={Wu, Jiahong and Zheng, He and Zhao, Bo and Li, Yixin and Yan, Baoming and Liang, Rui and Wang, Wenjia and Zhou, Shipei and Lin, Guosen and Fu, Yanwei and others},
+  journal={arXiv preprint arXiv:1711.06475},
+  year={2017}
+}
+```
+
+</details>
+
+Results on COCO val2017 with detector having human AP of 56.4 on COCO val2017 dataset
+
+| Train Set                                    | Arch           | Input Size |  AP   | AP<sup>50</sup> | AP<sup>75</sup> |  AR   | AR<sup>50</sup> |                  ckpt                   |                  log                   |
+| :------------------------------------------- | :------------- | :--------: | :---: | :-------------: | :-------------: | :---: | :-------------: | :-------------------------------------: | :------------------------------------: |
+| [coco-aic-merge](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py) | pose_hrnet_w32 |  256x192   | 0.757 |      0.907      |      0.829      | 0.809 |      0.944      | [ckpt](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge-b05435b9_20221025.pth) | [log](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge_20221025.log) |
+| [coco-aic-combine](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py) | pose_hrnet_w32 |  256x192   | 0.756 |      0.906      |      0.826      | 0.807 |      0.943      | [ckpt](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine-4ce66880_20221026.pth) | [log](https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine_20221026.log) |

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/hrnet_coco_aic.md
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/hrnet_coco_aic.md
@@ -49,10 +49,10 @@
 
 MMPose supports training model with combined datasets. [coco-aic-merge](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py) and [coco-aic-combine](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py) are two examples.
 
-- [coco-aic-merge](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py) leverages AIC data with partial keypoints to train a COCO model
-- [coco-aic-combine](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py) trains a model that predicts both COCO and AIC keypoints
+- [coco-aic-merge](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py) leverages AIC data with partial keypoints as auxiliary data to train a COCO model
+- [coco-aic-combine](/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py) constructs a combined dataset whose keypoints are the union of COCO and AIC keypoints to train a model that predicts keypoints of both datasets.
 
-Results on COCO val2017 with detector having human AP of 56.4 on COCO val2017 dataset
+Evaluation results on COCO val2017 of models trained with solely COCO dataset and combined dataset as shown below. These models are evaluated with detector having human AP of 56.4 on COCO val2017 dataset.
 
 | Train Set                                    | Arch           | Input Size |  AP   | AP<sup>50</sup> | AP<sup>75</sup> |  AR   | AR<sup>50</sup> |                  ckpt                   |                  log                   |
 | :------------------------------------------- | :------------- | :--------: | :---: | :-------------: | :-------------: | :---: | :-------------: | :-------------------------------------: | :------------------------------------: |

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py
@@ -125,7 +125,9 @@ model = dict(
         flip_test=True,
         flip_mode='heatmap',
         shift_heatmap=True,
-        out_keypoint_indices=[target for _, target in keypoint_mapping_coco]))
+        output_keypoint_indices=[
+            target for _, target in keypoint_mapping_coco
+        ]))
 
 # base dataset settings
 dataset_type = 'CocoDataset'

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py
@@ -1,0 +1,212 @@
+_base_ = ['../../../_base_/default_runtime.py']
+
+# runtime
+train_cfg = dict(max_epochs=210, val_interval=10)
+
+# optimizer
+optim_wrapper = dict(optimizer=dict(
+    type='Adam',
+    lr=5e-4,
+))
+
+# learning policy
+param_scheduler = [
+    dict(
+        type='LinearLR', begin=0, end=500, start_factor=0.001,
+        by_epoch=False),  # warm-up
+    dict(
+        type='MultiStepLR',
+        begin=0,
+        end=210,
+        milestones=[170, 200],
+        gamma=0.1,
+        by_epoch=True)
+]
+
+# automatically scaling LR based on the actual training batch size
+auto_scale_lr = dict(base_batch_size=512)
+
+# hooks
+default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='HRNet',
+        in_channels=3,
+        extra=dict(
+            stage1=dict(
+                num_modules=1,
+                num_branches=1,
+                block='BOTTLENECK',
+                num_blocks=(4, ),
+                num_channels=(64, )),
+            stage2=dict(
+                num_modules=1,
+                num_branches=2,
+                block='BASIC',
+                num_blocks=(4, 4),
+                num_channels=(32, 64)),
+            stage3=dict(
+                num_modules=4,
+                num_branches=3,
+                block='BASIC',
+                num_blocks=(4, 4, 4),
+                num_channels=(32, 64, 128)),
+            stage4=dict(
+                num_modules=3,
+                num_branches=4,
+                block='BASIC',
+                num_blocks=(4, 4, 4, 4),
+                num_channels=(32, 64, 128, 256))),
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='https://download.openmmlab.com/mmpose/'
+            'pretrain_models/hrnet_w32-36af842e.pth'),
+    ),
+    head=dict(
+        type='HeatmapHead',
+        in_channels=32,
+        out_channels=19,
+        deconv_out_channels=None,
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args={{_base_.file_client_args}}),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='GenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+val_pipeline = [
+    dict(type='LoadImage', file_client_args={{_base_.file_client_args}}),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# train datasets
+dataset_coco = dict(
+    type=dataset_type,
+    data_root=data_root,
+    data_mode=data_mode,
+    ann_file='annotations/person_keypoints_train2017.json',
+    data_prefix=dict(img='train2017/'),
+    pipeline=[
+        dict(
+            type='KeypointConverter',
+            num_keypoints=19,
+            mapping=[
+                (0, 0),
+                (1, 1),
+                (2, 2),
+                (3, 3),
+                (4, 4),
+                (5, 5),
+                (6, 6),
+                (7, 7),
+                (8, 8),
+                (9, 9),
+                (10, 10),
+                (11, 11),
+                (12, 12),
+                (13, 13),
+                (14, 14),
+                (15, 15),
+                (16, 16),
+            ])
+    ],
+)
+
+dataset_aic = dict(
+    type='AicDataset',
+    data_root='data/aic/',
+    data_mode=data_mode,
+    ann_file='annotations/aic_train.json',
+    data_prefix=dict(img='ai_challenger_keypoint_train_20170902/'
+                     'keypoint_train_images_20170902/'),
+    pipeline=[
+        dict(
+            type='KeypointConverter',
+            num_keypoints=19,
+            mapping=[
+                (0, 6),
+                (1, 8),
+                (2, 10),
+                (3, 5),
+                (4, 7),
+                (5, 9),
+                (6, 12),
+                (7, 14),
+                (8, 16),
+                (9, 11),
+                (10, 13),
+                (11, 15),
+                (12, 17),
+                (13, 18),
+            ])
+    ],
+)
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type='CombinedDataset',
+        metainfo=dict(from_file='configs/_base_/datasets/coco_aic.py'),
+        datasets=[dataset_coco, dataset_aic],
+        pipeline=train_pipeline,
+        test_mode=False,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False, round_up=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        data_mode=data_mode,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=val_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+# evaluators
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py
@@ -27,11 +27,50 @@ param_scheduler = [
 auto_scale_lr = dict(base_batch_size=512)
 
 # hooks
-default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
+default_hooks = dict(
+    checkpoint=dict(save_best='coco/AP', rule='greater', max_keep_ckpts=3))
 
 # codec settings
 codec = dict(
     type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# keypoint mappings
+keypoint_mapping_coco = [
+    (0, 0),
+    (1, 1),
+    (2, 2),
+    (3, 3),
+    (4, 4),
+    (5, 5),
+    (6, 6),
+    (7, 7),
+    (8, 8),
+    (9, 9),
+    (10, 10),
+    (11, 11),
+    (12, 12),
+    (13, 13),
+    (14, 14),
+    (15, 15),
+    (16, 16),
+]
+
+keypoint_mapping_aic = [
+    (0, 6),
+    (1, 8),
+    (2, 10),
+    (3, 5),
+    (4, 7),
+    (5, 9),
+    (6, 12),
+    (7, 14),
+    (8, 16),
+    (9, 11),
+    (10, 13),
+    (11, 15),
+    (12, 17),
+    (13, 18),
+]
 
 # model settings
 model = dict(
@@ -41,6 +80,7 @@ model = dict(
         mean=[123.675, 116.28, 103.53],
         std=[58.395, 57.12, 57.375],
         bgr_to_rgb=True),
+    metainfo=dict(from_file='configs/_base_/datasets/coco_aic.py'),
     backbone=dict(
         type='HRNet',
         in_channels=3,
@@ -85,7 +125,7 @@ model = dict(
         flip_test=True,
         flip_mode='heatmap',
         shift_heatmap=True,
-    ))
+        out_keypoint_indices=[target for _, target in keypoint_mapping_coco]))
 
 # base dataset settings
 dataset_type = 'CocoDataset'
@@ -121,25 +161,7 @@ dataset_coco = dict(
         dict(
             type='KeypointConverter',
             num_keypoints=19,
-            mapping=[
-                (0, 0),
-                (1, 1),
-                (2, 2),
-                (3, 3),
-                (4, 4),
-                (5, 5),
-                (6, 6),
-                (7, 7),
-                (8, 8),
-                (9, 9),
-                (10, 10),
-                (11, 11),
-                (12, 12),
-                (13, 13),
-                (14, 14),
-                (15, 15),
-                (16, 16),
-            ])
+            mapping=keypoint_mapping_coco)
     ],
 )
 
@@ -154,22 +176,7 @@ dataset_aic = dict(
         dict(
             type='KeypointConverter',
             num_keypoints=19,
-            mapping=[
-                (0, 6),
-                (1, 8),
-                (2, 10),
-                (3, 5),
-                (4, 7),
-                (5, 9),
-                (6, 12),
-                (7, 14),
-                (8, 16),
-                (9, 11),
-                (10, 13),
-                (11, 15),
-                (12, 17),
-                (13, 18),
-            ])
+            mapping=keypoint_mapping_aic)
     ],
 )
 

--- a/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py
+++ b/configs/body_2d_keypoint/topdown_heatmap/coco/td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py
@@ -1,0 +1,187 @@
+_base_ = ['../../../_base_/default_runtime.py']
+
+# runtime
+train_cfg = dict(max_epochs=210, val_interval=10)
+
+# optimizer
+optim_wrapper = dict(optimizer=dict(
+    type='Adam',
+    lr=5e-4,
+))
+
+# learning policy
+param_scheduler = [
+    dict(
+        type='LinearLR', begin=0, end=500, start_factor=0.001,
+        by_epoch=False),  # warm-up
+    dict(
+        type='MultiStepLR',
+        begin=0,
+        end=210,
+        milestones=[170, 200],
+        gamma=0.1,
+        by_epoch=True)
+]
+
+# automatically scaling LR based on the actual training batch size
+auto_scale_lr = dict(base_batch_size=512)
+
+# hooks
+default_hooks = dict(checkpoint=dict(save_best='coco/AP', rule='greater'))
+
+# codec settings
+codec = dict(
+    type='MSRAHeatmap', input_size=(192, 256), heatmap_size=(48, 64), sigma=2)
+
+# model settings
+model = dict(
+    type='TopdownPoseEstimator',
+    data_preprocessor=dict(
+        type='PoseDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True),
+    backbone=dict(
+        type='HRNet',
+        in_channels=3,
+        extra=dict(
+            stage1=dict(
+                num_modules=1,
+                num_branches=1,
+                block='BOTTLENECK',
+                num_blocks=(4, ),
+                num_channels=(64, )),
+            stage2=dict(
+                num_modules=1,
+                num_branches=2,
+                block='BASIC',
+                num_blocks=(4, 4),
+                num_channels=(32, 64)),
+            stage3=dict(
+                num_modules=4,
+                num_branches=3,
+                block='BASIC',
+                num_blocks=(4, 4, 4),
+                num_channels=(32, 64, 128)),
+            stage4=dict(
+                num_modules=3,
+                num_branches=4,
+                block='BASIC',
+                num_blocks=(4, 4, 4, 4),
+                num_channels=(32, 64, 128, 256))),
+        init_cfg=dict(
+            type='Pretrained',
+            checkpoint='https://download.openmmlab.com/mmpose/'
+            'pretrain_models/hrnet_w32-36af842e.pth'),
+    ),
+    head=dict(
+        type='HeatmapHead',
+        in_channels=32,
+        out_channels=17,
+        deconv_out_channels=None,
+        loss=dict(type='KeypointMSELoss', use_target_weight=True),
+        decoder=codec),
+    test_cfg=dict(
+        flip_test=True,
+        flip_mode='heatmap',
+        shift_heatmap=True,
+    ))
+
+# base dataset settings
+dataset_type = 'CocoDataset'
+data_mode = 'topdown'
+data_root = 'data/coco/'
+
+# pipelines
+train_pipeline = [
+    dict(type='LoadImage', file_client_args={{_base_.file_client_args}}),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='RandomFlip', direction='horizontal'),
+    dict(type='RandomHalfBody'),
+    dict(type='RandomBBoxTransform'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='GenerateTarget', target_type='heatmap', encoder=codec),
+    dict(type='PackPoseInputs')
+]
+val_pipeline = [
+    dict(type='LoadImage', file_client_args={{_base_.file_client_args}}),
+    dict(type='GetBBoxCenterScale'),
+    dict(type='TopdownAffine', input_size=codec['input_size']),
+    dict(type='PackPoseInputs')
+]
+
+# train datasets
+dataset_coco = dict(
+    type=dataset_type,
+    data_root=data_root,
+    data_mode=data_mode,
+    ann_file='annotations/person_keypoints_train2017.json',
+    data_prefix=dict(img='train2017/'),
+    pipeline=[],
+)
+
+dataset_aic = dict(
+    type='AicDataset',
+    data_root='data/aic/',
+    data_mode=data_mode,
+    ann_file='annotations/aic_train.json',
+    data_prefix=dict(img='ai_challenger_keypoint_train_20170902/'
+                     'keypoint_train_images_20170902/'),
+    pipeline=[
+        dict(
+            type='KeypointConverter',
+            num_keypoints=17,
+            mapping=[
+                (0, 6),
+                (1, 8),
+                (2, 10),
+                (3, 5),
+                (4, 7),
+                (5, 9),
+                (6, 12),
+                (7, 14),
+                (8, 16),
+                (9, 11),
+                (10, 13),
+                (11, 15),
+            ])
+    ],
+)
+
+# data loaders
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type='CombinedDataset',
+        metainfo=dict(from_file='configs/_base_/datasets/coco.py'),
+        datasets=[dataset_coco, dataset_aic],
+        pipeline=train_pipeline,
+        test_mode=False,
+    ))
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False, round_up=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        data_mode=data_mode,
+        ann_file='annotations/person_keypoints_val2017.json',
+        bbox_file='data/coco/person_detection_results/'
+        'COCO_val2017_detections_AP_H_56_person.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=val_pipeline,
+    ))
+test_dataloader = val_dataloader
+
+# evaluators
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/person_keypoints_val2017.json')
+test_evaluator = val_evaluator

--- a/docs/en/user_guides/prepare_datasets.md
+++ b/docs/en/user_guides/prepare_datasets.md
@@ -224,4 +224,46 @@ Make sure you have provided all the paths correctly.
 
 The following dataset wrappers are supported in [MMEngine](https://github.com/open-mmlab/mmengine), you can refer to [MMEngine tutorial](https://mmengine.readthedocs.io/en/latest) to learn how to use it.
 
+- [ConcatDataset](https://mmengine.readthedocs.io/en/latest/advanced_tutorials/basedataset.html#concatdataset)
 - [RepeatDataset](https://mmengine.readthedocs.io/en/latest/advanced_tutorials/basedataset.html#repeatdataset)
+
+### CombinedDataset
+
+MMPose provides `CombinedDataset` to combine multiple datasets with different annotations. A combined dataset can be defined in config files as:
+
+```python
+dataset_1 = dict(
+    type='dataset_type_1',
+    data_root='root/of/your/dataset1',
+    data_prefix=dict(img_path='path/to/your/img'),
+    ann_file='annotations/train.json',
+    pipeline=[
+        # the converter transforms convert data into a unified format
+        converter_transform_1
+    ])
+
+dataset_2 = dict(
+    type='dataset_type_2',
+    data_root='root/of/your/dataset2',
+    data_prefix=dict(img_path='path/to/your/img'),
+    ann_file='annotations/train.json',
+    pipeline=[
+        converter_transform_2
+    ])
+
+shared_pipeline = [
+    LoadImage(),
+    ParseImage(),
+]
+
+combined_dataset = dict(
+    type='CombinedDataset',
+    metainfo=dict(from_file='path/to/your/metainfo'),
+    datasets=[dataset_1, dataset_2],
+    pipeline=shared_pipeline,
+)
+```
+
+- **MetaInfo of combined dataset** determines the annotation format. Either metainfo of a sub-dataset or a customed dataset metainfo is valid here. To custom a dataset metainfo, please refer to [Create a custom dataset_info config file for the dataset](#create-a-custom-datasetinfo-config-file-for-the-dataset).
+
+- **Converter transforms of sub-datasets** are applied when there exist mismatches of annotation format between sub-datasets and the combined dataset. For example, the number and order of keypoints might be different in the combined dataset and the sub-datasets. Then `KeypointConverter` can be used to unify the keypoints number and order.

--- a/mmpose/apis/inference.py
+++ b/mmpose/apis/inference.py
@@ -104,7 +104,7 @@ def init_model(config: Union[str, Path, Config],
             dataset_meta = ckpt['meta']['dataset_meta']
 
     if dataset_meta is None:
-        dataset_meta = dataset_meta_from_config(config, dataset_mode='test')
+        dataset_meta = dataset_meta_from_config(config, dataset_mode='train')
 
     if dataset_meta is None:
         warnings.simplefilter('once')

--- a/mmpose/datasets/__init__.py
+++ b/mmpose/datasets/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .builder import build_dataset
+from .dataset_wrappers import CombinedDataset, RepeatDataset
 from .datasets import *  # noqa
 from .transforms import *  # noqa
 
-__all__ = ['build_dataset']
+__all__ = ['build_dataset', 'RepeatDataset', 'CombinedDataset']

--- a/mmpose/datasets/dataset_wrappers.py
+++ b/mmpose/datasets/dataset_wrappers.py
@@ -58,7 +58,7 @@ class CombinedDataset(BaseDataset):
         self.datasets = []
 
         for cfg in datasets:
-            dataset = build_from_cfg(cfg['dataset'], DATASETS)
+            dataset = build_from_cfg(cfg, DATASETS)
             self.datasets.append(dataset)
 
         self._lens = [len(dataset) for dataset in self.datasets]
@@ -116,6 +116,7 @@ class CombinedDataset(BaseDataset):
         subset_idx, sample_idx = self._get_subset_index(idx)
         # Get data sample from the subset
         data_info = self.datasets[subset_idx].get_data_info(sample_idx)
+        data_info = self.datasets[subset_idx].pipeline(data_info)
 
         # Add metainfo items that are required in the pipeline and the model
         metainfo_keys = [

--- a/mmpose/datasets/dataset_wrappers.py
+++ b/mmpose/datasets/dataset_wrappers.py
@@ -1,5 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .builder import DATASETS
+
+from copy import deepcopy
+from typing import Any, Callable, List, Tuple, Union
+
+from mmengine.dataset import BaseDataset
+from mmengine.registry import build_from_cfg
+
+from mmpose.registry import DATASETS
+from .datasets.utils import parse_pose_metainfo
 
 
 @DATASETS.register_module()
@@ -29,3 +37,106 @@ class RepeatDataset:
     def __len__(self):
         """Length after repetition."""
         return self.times * self._ori_len
+
+
+@DATASETS.register_module()
+class CombinedDataset(BaseDataset):
+    """A wrapper of combined dataset.
+
+    Args:
+        metainfo (dict): The meta information of combined dataset.
+        datasets (list): The configs of datasets to be combined.
+        pipeline (list, optional): Processing pipeline. Defaults to [].
+    """
+
+    def __init__(self,
+                 metainfo: dict,
+                 datasets: list,
+                 pipeline: List[Union[dict, Callable]] = [],
+                 **kwargs):
+
+        self.datasets = []
+
+        for cfg in datasets:
+            dataset = build_from_cfg(cfg['dataset'], DATASETS)
+            self.datasets.append(dataset)
+
+        self._lens = [len(dataset) for dataset in self.datasets]
+        self._len = sum(self._lens)
+
+        super(CombinedDataset, self).__init__(pipeline=pipeline, **kwargs)
+        self._metainfo = parse_pose_metainfo(metainfo)
+
+    @property
+    def metainfo(self):
+        return deepcopy(self._metainfo)
+
+    def __len__(self):
+        return self._len
+
+    def _get_subset_index(self, index: int) -> Tuple[int, int]:
+        """Given a data sample's global index, return the index of the sub-
+        dataset the data sample belongs to, and the local index within that
+        sub-dataset.
+
+        Args:
+            index (int): The global data sample index
+
+        Returns:
+            tuple[int, int]:
+            - subset_index (int): The index of the sub-dataset
+            - local_index (int): The index of the data sample within
+                the sub-dataset
+        """
+        if index >= len(self) or index < -len(self):
+            raise ValueError(
+                f'index({index}) is out of bounds for dataset with '
+                f'length({len(self)}).')
+
+        if index < 0:
+            index = index + len(self)
+
+        subset_index = 0
+        while index >= self._lens[subset_index]:
+            index -= self._lens[subset_index]
+            subset_index += 1
+        return subset_index, index
+
+    def prepare_data(self, idx: int) -> Any:
+        """Get data processed by ``self.pipeline``.The source dataset is
+        depending on the index.
+
+        Args:
+            idx (int): The index of ``data_info``.
+
+        Returns:
+            Any: Depends on ``self.pipeline``.
+        """
+
+        subset_idx, sample_idx = self._get_subset_index(idx)
+        # Get data sample from the subset
+        data_info = self.datasets[subset_idx].get_data_info(sample_idx)
+
+        # Add metainfo items that are required in the pipeline and the model
+        metainfo_keys = [
+            'upper_body_ids', 'lower_body_ids', 'flip_pairs',
+            'dataset_keypoint_weights', 'flip_indices'
+        ]
+
+        for key in metainfo_keys:
+            assert key not in data_info, (
+                f'"{key}" is a reserved key for `metainfo`, but already '
+                'exists in the `data_info`.')
+            data_info[key] = deepcopy(self._metainfo[key])
+
+        return self.pipeline(data_info)
+
+    def full_init(self):
+        """Fully initialize all sub datasets."""
+
+        if self._fully_initialized:
+            return
+
+        for dataset in self.datasets:
+            dataset.full_init()
+        self._fully_initialized = True

--- a/mmpose/datasets/transforms/__init__.py
+++ b/mmpose/datasets/transforms/__init__.py
@@ -5,6 +5,7 @@ from .common_transforms import (Albumentation, GenerateTarget,
                                 GetBBoxCenterScale, PhotometricDistortion,
                                 RandomBBoxTransform, RandomFlip,
                                 RandomHalfBody)
+from .converting import KeypointConverter
 from .formatting import PackPoseInputs
 from .loading import LoadImage
 from .topdown_transforms import TopdownAffine
@@ -14,5 +15,5 @@ __all__ = [
     'RandomHalfBody', 'TopdownAffine', 'Albumentation',
     'PhotometricDistortion', 'PackPoseInputs', 'LoadImage',
     'BottomupGetHeatmapMask', 'BottomupRandomAffine', 'BottomupResize',
-    'GenerateTarget'
+    'GenerateTarget', 'KeypointConverter'
 ]

--- a/mmpose/datasets/transforms/converting.py
+++ b/mmpose/datasets/transforms/converting.py
@@ -1,0 +1,58 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import List, Tuple
+
+import numpy as np
+from mmcv.transforms import BaseTransform
+
+from mmpose.registry import TRANSFORMS
+
+
+@TRANSFORMS.register_module()
+class KeypointConverter(BaseTransform):
+    """Change the order of keypoints according to the given mapping.
+
+    Required Keys:
+
+        - keypoints
+        - keypoints_visible
+
+    Modified Keys:
+
+        - keypoints
+        - keypoints_visible
+
+    Args:
+        num_keypoints (int): The number of keypoints in target dataset.
+        mapping (list): A list containing mapping indexes. Each element has
+            format (source_index, target_index)
+    """
+
+    def __init__(self, num_keypoints: int, mapping: List[Tuple[int, int]]):
+        self.num_keypoints = num_keypoints
+        self.mapping = mapping
+
+    def transform(self, results: dict) -> dict:
+        num_instances = results['keypoints'].shape[0]
+
+        keypoints = np.zeros((num_instances, self.num_keypoints, 2))
+        keypoints_visible = np.zeros((num_instances, self.num_keypoints))
+
+        source_index, target_index = zip(*self.mapping)
+        keypoints[:, target_index] = results['keypoints'][:, source_index]
+        keypoints_visible[:, target_index] = results[
+            'keypoints_visible'][:, source_index]
+
+        results['keypoints'] = keypoints
+        results['keypoints_visible'] = keypoints_visible
+        return results
+
+    def __repr__(self) -> str:
+        """print the basic information of the transform.
+
+        Returns:
+            str: Formatted string.
+        """
+        repr_str = self.__class__.__name__
+        repr_str += f'(num_keypoints={self.num_keypoints}, '\
+                    f'mapping={self.mapping})'
+        return repr_str

--- a/mmpose/models/pose_estimators/base.py
+++ b/mmpose/models/pose_estimators/base.py
@@ -15,11 +15,15 @@ class BasePoseEstimator(BaseModel, metaclass=ABCMeta):
 
     Args:
         data_preprocessor (dict | ConfigDict, optional): The pre-processing
-            config of :class:`BaseDataPreprocessor`. Defaults to ``None``.
+            config of :class:`BaseDataPreprocessor`. Defaults to ``None``
         init_cfg (dict | ConfigDict): The model initialization config.
             Defaults to ``None``
         metainfo (dict): Meta information for dataset, such as keypoints
-            information. Default: ``None``.
+            definition and properties. If set, the metainfo of the input data
+            batch will be overridden. For more details, please refer to
+            https://mmpose.readthedocs.io/en/1.x/user_guides/
+            prepare_datasets.html#create-a-custom-dataset-info-
+            config-file-for-the-dataset. Defaults to ``None``
     """
 
     def __init__(

--- a/mmpose/models/pose_estimators/base.py
+++ b/mmpose/models/pose_estimators/base.py
@@ -5,8 +5,9 @@ import torch
 from mmengine.model import BaseModel
 from torch import Tensor
 
-from mmpose.utils.typing import (ForwardResults, OptConfigType, OptMultiConfig,
-                                 OptSampleList, SampleList)
+from mmpose.datasets.datasets.utils import parse_pose_metainfo
+from mmpose.utils.typing import (ForwardResults, OptConfigType, Optional,
+                                 OptMultiConfig, OptSampleList, SampleList)
 
 
 class BasePoseEstimator(BaseModel, metaclass=ABCMeta):
@@ -17,13 +18,19 @@ class BasePoseEstimator(BaseModel, metaclass=ABCMeta):
             config of :class:`BaseDataPreprocessor`. Defaults to ``None``.
         init_cfg (dict | ConfigDict): The model initialization config.
             Defaults to ``None``
+        metainfo (dict): Meta information for dataset, such as keypoints
+            information. Default: ``None``.
     """
 
-    def __init__(self,
-                 data_preprocessor: OptConfigType = None,
-                 init_cfg: OptMultiConfig = None):
+    def __init__(
+        self,
+        data_preprocessor: OptConfigType = None,
+        init_cfg: OptMultiConfig = None,
+        metainfo: Optional[dict] = None,
+    ):
         super().__init__(
             data_preprocessor=data_preprocessor, init_cfg=init_cfg)
+        self.metainfo = self._load_metainfo(metainfo)
 
     @property
     def with_neck(self) -> bool:
@@ -34,6 +41,27 @@ class BasePoseEstimator(BaseModel, metaclass=ABCMeta):
     def with_head(self) -> bool:
         """bool: whether the pose estimator has a head."""
         return hasattr(self, 'head') and self.head is not None
+
+    @staticmethod
+    def _load_metainfo(metainfo: dict = None) -> dict:
+        """Collect meta information from the dictionary of meta.
+
+        Args:
+            metainfo (dict): Raw data of pose meta information.
+
+        Returns:
+            dict: Parsed meta information.
+        """
+
+        if metainfo is None:
+            return None
+
+        if not isinstance(metainfo, dict):
+            raise TypeError(
+                f'metainfo should be a dict, but got {type(metainfo)}')
+
+        metainfo = parse_pose_metainfo(metainfo)
+        return metainfo
 
     def forward(self,
                 inputs: torch.Tensor,
@@ -73,6 +101,10 @@ class BasePoseEstimator(BaseModel, metaclass=ABCMeta):
         if mode == 'loss':
             return self.loss(inputs, data_samples)
         elif mode == 'predict':
+            # use customed metainfo to override the default metainfo
+            if self.metainfo is not None:
+                for data_sample in data_samples:
+                    data_sample.set_metainfo(self.metainfo)
             return self.predict(inputs, data_samples)
         elif mode == 'tensor':
             return self._forward(inputs)

--- a/mmpose/models/pose_estimators/topdown.py
+++ b/mmpose/models/pose_estimators/topdown.py
@@ -203,7 +203,7 @@ class TopdownPoseEstimator(BasePoseEstimator):
                 num_keypoints = pred_instances.keypoints.shape[1]
                 for key, value in pred_instances.all_items():
                     if key.startswith('keypoint'):
-                        setattr(pred_instances, key, value[:, kpt_indices])
+                        pred_instances.set_field(value[:, kpt_indices], key)
 
             # add bbox information into pred_instances
             pred_instances.bboxes = gt_instances.bboxes
@@ -214,16 +214,11 @@ class TopdownPoseEstimator(BasePoseEstimator):
             if pred_fields is not None:
                 if kpt_indices is not None:
                     # select output heatmap channels with keypoint indices
+                    # when the number of heatmap channel matches num_keypoints
                     for key, value in pred_fields.all_items():
-                        if value.shape[0] % num_keypoints != 0:
+                        if value.shape[0] != num_keypoints:
                             continue
-                        field_size = value.shape[1:]
-                        # in some cases, such as UDP-regress, the number of
-                        # heatmap channels is a multiply of the number of
-                        # keypoints.
-                        value = value.reshape(num_keypoints, -1, *field_size)
-                        value = value[kpt_indices].reshape(-1, *field_size)
-                        setattr(pred_fields, key, value)
+                        pred_fields.set_field(value[kpt_indices], key)
                 data_sample.pred_fields = pred_fields
 
         return batch_data_samples

--- a/tests/test_datasets/test_datasets/test_dataset_wrappers/test_combined_dataset.py
+++ b/tests/test_datasets/test_datasets/test_dataset_wrappers/test_combined_dataset.py
@@ -30,8 +30,7 @@ class TestCombinedDataset(TestCase):
 
         cfg = dict(
             metainfo=dict(from_file='configs/_base_/datasets/coco.py'),
-            datasets=[dict(dataset=coco_cfg),
-                      dict(dataset=aic_cfg)],
+            datasets=[coco_cfg, aic_cfg],
             pipeline=[])
         cfg.update(kwargs)
         return CombinedDataset(**cfg)

--- a/tests/test_datasets/test_datasets/test_dataset_wrappers/test_combined_dataset.py
+++ b/tests/test_datasets/test_datasets/test_dataset_wrappers/test_combined_dataset.py
@@ -1,0 +1,92 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from unittest import TestCase
+
+import numpy as np
+
+from mmpose.datasets.dataset_wrappers import CombinedDataset
+
+
+class TestCombinedDataset(TestCase):
+
+    def build_combined_dataset(self, **kwargs):
+
+        coco_cfg = dict(
+            type='CocoDataset',
+            ann_file='test_coco.json',
+            bbox_file=None,
+            data_mode='topdown',
+            data_root='tests/data/coco',
+            pipeline=[],
+            test_mode=False)
+
+        aic_cfg = dict(
+            type='AicDataset',
+            ann_file='test_aic.json',
+            bbox_file=None,
+            data_mode='topdown',
+            data_root='tests/data/aic',
+            pipeline=[],
+            test_mode=False)
+
+        cfg = dict(
+            metainfo=dict(from_file='configs/_base_/datasets/coco.py'),
+            datasets=[dict(dataset=coco_cfg),
+                      dict(dataset=aic_cfg)],
+            pipeline=[])
+        cfg.update(kwargs)
+        return CombinedDataset(**cfg)
+
+    def check_data_info_keys(self,
+                             data_info: dict,
+                             data_mode: str = 'topdown'):
+        if data_mode == 'topdown':
+            expected_keys = dict(
+                img_id=int,
+                img_path=str,
+                bbox=np.ndarray,
+                bbox_score=np.ndarray,
+                keypoints=np.ndarray,
+                keypoints_visible=np.ndarray,
+                id=int)
+        elif data_mode == 'bottomup':
+            expected_keys = dict(
+                img_id=int,
+                img_path=str,
+                bbox=np.ndarray,
+                bbox_score=np.ndarray,
+                keypoints=np.ndarray,
+                keypoints_visible=np.ndarray,
+                invalid_segs=list,
+                id=list)
+        else:
+            raise ValueError(f'Invalid data_mode {data_mode}')
+
+        for key, type_ in expected_keys.items():
+            self.assertIn(key, data_info)
+            self.assertIsInstance(data_info[key], type_, key)
+
+    def test_get_subset_index(self):
+        dataset = self.build_combined_dataset()
+        lens = dataset._lens
+
+        with self.assertRaises(ValueError):
+            subset_idx, sample_idx = dataset._get_subset_index(sum(lens))
+
+        index = lens[0]
+        subset_idx, sample_idx = dataset._get_subset_index(index)
+        self.assertEqual(subset_idx, 1)
+        self.assertEqual(sample_idx, 0)
+
+        index = -lens[1] - 1
+        subset_idx, sample_idx = dataset._get_subset_index(index)
+        self.assertEqual(subset_idx, 0)
+        self.assertEqual(sample_idx, lens[0] - 1)
+
+    def test_prepare_data(self):
+        dataset = self.build_combined_dataset()
+        lens = dataset._lens
+
+        data_info = dataset[lens[0]]
+        print(data_info.keys())
+        print(data_info['dataset_keypoint_weights'])
+        self.check_data_info_keys(data_info)

--- a/tests/test_datasets/test_transforms/test_converting.py
+++ b/tests/test_datasets/test_transforms/test_converting.py
@@ -1,0 +1,36 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from unittest import TestCase
+
+from mmpose.datasets.transforms import KeypointConverter
+from mmpose.testing import get_coco_sample
+
+
+class TestKeypointConverter(TestCase):
+
+    def setUp(self):
+        # prepare dummy bottom-up data sample with COCO metainfo
+        self.data_info = get_coco_sample(
+            img_shape=(240, 320), num_instances=4, with_bbox_cs=True)
+
+    def test_transform(self):
+        mapping = [(3, 0), (6, 1), (16, 2), (5, 3)]
+        transform = KeypointConverter(num_keypoints=5, mapping=mapping)
+        results = transform(self.data_info.copy())
+
+        # check shape
+        self.assertEqual(results['keypoints'].shape[0],
+                         self.data_info['keypoints'].shape[0])
+        self.assertEqual(results['keypoints'].shape[1], 5)
+        self.assertEqual(results['keypoints'].shape[2], 2)
+        self.assertEqual(results['keypoints_visible'].shape[0],
+                         self.data_info['keypoints_visible'].shape[0])
+        self.assertEqual(results['keypoints_visible'].shape[1], 5)
+
+        # check value
+        for source_index, target_index in mapping:
+            self.assertTrue((results['keypoints'][:, target_index] ==
+                             self.data_info['keypoints'][:,
+                                                         source_index]).all())
+            self.assertTrue(
+                (results['keypoints_visible'][:, target_index] ==
+                 self.data_info['keypoints_visible'][:, source_index]).all())


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->
Support training with combined datasets

## Modification

<!-- Please briefly describe what modification is made in this PR. -->
1. add a new dataset wrapper `CombinedDataset`
2. add `KeypointConverter` to convert the channel order of `keypoints` and `keypoints_visible`
3. add unittests
4. add two example configs
  - `td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-merge.py` maps the keypoints of AIC to COCO format.\
  - `td-hm_hrnet-w32_8xb64-210e_coco-aic-256x192-combine.py` maps the keypoints of AIC & COCO to a combined format. 
5. modify default `dataset_meta` in `init_cfg` from test dataset to train dataset


## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
