### PR TITLE
[Fix] config param and return values of functions in the dataset class in the tutorial 

### DIFF
--- a/demo/MMPose_Tutorial.ipynb
+++ b/demo/MMPose_Tutorial.ipynb
@@ -1191,7 +1191,7 @@
         "            data_list.append(data_info)\n",
         "            ann_id = ann_id + 1\n",
         "\n",
-        "        return data_list\n"
+        "        return data_list, None\n"
       ]
     },
     {
@@ -1488,7 +1488,7 @@
         "cfg.val_evaluator = dict(type='PCKAccuracy')\n",
         "cfg.test_evaluator = cfg.val_evaluator\n",
         "\n",
-        "cfg.default_hooks.checkpoint.save_best = 'pck/PCK@0.05'\n",
+        "cfg.default_hooks.checkpoint.save_best = 'PCK'\n",
         "cfg.default_hooks.checkpoint.max_keep_ckpts = 1\n",
         "\n",
         "print(cfg.pretty_text)\n"


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

MMPose_Tutorial.ipynb output an error at runtime. Therefore, I fixed it.

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

## Modification

Two modifications are as follows

- Return value of _load_annotations()
  - The caller of the _load_annotations function expects two values to be returned, but the code before the modification returned only one value. Therefore, this was changed to return two values. However, the second return value is not used by the caller, so None is returned.
- Metrics
  - There was no "pck/PCK@0.0" metric, so I corrected it to "PCK".


## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
