### PR TITLE
[Fix] make category_id in CocoWholeBodyDataset as numpy.array

### DIFF
--- a/mmpose/datasets/datasets/wholebody/coco_wholebody_dataset.py
+++ b/mmpose/datasets/datasets/wholebody/coco_wholebody_dataset.py
@@ -125,7 +125,7 @@ class CocoWholeBodyDataset(BaseCocoStyleDataset):
             'segmentation': ann['segmentation'],
             'area': area,
             'id': ann['id'],
-            'category_id': ann['category_id'],
+            'category_id': np.array(ann['category_id']),
             # store the raw annotation of the instance
             # it is useful for evaluation without providing ann_file
             'raw_ann_info': copy.deepcopy(ann),


### PR DESCRIPTION
<!-- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation

<!-- Please describe the motivation of this PR and the goal you want to achieve through this PR. -->
``parse_data_info()`` in ``class CocoWholeBodyDataset`` will return `category_id` as a `List`, making the `transform()` in ``class FilterAnnotations`` fails to **indexing** like a np.array.

## Modification
make `category_id` as a `numpy.array`, just like what in ``class BaseCocoStyleDataset`` does.
<!-- Please briefly describe what modification is made in this PR. -->


<!-- Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.
