### PR TITLE
[Fix] Fix to local_visualizer_3d data dumping

### DIFF
--- a/mmpose/visualization/local_visualizer_3d.py
+++ b/mmpose/visualization/local_visualizer_3d.py
@@ -280,23 +280,27 @@ class Pose3dLocalVisualizer(PoseLocalVisualizer):
                                  'data sample must contain '
                                  '"lifting_target" or "keypoints_gt"')
 
-            _draw_3d_instances_kpts(keypoints, scores, keypoints_visible, 2,
-                                    show_kpt_idx, 'Ground Truth')
+            if scores_2d is None:
+                scores_2d = np.ones(keypoints.shape[:-1])
+
+            _draw_3d_instances_kpts(keypoints, scores, scores_2d,
+                                    keypoints_visible, 2, show_kpt_idx,
+                                    'Ground Truth')
 
         # convert figure to numpy array
         fig.tight_layout()
         fig.canvas.draw()
 
-        pred_img_data = fig.canvas.tostring_rgb()
         pred_img_data = np.frombuffer(
             fig.canvas.tostring_rgb(), dtype=np.uint8)
 
         if not pred_img_data.any():
             pred_img_data = np.full((vis_height, vis_width, 3), 255)
         else:
-            pred_img_data = pred_img_data.reshape(vis_height,
-                                                  vis_width * num_instances,
-                                                  -1)
+            width, height = fig.get_size_inches() * fig.get_dpi()
+            pred_img_data = pred_img_data.reshape(
+                int(height),
+                int(width) * num_instances, 3)
 
         plt.close(fig)
 


### PR DESCRIPTION
fig.canvas provides float32 data, not uint8. This fixes the issue.

<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

This fixes this issue https://github.com/open-mmlab/mmpose/issues/2816

## Modification

Fixes the issue where the data is not processed properly

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
