### PR TITLE
Enhancing the program compatibility of  inferencing image directory

### DIFF
--- a/mmpose/apis/inferencers/base_mmpose_inferencer.py
+++ b/mmpose/apis/inferencers/base_mmpose_inferencer.py
@@ -182,6 +182,8 @@ class BaseMMPoseInferencer(BaseInferencer):
                 ]
                 inputs = []
                 for filepath in filepath_list:
+                    if mimetypes.guess_type(filepath)[0] is None:
+                        continue
                     input_type = mimetypes.guess_type(filepath)[0].split(
                         '/')[0]
                     if input_type == 'image':


### PR DESCRIPTION

## Motivation

An error occurred while mmpose was inferring the image directory

## Modification

 when mimetypes.guess_type(filepath)[0] is none, subsequent reasoning does not require execution


## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.
