### PR TITLE
[Feature] Add center alignments for draw_texts in OpencvBackendVisualizer

### DIFF
--- a/mmpose/visualization/opencv_backend_visualizer.py
+++ b/mmpose/visualization/opencv_backend_visualizer.py
@@ -240,9 +240,13 @@ class OpencvBackendVisualizer(Visualizer):
             x = int(positions[0])
             if horizontal_alignments == 'right':
                 x = max(0, x - text_size[0])
+            elif horizontal_alignments == 'center':
+                x = max(0, x - text_size[0] // 2)
             y = int(positions[1])
             if vertical_alignments == 'top':
                 y = min(self.height, y + text_size[1])
+            elif vertical_alignments == 'center':
+                y = min(self.height, y + text_size[1] // 2)
 
             if bboxes is not None:
                 bbox_color = bboxes[0]['facecolor']


### PR DESCRIPTION
## Motivation

This pull request addresses a gap in the `OpencvBackendVisualizer` class's `draw_texts` method. Although the docstring mentions support for "bottom," "top," and "center" alignments, the current implementation lacks the ability to center-align text. This modification aims to rectify this limitation.

## Modification

I've updated the draw_texts method to support center alignment for both horizontal and vertical positioning.

## BC-breaking (Optional)

## Use cases (Optional)

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
