### PR TITLE
[Fix] Remove the native list attribute `self.layers` in HRFormer FFN modules

### DIFF
--- a/mmpose/models/backbones/hrformer.py
+++ b/mmpose/models/backbones/hrformer.py
@@ -299,17 +299,12 @@ class CrossFFN(BaseModule):
         self.act3 = build_activation_layer(act_cfg)
         self.norm3 = build_norm_layer(norm_cfg, out_features)[1]
 
-        # put the modules togather
-        self.layers = [
-            self.fc1, self.norm1, self.act1, self.dw3x3, self.norm2, self.act2,
-            self.fc2, self.norm3, self.act3
-        ]
-
     def forward(self, x, H, W):
         """Forward function."""
         x = nlc_to_nchw(x, (H, W))
-        for layer in self.layers:
-            x = layer(x)
+        x = self.act1(self.norm1(self.fc1(x)))
+        x = self.act2(self.norm2(self.dw3x3(x)))
+        x = self.act3(self.norm3(self.fc2(x)))
         x = nchw_to_nlc(x)
         return x
 


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->

As illustrated in https://github.com/open-mmlab/mmpose/issues/2448, applying `revert_sync_batchnorm` on HRFormer does not convert the BNs within the `self.layers` list in the FFN modules. Consequently, this triggers a RuntimeError during the inference process.

## Modification

<!-- Please briefly describe what modification is made in this PR. -->
1. remove the attribute `layers` in FFN module
2. rewrite the forward process

## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
