### PR TITLE
[Draft] Update AUC to use MMEval

### DIFF
--- a/mmpose/evaluation/metrics/keypoint_2d_metrics.py
+++ b/mmpose/evaluation/metrics/keypoint_2d_metrics.py
@@ -5,10 +5,10 @@ from typing import Dict, Optional, Sequence, Union
 import numpy as np
 from mmengine.evaluator import BaseMetric
 from mmengine.logging import MMLogger
+from mmeval.metrics import KeypointAUC as MMEVAL_KeypointAUC
 
 from mmpose.registry import METRICS
-from ..functional import (keypoint_auc, keypoint_epe, keypoint_nme,
-                          keypoint_pck_accuracy)
+from ..functional import keypoint_epe, keypoint_nme, keypoint_pck_accuracy
 
 
 @METRICS.register_module()
@@ -533,7 +533,7 @@ class JhmdbPCKAccuracy(PCKAccuracy):
 
 
 @METRICS.register_module()
-class AUC(BaseMetric):
+class AUC(MMEVAL_KeypointAUC):
     """AUC evaluation metric.
 
     Calculate the Area Under Curve (AUC) of keypoint PCK accuracy.
@@ -549,83 +549,57 @@ class AUC(BaseMetric):
     Args:
         norm_factor (float): AUC normalization factor, Default: 30 (pixels).
         num_thrs (int): number of thresholds to calculate auc. Default: 20.
-        collect_device (str): Device name used for collecting results from
-            different ranks during distributed training. Must be ``'cpu'`` or
-            ``'gpu'``. Default: ``'cpu'``.
-        prefix (str, optional): The prefix that will be added in the metric
-            names to disambiguate homonymous metrics of different evaluators.
-            If prefix is not provided in the argument, ``self.default_prefix``
-            will be used instead. Default: ``None``.
+        **kwargs: Keyword parameters passed to :class:`mmeval.BaseMetric`. Must
+            include ``dataset_meta`` in order to compute the metric.
     """
 
     def __init__(self,
                  norm_factor: float = 30,
                  num_thrs: int = 20,
-                 collect_device: str = 'cpu',
-                 prefix: Optional[str] = None) -> None:
-        super().__init__(collect_device=collect_device, prefix=prefix)
-        self.norm_factor = norm_factor
-        self.num_thrs = num_thrs
+                 **kwargs) -> None:
+        super().__init__(norm_factor=norm_factor, num_thrs=num_thrs, **kwargs)
 
     def process(self, data_batch: Sequence[dict],
                 data_samples: Sequence[dict]) -> None:
-        """Process one batch of data samples and predictions. The processed
-        results should be stored in ``self.results``, which will be used to
-        compute the metrics when all batches have been processed.
+        """Process one batch of data samples.
+
+        Parse predictions and groundtruths from ``data_samples`` and invoke
+        ``self.add``.
 
         Args:
-            data_batch (Sequence[dict]): A batch of data
-                from the dataloader.
-            data_sample (Sequence[dict]): A batch of outputs from
-                the model.
+            data_batch: A batch of data from the dataloader.
+            data_samples (Sequence[dict]): A batch of outputs from the model.
         """
+        predictions, groundtruths = [], []
+
         for data_sample in data_samples:
-            # predicted keypoints coordinates, [1, K, D]
             pred_coords = data_sample['pred_instances']['keypoints']
+            prediction = {
+                # predicted keypoints coordinates, [1, K, D]
+                'coords': pred_coords
+            }
             # ground truth data_info
             gt = data_sample['gt_instances']
-            # ground truth keypoints coordinates, [1, K, D]
             gt_coords = gt['keypoints']
-            # ground truth keypoints_visible, [1, K, 1]
-            mask = gt['keypoints_visible'].astype(bool).reshape(1, -1)
-
-            result = {
-                'pred_coords': pred_coords,
-                'gt_coords': gt_coords,
-                'mask': mask,
+            groundtruth = {
+                # ground truth keypoints coordinates, [1, K, D]
+                'coords': gt_coords,
+                # ground truth keypoints_visible, [1, K, 1]
+                'mask': gt['keypoints_visible'].astype(bool).reshape(1, -1)
             }
 
-            self.results.append(result)
+            predictions.append(prediction)
+            groundtruths.append(groundtruth)
 
-    def compute_metrics(self, results: list) -> Dict[str, float]:
-        """Compute the metrics from processed results.
+        self.add(predictions, groundtruths)
 
-        Args:
-            results (list): The processed results of each batch.
+    def evaluate(self, *args, **kwargs) -> Dict:
+        """Returns metric results and reset state.
 
-        Returns:
-            Dict[str, float]: The computed metrics. The keys are the names of
-            the metrics, and the values are corresponding results.
+        This method would be invoked by ``mmengine.Evaluator``.
         """
-        logger: MMLogger = MMLogger.get_current_instance()
-
-        # pred_coords: [N, K, D]
-        pred_coords = np.concatenate(
-            [result['pred_coords'] for result in results])
-        # gt_coords: [N, K, D]
-        gt_coords = np.concatenate([result['gt_coords'] for result in results])
-        # mask: [N, K]
-        mask = np.concatenate([result['mask'] for result in results])
-
-        logger.info(f'Evaluating {self.__class__.__name__}...')
-
-        auc = keypoint_auc(pred_coords, gt_coords, mask, self.norm_factor,
-                           self.num_thrs)
-
-        metrics = dict()
-        metrics['AUC'] = auc
-
-        return metrics
+        metric_results = self.compute(*args, **kwargs)
+        return metric_results
 
 
 @METRICS.register_module()

--- a/tests/test_evaluation/test_metrics/test_keypoint_2d_metrics.py
+++ b/tests/test_evaluation/test_metrics/test_keypoint_2d_metrics.py
@@ -269,7 +269,7 @@ class TestAUCandEPE(TestCase):
         auc_metric = AUC(norm_factor=20, num_thrs=4)
         auc_metric.process(self.data_batch, self.data_samples)
         auc = auc_metric.evaluate(1)
-        target = {'AUC': 0.375}
+        target = {'AUC@4': 0.375}
         self.assertDictEqual(auc, target)
 
     def test_epe_evaluate(self):


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

Support MMEval's KeypointAUC metric in MMPose-1.x.

Related PR: https://github.com/open-mmlab/mmeval/pull/91

## Comparison with Default Implementation
Test command:
```
python tools/test.py configs/body_2d_keypoint/topdown_heatmap/mpii/td-hm_hrnet-w32_8xb64-210e_mpii-256x256.py https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_mpii_256x256-6c4f923f_20200812.pth
```
Performance on dev-1.x branch:
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/46705745/220112118-9a4d9510-a705-4af7-a071-5d1cc28f3106.png">

Performance with this modifications:
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/46705745/220112189-61b9c9f6-764e-48a7-a082-48ca08f3cf65.png">


## Modification

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
