### PR TITLE
compatible mmcv 1.7.1 and mmpose 0.29.0

### DIFF
--- a/mmpose/__init__.py
+++ b/mmpose/__init__.py
@@ -17,7 +17,7 @@ def digit_version(version_str):
 
 
 mmcv_minimum_version = '1.3.8'
-mmcv_maximum_version = '1.7.0'
+mmcv_maximum_version = '1.7.1'
 mmcv_version = digit_version(mmcv.__version__)
 
 


### PR DESCRIPTION
We want to use mmcv==1.7.1 and mmpose==0.29.0 at the same time to use the PCT algorithm (https://github.com/Gengzigang/PCT).
We've checked that these two versions can be used together when testing the PCT.