### PR TITLE
[Fix] fix warnings when falling back to mmengine registry

### DIFF
--- a/mmpose/engine/__init__.py
+++ b/mmpose/engine/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .hooks import *  # noqa: F401, F403
+from .optim_wrappers import *  # noqa: F401, F403

--- a/mmpose/registry.py
+++ b/mmpose/registry.py
@@ -76,24 +76,22 @@ BATCH_AUGMENTS = Registry('batch augment', locations=['mmpose.models'])
 # Registries For Optimizer and the related
 # manage all kinds of optimizers like `SGD` and `Adam`
 OPTIMIZERS = Registry(
-    'optimizer',
-    parent=MMENGINE_OPTIMIZERS,
-    locations=['mmpose.engine.optimizers'])
+    'optimizer', parent=MMENGINE_OPTIMIZERS, locations=['mmpose.engine'])
 # manage optimizer wrapper
 OPTIM_WRAPPERS = Registry(
     'optimizer_wrapper',
     parent=MMENGINE_OPTIM_WRAPPERS,
-    locations=['mmpose.engine.optimizers'])
+    locations=['mmpose.engine'])
 # manage constructors that customize the optimization hyperparameters.
 OPTIM_WRAPPER_CONSTRUCTORS = Registry(
     'optimizer wrapper constructor',
     parent=MMENGINE_OPTIM_WRAPPER_CONSTRUCTORS,
-    locations=['mmpose.engine.optimizers'])
+    locations=['mmpose.engine.optim_wrappers'])
 # manage all kinds of parameter schedulers like `MultiStepLR`
 PARAM_SCHEDULERS = Registry(
     'parameter scheduler',
     parent=MMENGINE_PARAM_SCHEDULERS,
-    locations=['mmpose.engine.schedulers'])
+    locations=['mmpose.engine'])
 
 # manage all kinds of metrics
 METRICS = Registry(


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

This PR fixes the warnings raised when falling back to mmengine registries (registries without registered modules in mmpose).

## Modification

<!-- Please briefly describe what modification is made in this PR. -->

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
