### PR TITLE
[Enhance] Inferencer support mmyolo detector

### DIFF
--- a/mmpose/apis/inferencers/pose2d_inferencer.py
+++ b/mmpose/apis/inferencers/pose2d_inferencer.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os
 import warnings
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
@@ -91,6 +92,7 @@ class Pose2DInferencer(BaseMMPoseInferencer):
 
         # initialize detector for top-down models
         if self.cfg.data_mode == 'topdown':
+            det_scope = 'mmdet'
             if det_model is None:
                 det_model = DATASETS.get(
                     self.cfg.dataset_type).__module__.split(
@@ -98,10 +100,13 @@ class Pose2DInferencer(BaseMMPoseInferencer):
                 det_info = default_det_models[det_model]
                 det_model, det_weights, det_cat_ids = det_info[
                     'model'], det_info['weights'], det_info['cat_ids']
+            elif os.path.exists(det_model):
+                det_cfg = Config.fromfile(det_model)
+                det_scope = det_cfg.default_scope
 
             if has_mmdet:
                 self.detector = DetInferencer(
-                    det_model, det_weights, device=device)
+                    det_model, det_weights, device=device, scope=det_scope)
             else:
                 raise RuntimeError(
                     'MMDetection (v3.0.0rc6 or above) is required to '


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->
To allow the `demo/inferencer_demo.py` to utilize models from mmyolo for object detection in top-down pose estimation.

## Modification

<!-- Please briefly describe what modification is made in this PR. -->

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

```shell
python demo/inferencer_demo.py tests/data/coco/000000000785.jpg --pose2d human \
    --det-model ${MMYOLO_PATH}/configs/yolox/yolox_tiny_fast_8xb8-300e_coco.py \
    --det-weights https://download.openmmlab.com/mmyolo/v0/yolox/yolox_tiny_8xb8-300e_coco/yolox_tiny_8xb8-300e_coco_20220919_090908-0e40a6fc.pth \
    --show
```

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
