### PR TITLE
Update base_head.py

### DIFF
--- a/mmpose/models/heads/base_head.py
+++ b/mmpose/models/heads/base_head.py
@@ -66,6 +66,10 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
     def _transform_inputs(self, feats: Tuple[Tensor]
                           ) -> Union[Tensor, Tuple[Tensor]]:
         """Transform multi scale features into the network input."""
+        
+        if not isinstance(feats, Tuple):
+            return feats
+        
         if self.input_transform == 'resize_concat':
             inputs = [feats[i] for i in self.input_index]
             resized_inputs = [

--- a/mmpose/models/heads/base_head.py
+++ b/mmpose/models/heads/base_head.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import warnings
 from abc import ABCMeta, abstractmethod
 from typing import List, Sequence, Tuple, Union
 
@@ -69,6 +70,9 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
     ) -> Union[Tensor, Tuple[Tensor]]:
         """Transform multi scale features into the network input."""
         if not isinstance(feats, Sequence):
+            warnings.warn(f'the input of {self._get_name()} is a tensor '
+                          f'instead of a tuple or list. The argument '
+                          f'`input_transform` will be ignored.')
             return feats
 
         if self.input_transform == 'resize_concat':

--- a/mmpose/models/heads/base_head.py
+++ b/mmpose/models/heads/base_head.py
@@ -68,7 +68,6 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
         """Transform multi scale features into the network input."""
         if not isinstance(feats, Tuple):
             return feats
-        
         if self.input_transform == 'resize_concat':
             inputs = [feats[i] for i in self.input_index]
             resized_inputs = [

--- a/mmpose/models/heads/base_head.py
+++ b/mmpose/models/heads/base_head.py
@@ -66,7 +66,6 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
     def _transform_inputs(self, feats: Tuple[Tensor]
                           ) -> Union[Tensor, Tuple[Tensor]]:
         """Transform multi scale features into the network input."""
-        
         if not isinstance(feats, Tuple):
             return feats
         

--- a/mmpose/models/heads/base_head.py
+++ b/mmpose/models/heads/base_head.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import ABCMeta, abstractmethod
-from typing import List, Tuple, Union
+from typing import List, Sequence, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -63,11 +63,14 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
 
         return in_channels
 
-    def _transform_inputs(self, feats: Tuple[Tensor]
-                          ) -> Union[Tensor, Tuple[Tensor]]:
+    def _transform_inputs(
+        self,
+        feats: Union[Tensor, Sequence[Tensor]],
+    ) -> Union[Tensor, Tuple[Tensor]]:
         """Transform multi scale features into the network input."""
-        if not isinstance(feats, Tuple):
+        if not isinstance(feats, Sequence):
             return feats
+
         if self.input_transform == 'resize_concat':
             inputs = [feats[i] for i in self.input_index]
             resized_inputs = [

--- a/tests/test_models/test_heads/test_heatmap_heads/test_heatmap_head.py
+++ b/tests/test_models/test_heads/test_heatmap_heads/test_heatmap_head.py
@@ -122,7 +122,7 @@ class TestHeatmapHead(TestCase):
             conv_kernel_sizes=(1, ),
             decoder=decoder_cfg)
         feats = self._get_feats(batch_size=2, feat_shapes=[(48, 16, 12)])[0]
-        batch_data_samples = self._get_data_samples(batch_size=2)
+        batch_data_samples = get_packed_inputs(batch_size=2)['data_samples']
         with self.assertWarnsRegex(
                 Warning,
                 'the input of HeatmapHead is a tensor instead of a tuple '

--- a/tests/test_models/test_heads/test_heatmap_heads/test_heatmap_head.py
+++ b/tests/test_models/test_heads/test_heatmap_heads/test_heatmap_head.py
@@ -110,7 +110,31 @@ class TestHeatmapHead(TestCase):
         self.assertEqual(preds[0].keypoints.shape,
                          batch_data_samples[0].gt_instances.keypoints.shape)
 
-        # input transform: output heatmap
+        # input transform: none
+        head = HeatmapHead(
+            in_channels=[16, 32],
+            out_channels=17,
+            input_transform='resize_concat',
+            input_index=[0, 1],
+            deconv_out_channels=(256, 256),
+            deconv_kernel_sizes=(4, 4),
+            conv_out_channels=(256, ),
+            conv_kernel_sizes=(1, ),
+            decoder=decoder_cfg)
+        feats = self._get_feats(batch_size=2, feat_shapes=[(48, 16, 12)])[0]
+        batch_data_samples = self._get_data_samples(batch_size=2)
+        with self.assertWarnsRegex(
+                Warning,
+                'the input of HeatmapHead is a tensor instead of a tuple '
+                'or list. The argument `input_transform` will be ignored.'):
+            preds = head.predict(feats, batch_data_samples)
+
+        self.assertTrue(len(preds), 2)
+        self.assertIsInstance(preds[0], InstanceData)
+        self.assertEqual(preds[0].keypoints.shape,
+                         batch_data_samples[0].gt_instances.keypoints.shape)
+
+        # output heatmap
         head = HeatmapHead(
             in_channels=[16, 32],
             out_channels=17,


### PR DESCRIPTION
A small modification that applies to different backbone outputs. from issue #1838

<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

when I use mmpose 1.0.0 rc to train a new backbone, I find that the output head raises a size unmatching error, which did not happen in the past editions. The main issue is the BaseHead treat output of backbone as a tuple by default, while the output of the backbone i used is a tensor.  The positioning of the reported error is ambiguous, which may result in more users consuming some time to locate what the problem is. However, it is only a matter of condition statements.

## Modification

Add a condition statements in a private function of BaseHead class (._transform_inputs) :
original:
![image](https://user-images.githubusercontent.com/51226104/204444310-032c4386-acc3-46f0-bc4c-12c188a15252.png)
modified
![image](https://user-images.githubusercontent.com/51226104/204444341-526a1870-3fa6-405e-84cf-575272a5e644.png)

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

No

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
