### PR TITLE
[Fix] Fix webcam metainfo

### DIFF
--- a/mmpose/apis/webcam/nodes/model_nodes/pose_estimator_node.py
+++ b/mmpose/apis/webcam/nodes/model_nodes/pose_estimator_node.py
@@ -128,8 +128,8 @@ class TopDownPoseEstimatorNode(Node):
                 object['keypoints'] = pred_instances.keypoints[0]
                 object['keypoint_scores'] = pred_instances.keypoint_scores[0]
 
-                dataset_meta = object.get('dataset_meta', dict())
-                dataset_meta.update(self.model.dataset_meta)
+                dataset_meta = self.model.dataset_meta.copy()
+                dataset_meta.update(object.get('dataset_meta', dict()))
                 object['dataset_meta'] = dataset_meta
                 object['pose_model_cfg'] = self.model.cfg
 


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

The metainfo item `'CLASSES'` in MMPose has a different format from that in MMDectection. This conflict will lead to an error illustrated in https://github.com/open-mmlab/mmpose/issues/1812.

## Modification

<!-- Please briefly describe what modification is made in this PR. -->
In [`TopDownPoseEstimatorNode`](https://github.com/open-mmlab/mmpose/blob/dev-1.x/mmpose/apis/webcam/nodes/model_nodes/pose_estimator_node.py), use the values from detector metainfo for overlapped keys instead of the values from pose estimator metainfo.

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
