### PR TITLE
[Fix] Set default det-cat-ids for inferencer_demo.py

### DIFF
--- a/demo/inferencer_demo.py
+++ b/demo/inferencer_demo.py
@@ -35,7 +35,7 @@ def parse_args():
         '--det-cat-ids',
         type=int,
         nargs='+',
-        default=None,
+        default=0,
         help='Category id for detection model.')
     parser.add_argument(
         '--scope',


### PR DESCRIPTION
需要把inferencer_demo.py中的--det-cat-ids参数默认设置为0，否则检测不到关键点，建议修改一下。