### PR TITLE
[Fix] Fix incorrect keepdims in vis_accuracy of vis_head

### DIFF
--- a/mmpose/models/heads/hybrid_heads/vis_head.py
+++ b/mmpose/models/heads/hybrid_heads/vis_head.py
@@ -185,7 +185,7 @@ class VisPredictHead(BaseHead):
         correct = (predictions == vis_labels).float()
         if vis_weights is not None:
             accuracy = (correct * vis_weights).sum(dim=1) / (
-                vis_weights.sum(dim=1, keepdims=True) + 1e-6)
+                vis_weights.sum(dim=1) + 1e-6)
         else:
             accuracy = correct.mean(dim=1)
         return accuracy.mean()


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->
As mentioned in [issues/2799](https://github.com/open-mmlab/mmpose/issues/2799), when shape of vis_weights is also [N,K], keepdims=True will lead accuracy larger than 1.0;

## Modification

<!-- Please briefly describe what modification is made in this PR. -->
For now vis_weights value comes from vis_label.new_ones or dataset visible labels( when shape is [N,K,2]), so vis_weights is always [N,K]. I just delete the keepdims para.
Perhaps I miss some cases?
## BC-breaking (Optional)

<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->

## Use cases (Optional)

<!-- If this PR introduces a new feature, it is better to list some use cases here and update the documentation. -->

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
