### PR TITLE
fix: handle resume on RTMOModeSwitchHook and YOLOXPoseModeSwitchHook

### DIFF
--- a/mmpose/engine/hooks/mode_switch_hooks.py
+++ b/mmpose/engine/hooks/mode_switch_hooks.py
@@ -3,7 +3,6 @@ import copy
 from typing import Dict, Sequence
 
 import torch.nn as nn
-
 from mmengine.hooks import Hook
 from mmengine.model import is_model_wrapper
 from mmengine.runner import Runner
@@ -63,7 +62,8 @@ class YOLOXPoseModeSwitchHook(Hook):
         if is_model_wrapper(model):
             model = model.module
 
-        if self.switched is False and (epoch + 1 >= runner.max_epochs - self.num_last_epochs):
+        if self.switched is False and (
+                epoch + 1 >= runner.max_epochs - self.num_last_epochs):
             self._modify_dataloader(runner)
             runner.logger.info('Added additional reg loss now!')
             model.head.use_aux_loss = True
@@ -95,13 +95,14 @@ class RTMOModeSwitchHook(Hook):
         self.epoch_attributes = epoch_attributes
         self.handled_resume = False
 
-    def handle_resume(self, runner: Runner, model: nn.Module, resumed_epoch: int):
-        """Iter over all the previous batch size when training is resumed to apply each epoch attributes modification in order.        
-        """
+    def handle_resume(self, runner: Runner, model: nn.Module,
+                      resumed_epoch: int):
+        """Iter over all the previous batch size when training is resumed to
+        apply each epoch attributes modification in order."""
         for epoch in self.epoch_attributes.keys():
             if epoch >= resumed_epoch:
                 break
-            
+
             for key, value in self.epoch_attributes[epoch].items():
                 rsetattr(model.head, key, value)
                 runner.logger.info(

--- a/mmpose/engine/hooks/mode_switch_hooks.py
+++ b/mmpose/engine/hooks/mode_switch_hooks.py
@@ -40,6 +40,7 @@ class YOLOXPoseModeSwitchHook(Hook):
         self.num_last_epochs = num_last_epochs
         self.new_train_dataset = new_train_dataset
         self.new_train_pipeline = new_train_pipeline
+        self.switched = False
 
     def _modify_dataloader(self, runner: Runner):
         """Modify dataloader with new dataset and pipeline configurations."""
@@ -62,10 +63,11 @@ class YOLOXPoseModeSwitchHook(Hook):
         if is_model_wrapper(model):
             model = model.module
 
-        if epoch + 1 == runner.max_epochs - self.num_last_epochs:
+        if self.switched is False and (epoch + 1 >= runner.max_epochs - self.num_last_epochs):
             self._modify_dataloader(runner)
             runner.logger.info('Added additional reg loss now!')
             model.head.use_aux_loss = True
+            self.switched = True
 
 
 @HOOKS.register_module()


### PR DESCRIPTION
There was an issue when resuming training on theses Hooks (RTMOModeSwitchHook, YOLOXPoseModeSwitchHook).
These hooks were not triggered when resuming training because they required the training to go over each specific epoch.

## Motivation
Fix the issue

## Modification
Add logic to handle the resume, It now applies the switch mode in order until it reach the resumed epoch.

## Checklist

**Before PR**:

- [X] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [X] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.